### PR TITLE
feat: use scoped signing keys for users

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -58,6 +58,9 @@ type AccountClaims struct {
 type AccountStatus struct {
 	// +optional
 	Claims AccountClaims `json:"claims,omitempty"`
+	// +listType=set
+	// +optional
+	SigningKeys []string `json:"signingKeys,omitempty"`
 	// +listType=map
 	// +listMapKey=type
 	// +patchStrategy=merge

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -247,6 +247,11 @@ func (in *AccountSpec) DeepCopy() *AccountSpec {
 func (in *AccountStatus) DeepCopyInto(out *AccountStatus) {
 	*out = *in
 	in.Claims.DeepCopyInto(&out.Claims)
+	if in.SigningKeys != nil {
+		in, out := &in.SigningKeys, &out.SigningKeys
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/charts/nauth-crds/crds/nauth.io_accounts.yaml
+++ b/charts/nauth-crds/crds/nauth.io_accounts.yaml
@@ -488,6 +488,11 @@ spec:
                   name:
                     type: string
                 type: object
+              signingKeys:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
             type: object
         type: object
     served: true

--- a/charts/nauth-crds/crds/nauth.io_users.yaml
+++ b/charts/nauth-crds/crds/nauth.io_users.yaml
@@ -117,6 +117,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              useSigningKey:
+                description: UseSigningKey generates a scopping signing key for the
+                  user.
+                type: boolean
               userLimits:
                 properties:
                   src:

--- a/charts/nauth/resources/crds/nauth.io_accounts.yaml
+++ b/charts/nauth/resources/crds/nauth.io_accounts.yaml
@@ -488,6 +488,11 @@ spec:
                   name:
                     type: string
                 type: object
+              signingKeys:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
             type: object
         type: object
     served: true

--- a/charts/nauth/resources/crds/nauth.io_users.yaml
+++ b/charts/nauth/resources/crds/nauth.io_users.yaml
@@ -117,6 +117,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              useSigningKey:
+                description: UseSigningKey generates a scopping signing key for the
+                  user.
+                type: boolean
               userLimits:
                 properties:
                   src:

--- a/internal/account/mocks_test.go
+++ b/internal/account/mocks_test.go
@@ -23,7 +23,7 @@ type SecretStorerMock struct {
 }
 
 // ApplySecret implements ports.SecretStorer.
-func (s *SecretStorerMock) Apply(ctx context.Context, secretOwner *secret.Owner, meta metav1.ObjectMeta, valueMap map[string]string) error {
+func (s *SecretStorerMock) Apply(ctx context.Context, secretOwner *secret.Owner, meta metav1.ObjectMeta, valueMap map[string]string, update bool) error {
 	args := s.Called(ctx, secretOwner, meta, valueMap)
 	return args.Error(0)
 }

--- a/internal/k8s/account.go
+++ b/internal/k8s/account.go
@@ -34,7 +34,7 @@ func (a *AccountClient) Get(ctx context.Context, accountRefName string, namespac
 	}
 
 	if !isReady(account) {
-		log.Error(err, "account is not ready", "namespace", namespace, "accountName", accountRefName)
+		log.Info("account is not ready", "namespace", namespace, "accountName", accountRefName)
 		return nil, errors.Join(ErrAccountNotReady, err)
 	}
 

--- a/internal/k8s/errors.go
+++ b/internal/k8s/errors.go
@@ -6,4 +6,5 @@ var (
 	ErrNoAccountFound  = errors.New("no account found")
 	ErrAccountNotReady = errors.New("account is not ready")
 	ErrNotFound        = errors.New("not found")
+	NoErrRetryLater    = errors.New("try again later")
 )

--- a/internal/k8s/labels.go
+++ b/internal/k8s/labels.go
@@ -5,6 +5,8 @@ const (
 	LabelAccountSignedBy              = "account.nauth.io/signed-by"
 	LabelUserID                       = "user.nauth.io/id"
 	LabelUserAccountID                = "user.nauth.io/account-id"
+	LabelUserSigningKeyID             = "user.nauth.io/signing-key-id"
+	LabelUserName                     = "user.nauth.io/username"
 	LabelUserSignedBy                 = "user.nauth.io/signed-by"
 	LabelSecretType                   = "nauth.io/secret-type"
 	LabelManaged                      = "nauth.io/managed"

--- a/internal/k8s/secret/secret_test.go
+++ b/internal/k8s/secret/secret_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Secrets storer", func() {
 		It("should successfully create and update an existing secret", func() {
 			By("Creating a new secret from scratch")
 			secret := map[string]string{"key": "value"}
-			err := secretStorer.Apply(ctx, nil, secretMeta, secret)
+			err := secretStorer.Apply(ctx, nil, secretMeta, secret, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Retrieving the secret")
@@ -52,7 +52,7 @@ var _ = Describe("Secrets storer", func() {
 
 			By("Updating the secret with a new value")
 			newSecret := map[string]string{"key": "new value"}
-			err = secretStorer.Apply(ctx, nil, secretMeta, newSecret)
+			err = secretStorer.Apply(ctx, nil, secretMeta, newSecret, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Retrieving the updated secret")
@@ -77,7 +77,7 @@ var _ = Describe("Secrets storer", func() {
 
 				By("Trying to update the existing secret with a new value")
 				newSecret := map[string]string{"key": "new value"}
-				err = secretStorer.Apply(ctx, nil, secretMeta, newSecret)
+				err = secretStorer.Apply(ctx, nil, secretMeta, newSecret, true)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(fmt.Errorf("existing secret %s/%s not managed by nauth", namespace, resourceName)))
 
@@ -110,7 +110,7 @@ var _ = Describe("Secrets storer", func() {
 		It("should return success when deleting existing secret", func() {
 			By("Creating a new secret from scratch")
 			secret := map[string]string{"key": "value"}
-			err := secretStorer.Apply(ctx, nil, secretMeta, secret)
+			err := secretStorer.Apply(ctx, nil, secretMeta, secret, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Deleting the secret")

--- a/internal/k8s/secret_types.go
+++ b/internal/k8s/secret_types.go
@@ -7,6 +7,7 @@ const (
 
 const (
 	SecretTypeAccountRoot            = "account-root"
+	SecretTypeUserSign               = "user-sign"
 	SecretTypeAccountSign            = "account-sign"
 	SecretTypeOperatorSign           = "operator-sign"
 	SecretTypeSystemAccountUserCreds = "system-account-user-creds"

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -1,0 +1,9 @@
+package nats
+
+type NatsClient interface {
+	EnsureConnected(namespace string) error
+	Disconnect()
+	LookupAccountJWT(string) (string, error)
+	UploadAccountJWT(jwt string) error
+	DeleteAccountJWT(jwt string) error
+}

--- a/internal/user/claims.go
+++ b/internal/user/claims.go
@@ -49,6 +49,10 @@ func newClaimsBuilder(
 			claim.Times = append(claim.Times, time)
 		}
 		claim.Locale = spec.UserLimits.Locale
+	} else {
+		if spec.UseSigningKey {
+			claim.Limits = jwt.Limits{} // Needed for scoped users
+		}
 	}
 
 	// NATS Limits

--- a/internal/user/constants.go
+++ b/internal/user/constants.go
@@ -1,0 +1,5 @@
+package user
+
+const (
+	SecretNameUserSignTemplate = "%s-user-sign-%s"
+)

--- a/internal/user/mocks_test.go
+++ b/internal/user/mocks_test.go
@@ -23,7 +23,7 @@ type SecretStorerMock struct {
 }
 
 // ApplySecret implements ports.SecretStorer.
-func (s *SecretStorerMock) Apply(ctx context.Context, secretOwner *secret.Owner, meta metav1.ObjectMeta, valueMap map[string]string) error {
+func (s *SecretStorerMock) Apply(ctx context.Context, secretOwner *secret.Owner, meta metav1.ObjectMeta, valueMap map[string]string, update bool) error {
 	args := s.Called(ctx, secretOwner, meta, valueMap)
 	return args.Error(0)
 }

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/k8s"
 	"github.com/WirelessCar/nauth/internal/k8s/secret"
+	"github.com/WirelessCar/nauth/internal/nats"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	v1 "k8s.io/api/core/v1"
@@ -17,7 +21,7 @@ import (
 )
 
 type SecretClient interface {
-	Apply(ctx context.Context, owner *secret.Owner, meta metav1.ObjectMeta, valueMap map[string]string) error
+	Apply(ctx context.Context, owner *secret.Owner, meta metav1.ObjectMeta, valueMap map[string]string, update bool) error
 	Get(ctx context.Context, namespace string, name string) (map[string]string, error)
 	GetByLabels(ctx context.Context, namespace string, labels map[string]string) (*v1.SecretList, error)
 	Delete(ctx context.Context, namespace string, name string) error
@@ -29,37 +33,271 @@ type AccountGetter interface {
 }
 
 type Manager struct {
-	accounts     AccountGetter
-	secretClient SecretClient
+	accounts       AccountGetter
+	natsClient     nats.NatsClient
+	secretClient   SecretClient
+	nauthNamespace string
 }
 
-func NewManager(accounts AccountGetter, secretClient SecretClient) *Manager {
-	return &Manager{
+func NewManager(accounts AccountGetter, natsClient nats.NatsClient, secretClient SecretClient, opts ...func(*Manager)) *Manager {
+	manager := &Manager{
 		accounts:     accounts,
+		natsClient:   natsClient,
 		secretClient: secretClient,
 	}
+
+	for _, opt := range opts {
+		opt(manager)
+	}
+
+	if manager.nauthNamespace == "" {
+		controllerNamespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		if err != nil {
+			log.Fatalf("Failed create account manager. Failed to read namespace: %v", err)
+		}
+		manager.nauthNamespace = strings.TrimSpace(string(controllerNamespace))
+	}
+	return manager
 }
 
-func (u *Manager) CreateOrUpdate(ctx context.Context, state *v1alpha1.User) error {
-	account, err := u.accounts.Get(ctx, state.Spec.AccountName, state.Namespace)
+func WithNamespace(namespace string) func(*Manager) {
+	return func(manager *Manager) {
+		manager.nauthNamespace = namespace
+	}
+}
+
+func (u *Manager) getOperatorSigningKeyPair(ctx context.Context) (nkeys.KeyPair, error) {
+	labels := map[string]string{
+		k8s.LabelSecretType: k8s.SecretTypeOperatorSign,
+	}
+	operatorSecret, err := u.secretClient.GetByLabels(ctx, u.nauthNamespace, labels)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to get operator signing key: %w", err)
 	}
 
-	accountID := account.GetLabels()[k8s.LabelAccountID]
-	accountSigningKeyPair, err := u.getAccountSigningKeyPair(ctx, account.GetNamespace(), account.GetName(), accountID)
-	if err != nil {
-		return fmt.Errorf("failed to get signing key secret %s/%s: %w", account.GetNamespace(), account.GetName(), err)
+	if len(operatorSecret.Items) < 1 {
+		return nil, fmt.Errorf("missing operator signing key secret, make sure to label the secret with the label %s: %s", k8s.LabelSecretType, k8s.SecretTypeOperatorSign)
 	}
-	accountSigningKeyPublicKey, _ := accountSigningKeyPair.PublicKey()
+
+	if len(operatorSecret.Items) > 1 {
+		return nil, fmt.Errorf("multiple operator signing key secrets found, make sure only one secret has the label %s: %s", k8s.LabelSecretType, k8s.SecretTypeSystemAccountUserCreds)
+	}
+
+	seed, ok := operatorSecret.Items[0].Data[k8s.DefaultSecretKeyName]
+	if !ok {
+		return nil, fmt.Errorf("secret for operator signing key seed was malformed")
+	}
+
+	return nkeys.FromSeed(seed)
+}
+
+// ensureSigningKeySecret returns a KeyPair from a Kubernetes secret, which is created if needed
+func (u *Manager) ensureSigningKeySecret(ctx context.Context, namespace string, state *v1alpha1.User) (nkeys.KeyPair, error) {
+	signingKey, err := u.getUserSigningKeyPair(ctx, namespace, state.Name)
+	if err == nil {
+		return signingKey, nil
+	}
+	// Create or update the signing key secret
+	signingKey, _ = nkeys.CreateAccount()
+	accountSeed, _ := signingKey.Seed()
+	signingKeyPublicKey, _ := signingKey.PublicKey()
+	// signingPrivateKey, _ := sk.PrivateKey()
+	secretOwner := &secret.Owner{
+		Owner: state,
+	}
+	secretMeta := metav1.ObjectMeta{
+		Name:      state.GetUserSigningKeySecretName(),
+		Namespace: state.GetNamespace(),
+		Labels: map[string]string{
+			k8s.LabelUserSigningKeyID: signingKeyPublicKey,
+			k8s.LabelSecretType:       k8s.SecretTypeUserSign,
+			k8s.LabelManaged:          k8s.LabelManagedValue,
+			k8s.LabelUserName:         state.Name,
+		},
+	}
+	secretValue := map[string]string{
+		k8s.DefaultSecretKeyName: string(accountSeed),
+	}
+	err = u.secretClient.Apply(ctx, secretOwner, secretMeta, secretValue, true)
+	if err != nil {
+		return nil, err
+	}
+	return signingKey, nil
+}
+
+// deleteScoppingSigningKey removes a signing key from the account JWT
+func (u *Manager) deleteScoppingSigningKey(ctx context.Context, namespace string, accountID string, state *v1alpha1.User) error {
+	signingKeyPair, err := u.ensureSigningKeySecret(ctx, namespace, state)
+	if err != nil {
+		return fmt.Errorf("cannot get signing key secret: %w", err)
+	}
+	signingKeyPublicKey, _ := signingKeyPair.PublicKey()
+
+	// The secret is created, update the account JWT
+	err = u.natsClient.EnsureConnected(u.nauthNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to connect to NATS cluster: %w", err)
+	}
+	defer u.natsClient.Disconnect()
+	accountJWT, err := u.natsClient.LookupAccountJWT(accountID)
+	if err != nil {
+		return fmt.Errorf("failed to lookup account jwt for account %s: %w", accountID, err)
+	}
+	if len(accountJWT) == 0 {
+		return fmt.Errorf("account jwt for account %s not found", accountID)
+	}
+	accountNatsClaims, err := jwt.DecodeAccountClaims(accountJWT)
+	if err != nil {
+		return fmt.Errorf("failed to decode account jwt for account %s: %w", accountID, err)
+	}
+
+	// Add the new signing key to the list
+	if accountNatsClaims.SigningKeys == nil {
+		accountNatsClaims.SigningKeys = jwt.SigningKeys{}
+	}
+	accountNatsClaims.SigningKeys.Add(signingKeyPublicKey)
+
+	delete(accountNatsClaims.SigningKeys, signingKeyPublicKey)
+
+	// Get operator signing key
+	operatorSigningKeyPair, err := u.getOperatorSigningKeyPair(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get operator signing key pair from seed: %w", err)
+	}
+
+	// Sign account JWT
+	newAccountJWT, err := accountNatsClaims.Encode(operatorSigningKeyPair)
+	if err != nil {
+		userResource := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
+		return fmt.Errorf("failed to sign account jwt for %s: %w", userResource, err)
+	}
+
+	// Upload account JWT
+	if err := u.natsClient.UploadAccountJWT(newAccountJWT); err != nil {
+		return fmt.Errorf("failed to upload account jwt: %w", err)
+	}
+	return nil
+}
+
+// ensureScoppingSigningKey creates a scopping signing key, making sure the Kubernetes secret is created, and the account JWT updated
+func (u *Manager) ensureScoppingSigningKey(ctx context.Context, namespace string, accountID string, userPublicKey string, state *v1alpha1.User) (nkeys.KeyPair, error) {
+	signingKeyPair, err := u.ensureSigningKeySecret(ctx, namespace, state)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get signing key secret: %w", err)
+	}
+	signingKeyPublicKey, _ := signingKeyPair.PublicKey()
+
+	// The secret is created, update the account JWT
+	err = u.natsClient.EnsureConnected(u.nauthNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to NATS cluster: %w", err)
+	}
+	defer u.natsClient.Disconnect()
+	accountJWT, err := u.natsClient.LookupAccountJWT(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup account jwt for account %s: %w", accountID, err)
+	}
+	if len(accountJWT) == 0 {
+		return nil, fmt.Errorf("account jwt for account %s not found", accountID)
+	}
+	accountNatsClaims, err := jwt.DecodeAccountClaims(accountJWT)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode account jwt for account %s: %w", accountID, err)
+	}
+
+	// Add the new signing key to the list
+	if accountNatsClaims.SigningKeys == nil {
+		accountNatsClaims.SigningKeys = jwt.SigningKeys{}
+	}
+	accountNatsClaims.SigningKeys.Add(signingKeyPublicKey)
+
+	delete(accountNatsClaims.SigningKeys, signingKeyPublicKey)
+
+	natsClaims := newClaimsBuilder(getDisplayName(state), state.Spec, userPublicKey, accountID).build()
+	scope := jwt.NewUserScope()
+	scope.Key = signingKeyPublicKey
+	scope.Role = state.Name
+	scope.Template.Pub = natsClaims.Pub
+	scope.Template.Sub = natsClaims.Sub
+	scope.Template.Permissions = natsClaims.Permissions
+	scope.Template.Limits = natsClaims.Limits
+	accountNatsClaims.SigningKeys.AddScopedSigner(scope)
+
+	// Get operator signing key
+	operatorSigningKeyPair, err := u.getOperatorSigningKeyPair(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator signing key pair from seed: %w", err)
+	}
+
+	// Sign account JWT
+	newAccountJWT, err := accountNatsClaims.Encode(operatorSigningKeyPair)
+	if err != nil {
+		userResource := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
+		return nil, fmt.Errorf("failed to sign account jwt for %s: %w", userResource, err)
+	}
+
+	// Upload account JWT
+	if err := u.natsClient.UploadAccountJWT(newAccountJWT); err != nil {
+		return nil, fmt.Errorf("failed to upload account jwt: %w", err)
+	}
+	return signingKeyPair, nil
+}
+
+/*
+if useSigningKey = false
+
+	find user secret, create if needed, update if needed
+
+if useSigningKey = true
+
+	find user scoped key, create if needed, update if needed
+		if created of updated, update the account JWT
+	find user creds, create if needed (update not needed)
+*/
+func (u *Manager) CreateOrUpdate(ctx context.Context, state *v1alpha1.User) error {
+	acc, err := u.accounts.Get(ctx, state.Spec.AccountName, state.Namespace)
+	if err != nil {
+		return errors.Join(k8s.NoErrRetryLater, err)
+	}
+
+	var signingKeyPair nkeys.KeyPair
+	var natsClaims *jwt.UserClaims
+	var signingKeyPublicKey string
+
+	accountID := acc.GetLabels()[k8s.LabelAccountID]
+	accountSigningKeyPair, err := u.getAccountSigningKeyPair(ctx, acc.GetNamespace(), acc.GetName(), accountID)
+	if err != nil {
+		return fmt.Errorf("failed to get signing key secret %s/%s: %w", acc.GetNamespace(), acc.GetName(), err)
+	}
 
 	userKeyPair, _ := nkeys.CreateUser()
 	userPublicKey, _ := userKeyPair.PublicKey()
 	userSeed, _ := userKeyPair.Seed()
 
-	natsClaims := newClaimsBuilder(getDisplayName(state), state.Spec, userPublicKey, accountID).
-		build()
-	userJwt, err := natsClaims.Encode(accountSigningKeyPair)
+	// Get the user's signing key, create if needed
+	if state.Spec.UseSigningKey {
+		signingKeyPair, err = u.ensureScoppingSigningKey(ctx, acc.GetNamespace(), accountID, userPublicKey, state)
+		if err != nil {
+			return fmt.Errorf("failed to update the account JWT: %w", err)
+		}
+		signingKeyPublicKey, _ = signingKeyPair.PublicKey()
+		// Scopped users claims must be empty
+		natsClaims = newClaimsBuilder(getDisplayName(state), v1alpha1.UserSpec{
+			AccountName: state.Spec.AccountName,
+			DisplayName: state.Spec.DisplayName,
+			Permissions: nil,
+			UserLimits:  nil,
+			NatsLimits:  nil,
+		}, userPublicKey, accountID).build()
+	} else {
+		// Sign using the account key
+		signingKeyPublicKey, _ = accountSigningKeyPair.PublicKey()
+		signingKeyPair = accountSigningKeyPair
+		natsClaims = newClaimsBuilder(getDisplayName(state), state.Spec, userPublicKey, accountID).
+			build()
+	}
+
+	userJwt, err := natsClaims.Encode(signingKeyPair)
 	if err != nil {
 		userResource := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
 		return fmt.Errorf("failed to sign user jwt for %s: %w", userResource, err)
@@ -81,7 +319,7 @@ func (u *Manager) CreateOrUpdate(ctx context.Context, state *v1alpha1.User) erro
 	secretValue := map[string]string{
 		k8s.UserCredentialSecretKeyName: string(userCreds),
 	}
-	err = u.secretClient.Apply(ctx, secretOwner, secretMeta, secretValue)
+	err = u.secretClient.Apply(ctx, secretOwner, secretMeta, secretValue, !state.Spec.UseSigningKey)
 	if err != nil {
 		return err
 	}
@@ -94,8 +332,8 @@ func (u *Manager) CreateOrUpdate(ctx context.Context, state *v1alpha1.User) erro
 	}
 
 	state.GetLabels()[k8s.LabelUserID] = userPublicKey
-	state.GetLabels()[k8s.LabelUserAccountID] = account.GetLabels()[k8s.LabelAccountID]
-	state.GetLabels()[k8s.LabelUserSignedBy] = accountSigningKeyPublicKey
+	state.GetLabels()[k8s.LabelUserAccountID] = acc.GetLabels()[k8s.LabelAccountID]
+	state.GetLabels()[k8s.LabelUserSignedBy] = signingKeyPublicKey
 
 	state.Status.ObservedGeneration = state.Generation
 	state.Status.ReconcileTimestamp = metav1.Now()
@@ -103,16 +341,67 @@ func (u *Manager) CreateOrUpdate(ctx context.Context, state *v1alpha1.User) erro
 	return nil
 }
 
+/*
+if useSigningKey = false
+
+	Delete user secret
+
+if useSigningKey = true
+
+	Update Account JWT
+	Delete signing key secret
+	Delete secret
+*/
 func (u *Manager) Delete(ctx context.Context, state *v1alpha1.User) error {
 	log := logf.FromContext(ctx)
 	log.Info("Delete user", "userName", state.GetName())
 
-	err := u.secretClient.Delete(ctx, state.Namespace, state.GetUserSecretName())
-	if err != nil {
+	if state.Spec.UseSigningKey {
+		acc, err := u.accounts.Get(ctx, state.Spec.AccountName, state.Namespace)
+		if err != nil {
+			return errors.Join(k8s.NoErrRetryLater, err)
+		}
+
+		accountID := acc.GetLabels()[k8s.LabelAccountID]
+		if err := u.deleteScoppingSigningKey(ctx, state.Namespace, accountID, state); err != nil {
+			return fmt.Errorf("failed to update the account JWT: %w", err)
+		}
+
+		if err := u.secretClient.Delete(ctx, state.Namespace, state.GetUserSigningKeySecretName()); err != nil {
+			return fmt.Errorf("failed to delete user signing key secret %s/%s: %w", state.Namespace, state.GetUserSigningKeySecretName(), err)
+		}
+	}
+	if err := u.secretClient.Delete(ctx, state.Namespace, state.GetUserSecretName()); err != nil {
 		return fmt.Errorf("failed to delete user secret %s/%s: %w", state.Namespace, state.GetUserSecretName(), err)
 	}
 
 	return nil
+}
+
+func (u *Manager) getUserSigningKeyPair(ctx context.Context, namespace, userName string) (nkeys.KeyPair, error) {
+	labels := map[string]string{
+		k8s.LabelSecretType: k8s.SecretTypeUserSign,
+		k8s.LabelManaged:    k8s.LabelManagedValue,
+		k8s.LabelUserName:   userName,
+	}
+	secrets, err := u.secretClient.GetByLabels(ctx, namespace, labels)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get signing secret for user: %s-%s due to %w", namespace, userName, err)
+	}
+
+	if len(secrets.Items) < 1 {
+		return nil, fmt.Errorf("no signing secret found for user: %s-%s", namespace, userName)
+	}
+
+	if len(secrets.Items) > 1 {
+		return nil, fmt.Errorf("more than 1 signing secret found for user: %s-%s", namespace, userName)
+	}
+
+	seed, ok := secrets.Items[0].Data[k8s.DefaultSecretKeyName]
+	if !ok {
+		return nil, fmt.Errorf("secret for user credentials seed was malformed")
+	}
+	return nkeys.FromSeed(seed)
 }
 
 func (u *Manager) getAccountSigningKeyPair(ctx context.Context, namespace, accountName, accountID string) (nkeys.KeyPair, error) {
@@ -134,6 +423,7 @@ func (u *Manager) getAccountSigningKeyPairByAccountID(ctx context.Context, names
 		k8s.LabelSecretType: k8s.SecretTypeAccountSign,
 		k8s.LabelManaged:    k8s.LabelManagedValue,
 	}
+
 	secrets, err := u.secretClient.GetByLabels(ctx, namespace, labels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get signing secret for account: %s-%s due to %w", namespace, accountName, err)

--- a/internal/user/user_test.go
+++ b/internal/user/user_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/k8s"
+	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,18 +31,21 @@ var _ = Describe("User manager", func() {
 			userManager       *Manager
 			accountGetterMock *AccountGetterMock
 			secretStorerMock  *SecretStorerMock
+			natsClientMock    *NATSClientMock
 		)
 
 		BeforeEach(func() {
 			By("creating the user manager")
 			secretStorerMock = NewSecretStorerMock()
 			accountGetterMock = NewAccountGetterMock()
-			userManager = NewManager(accountGetterMock, secretStorerMock)
+			natsClientMock = NewNATSClientMock()
+			userManager = NewManager(accountGetterMock, natsClientMock, secretStorerMock, WithNamespace(accountNamespace))
 		})
 
 		AfterEach(func() {
 			secretStorerMock.AssertExpectations(GinkgoT())
 			accountGetterMock.AssertExpectations(GinkgoT())
+			natsClientMock.AssertExpectations(GinkgoT())
 		})
 
 		It("creates a new user belonging to the correct account", func() {
@@ -180,7 +184,92 @@ var _ = Describe("User manager", func() {
 			Expect(user.Status.Claims.NatsLimits.Data).Should(Equal(user.Spec.NatsLimits.Data))
 			Expect(user.Status.Claims.NatsLimits.Payload).Should(Equal(user.Spec.NatsLimits.Payload))
 		})
+
+		It("creates a new scopped user from an account with legacy secrets, then delete it", func() {
+			By("providing a user specification")
+			user := GetNewScoppedUser()
+
+			account := GetExistingAccount()
+
+			By("mocking the secret storer")
+
+			operatorKeyPair, _ := nkeys.CreateOperator()
+			operatorSeed, _ := operatorKeyPair.Seed()
+			operatorSignLabelsMock := map[string]string{k8s.LabelSecretType: k8s.SecretTypeOperatorSign}
+			operatorSignSecretMock := &corev1.SecretList{
+				Items: []corev1.Secret{{Data: map[string][]byte{k8s.DefaultSecretKeyName: operatorSeed}}},
+			}
+			secretStorerMock.On("GetByLabels", ctx, account.GetNamespace(), operatorSignLabelsMock).Return(operatorSignSecretMock, nil)
+
+			secretStorerMock.On("GetByLabels", mock.Anything, account.GetNamespace(), mock.Anything).Return(&corev1.SecretList{}, nil)
+
+			accountKeyPair, _ := nkeys.CreateAccount()
+			accountPublicKey, _ := accountKeyPair.PublicKey()
+			accountSeed, _ := accountKeyPair.Seed()
+			accountSecretValueMock := map[string]string{k8s.DefaultSecretKeyName: string(accountSeed)}
+			accountSecretNameMock := fmt.Sprintf(k8s.DeprecatedSecretNameAccountRootTemplate, account.GetName())
+			secretStorerMock.On("Get", mock.Anything, account.GetNamespace(), accountSecretNameMock).Return(accountSecretValueMock, nil)
+			accountSecretLabelsMock := map[string]string{
+				k8s.LabelAccountID:  accountPublicKey,
+				k8s.LabelSecretType: k8s.SecretTypeAccountRoot,
+				k8s.LabelManaged:    k8s.LabelManagedValue,
+			}
+			secretStorerMock.On("Label", mock.Anything, account.GetNamespace(), accountSecretNameMock, accountSecretLabelsMock).Return(nil)
+
+			accountSigningKeyPair, _ := nkeys.CreateAccount()
+			accountSigningPublicKey, _ := accountSigningKeyPair.PublicKey()
+			accountSigningSeed, _ := accountSigningKeyPair.Seed()
+			accountSigningSecretValueMock := map[string]string{k8s.DefaultSecretKeyName: string(accountSigningSeed)}
+			accountSigningSecretNameMock := fmt.Sprintf(k8s.DeprecatedSecretNameAccountSignTemplate, account.GetName())
+			secretStorerMock.On("Get", mock.Anything, account.GetNamespace(), accountSigningSecretNameMock).Return(accountSigningSecretValueMock, nil)
+			accountSigningSecretLabelsMock := map[string]string{
+				k8s.LabelAccountID:  accountPublicKey,
+				k8s.LabelSecretType: k8s.SecretTypeAccountSign,
+				k8s.LabelManaged:    k8s.LabelManagedValue,
+			}
+			secretStorerMock.On("Label", mock.Anything, account.GetNamespace(), accountSigningSecretNameMock, accountSigningSecretLabelsMock).Return(nil)
+			claims := jwt.NewAccountClaims(accountPublicKey)
+			token, _ := claims.Encode(accountSigningKeyPair)
+
+			By("mocking existing account")
+			account.Status.SigningKey = v1alpha1.KeyInfo{
+				Name: accountSigningPublicKey,
+			}
+			account.Labels = map[string]string{
+				k8s.LabelAccountID: accountPublicKey,
+			}
+			accountGetterMock.On("Get", ctx, accountName, accountNamespace).Return(*account, nil)
+
+			By("mock storing account WT")
+			secretStorerMock.On("Apply", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("map[string]string")).Return(nil)
+
+			By("mock getting the account JWT")
+			natsClientMock.On("LookupAccountJWT", mock.AnythingOfType("string")).Return(token, nil)
+
+			By("mocking the NATS client")
+			natsClientMock.On("EnsureConnected", accountNamespace).Return(nil)
+			natsClientMock.On("Disconnect").Return()
+			natsClientMock.On("UploadAccountJWT", mock.Anything).Return(nil)
+
+			// By("mock storing user credentials")
+			// secretStorerMock.On("Apply", mock.Anything, mock.Anything, mock.MatchedBy(func(s v1.ObjectMeta) bool {
+			// 	return s.GetName() == user.GetUserSecretName() && s.GetNamespace() == accountNamespace
+			// }), mock.AnythingOfType("map[string]string")).Return(nil)
+
+			err := userManager.CreateOrUpdate(ctx, user)
+
+			By("mock deleting secrets")
+			secretStorerMock.On("Delete", ctx, accountNamespace, mock.AnythingOfType("string")).Return(nil)
+			errDel := userManager.Delete(ctx, user)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(errDel).ToNot(HaveOccurred())
+
+			Expect(user.GetLabels()).ToNot(BeNil())
+			Expect(user.GetLabels()[k8s.LabelUserID]).Should(Satisfy(isUserPubKey))
+		})
 	})
+
 })
 
 func GetNewUser() *v1alpha1.User {
@@ -197,6 +286,22 @@ func GetNewUser() *v1alpha1.User {
 			},
 			UserLimits: &v1alpha1.UserLimits{},
 			NatsLimits: &v1alpha1.NatsLimits{},
+		},
+	}
+}
+
+func GetNewScoppedUser() *v1alpha1.User {
+	return &v1alpha1.User{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      userName,
+			Namespace: accountNamespace,
+		},
+		Spec: v1alpha1.UserSpec{
+			UseSigningKey: true,
+			AccountName:   accountName,
+			Permissions:   nil,
+			UserLimits:    nil,
+			NatsLimits:    nil,
 		},
 	}
 }

--- a/test/e2e/basic-test/00-assert-operator-secrets.yaml
+++ b/test/e2e/basic-test/00-assert-operator-secrets.yaml
@@ -44,7 +44,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: operator-sau-creds
+  name:
   namespace: nats
   labels:
     nauth.io/secret-type: system-account-user-creds


### PR DESCRIPTION
Using scoped signing keys allow to:
- keep the permissions inside the NATS resolver
- provide user creds whose permissions can be updated without the need to emit new creds
- revoke the user creds by simply removing the signing key from the NATS resolver

This PR adds a property in the User specification, which can be set to enable the use of signing keys. If not, it works the same than before.

NATS documentation on scoper signing keys: https://docs.nats.io/using-nats/nats-tools/nsc/signing_keys

I might also have corrected some bits of code which do not relate directly with the purpose of this PR, which prevented me to run the operator locally.

Still WIP, there is room for refactor, and I probably missed some cases.