### PR TITLE
feat: extend kubectl printer columns

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -77,6 +77,8 @@ type KeyInfo struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Message",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 
 // Account is the Schema for the accounts API.
 type Account struct {

--- a/api/v1alpha1/user_types.go
+++ b/api/v1alpha1/user_types.go
@@ -69,6 +69,8 @@ type UserStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Message",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 
 // User is the Schema for the users API.
 type User struct {

--- a/charts/nauth-crds/crds/nauth.io_accounts.yaml
+++ b/charts/nauth-crds/crds/nauth.io_accounts.yaml
@@ -14,7 +14,14 @@ spec:
     singular: account
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Message
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Account is the Schema for the accounts API.

--- a/charts/nauth-crds/crds/nauth.io_users.yaml
+++ b/charts/nauth-crds/crds/nauth.io_users.yaml
@@ -14,7 +14,14 @@ spec:
     singular: user
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Message
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: User is the Schema for the users API.

--- a/charts/nauth/resources/crds/nauth.io_accounts.yaml
+++ b/charts/nauth/resources/crds/nauth.io_accounts.yaml
@@ -14,7 +14,14 @@ spec:
     singular: account
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Message
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Account is the Schema for the accounts API.

--- a/charts/nauth/resources/crds/nauth.io_users.yaml
+++ b/charts/nauth/resources/crds/nauth.io_users.yaml
@@ -14,7 +14,14 @@ spec:
     singular: user
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Message
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: User is the Schema for the users API.


### PR DESCRIPTION
When invoking `kubectl get` we should provide more info columns to enable better cluster overview. Extend the printer columns with `Ready` (`True`/`False`) and `Message` (state reason).

Closes: #84
Signed-off-by: Thobias Karlsson <thobias.karlsson@gmail.com>

<!-- Write a clear title using https://conventionalcommits.org -->
<!-- Write a summary with intention about the pull request.-->
