### PR TITLE
feat: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-
+* @WirelessCar/nauth-maintainers


### PR DESCRIPTION
Automatically assigning code owners for PR reviews