### PR TITLE
fix: Enable memory storage for NATS as default in dev environment

### DIFF
--- a/examples/nats/values.yaml
+++ b/examples/nats/values.yaml
@@ -5,6 +5,9 @@ nats:
       replicas: 2
     jetstream:
       enabled: true
+      memoryStore:
+        enabled: true
+        maxSize: 100Mi
       fileStore:
         pvc:
           size: 100Mi


### PR DESCRIPTION
By default, there is no memory storage configured in NATS.
Adding a small size of memory to use for jetstreams, making it possible to test sourcing between accounts and similar.