### PR TITLE
feat(chart): Add .Values.global.labels & normalize all labels

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,*.go,.gitmodules}]
+indent_style = tab
+indent_size = 4
+
+[go.{mod,work,work.sum,sum}]
+charset = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+indent_style = unset
+indent_size = unset
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+eclint_indent_style = unset
+
+[Dockerfile]
+indent_size = 4

--- a/charts/nauth-crds/README.md.gotmpl
+++ b/charts/nauth-crds/README.md.gotmpl
@@ -1,0 +1,7 @@
+# NAuth CRDs
+
+This Helm chart contains only the Custom Resource Definitions (CRDs) for the NAuth operator.
+
+It is intended to be used alongside the main [nauth chart](../nauth) with `crds.install=false`.
+
+The chart uses Helm 3's native [`crds/`](./crds) folder to ensure CRDs are installed before any templates.

--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -8,6 +8,7 @@
 | crds.install | bool | `true` | Indicates if Custom Resource Definitions should be installed and upgraded as part of the release. |
 | crds.keep | bool | `true` | Indicates if Custom Resource Definitions should be kept when a release is uninstalled. |
 | fullnameOverride | string | `""` | Override the chart fullName (Release.name + Chart.name) |
+| global.labels | object | `{}` | Custom labels to apply to all resources. |
 | image.pullPolicy | string | `"IfNotPresent"` | Sets the pull policy for images. |
 | image.registry | string | `"ghcr.io/wirelesscar"` | Sets the operator image registry |
 | image.repository | string | `"nauth-operator"` | Sets the operator repository |
@@ -29,7 +30,7 @@
 | readinessProbe.periodSeconds | int | `10` |  |
 | replicaCount | int | `1` | Sets the replicaset count |
 | resources | object | `{}` | Setting resources is up to the user. Follows PodSpec. |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsGroup":65532,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext of the container |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext of the container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/nauth/templates/_helpers.tpl
+++ b/charts/nauth/templates/_helpers.tpl
@@ -54,6 +54,9 @@ helm.sh/chart: {{ include "nauth.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with ((.Values.global).labels) }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/nauth/templates/metrics_service.yaml
+++ b/charts/nauth/templates/metrics_service.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "nauth.fullname" . }}-metrics-service
   labels:
     service: nauth-metrics-service
+    {{- include "nauth.labels" . | nindent 4 }}
 spec:
   ports:
     - name: http-metrics

--- a/charts/nauth/templates/monitor.yaml
+++ b/charts/nauth/templates/monitor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     service: nauth-metrics-service
     release: prometheus
+    {{- include "nauth.labels" . | nindent 4 }}
 spec:
   endpoints:
     - path: /metrics

--- a/charts/nauth/templates/monitor_alarms.yaml
+++ b/charts/nauth/templates/monitor_alarms.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     service: nauth-metrics-service
     release: prometheus
+    {{- include "nauth.labels" . | nindent 4 }}
 spec:
   groups:
     - name: account.controller.rules

--- a/charts/nauth/templates/rbac_account_roles.yaml
+++ b/charts/nauth/templates/rbac_account_roles.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-account-admin
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -26,9 +26,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-account-editor
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -56,9 +56,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-account-viewer
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}

--- a/charts/nauth/templates/rbac_leader_election_role.yaml
+++ b/charts/nauth/templates/rbac_leader_election_role.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-leader-election
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   namespace: {{ include "nauth.namespaceName" . }}
 rules:
 - apiGroups:

--- a/charts/nauth/templates/rbac_manager-secret_role.yaml
+++ b/charts/nauth/templates/rbac_manager-secret_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
   name: {{ include "nauth.fullname" . }}-manager-secret
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}

--- a/charts/nauth/templates/rbac_manager_role.yaml
+++ b/charts/nauth/templates/rbac_manager_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
   name: {{ include "nauth.fullname" . }}-manager
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}

--- a/charts/nauth/templates/rbac_metrics.yaml
+++ b/charts/nauth/templates/rbac_metrics.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
   name: {{ include "nauth.fullname" . }}-metrics-auth
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -26,6 +28,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
   name: {{ include "nauth.fullname" . }}-metrics-reader
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -40,6 +44,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}RoleBinding
 metadata:
   name: {{ include "nauth.fullname" . }}-metrics-auth
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}

--- a/charts/nauth/templates/rbac_role_bindings.yaml
+++ b/charts/nauth/templates/rbac_role_bindings.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-manager
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -20,9 +20,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-manager-secret
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -39,9 +39,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-leader-election
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   namespace: {{ include "nauth.namespaceName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/nauth/templates/rbac_user_roles.yaml
+++ b/charts/nauth/templates/rbac_user_roles.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-user-admin
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -26,9 +26,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-user-editor
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}
@@ -56,9 +56,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not .Values.namespaced }}Cluster{{ end }}Role
 metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "nauth.name" . }}
   name: {{ include "nauth.fullname" . }}-user-viewer
+  labels:
+    {{- include "nauth.labels" . | nindent 4 }}
   {{- if .Values.namespaced }}
   namespace: {{ include "nauth.namespaceName" . }}
   {{- end }}

--- a/charts/nauth/tests/deployment_global_labels_test.yaml
+++ b/charts/nauth/tests/deployment_global_labels_test.yaml
@@ -1,0 +1,30 @@
+suite: .Values.global.labels on deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: doesn't fail with no globals
+    set:
+      global: ~
+    asserts:
+      - isNotEmpty:
+          path: metadata.labels
+  - it: doesn't fail with globals without labels
+    set:
+      global:
+        something: else
+    asserts:
+      - isNotEmpty:
+          path: metadata.labels
+  - it: propagates global.labels
+    set:
+      global:
+        labels:
+          custom.label.environment: dev
+          custom.label.team: team-potato
+    asserts:
+      - equal:
+          path: metadata.labels["custom.label.environment"]
+          value: dev
+      - equal:
+          path: metadata.labels["custom.label.team"]
+          value: team-potato

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -2,6 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # -- Custom labels to apply to all resources.
+  labels: {}
+  # custom.label.environment: dev
+  # custom.label.team: team-potato
+
 # -- Set the url for your nats server.<BR>The default means nats is deployed in the `nats` namespace.
 nats:
   url: nats://nats.nats.svc.cluster.local:4222


### PR DESCRIPTION
* Adds `.Values.global.labels` for putting custom labels on chart-produced resources. Useful for labelling after env, team or some other policy. Naming is aligned with the [NATS chart `.Values.global.labels`](https://github.com/nats-io/k8s/blob/d0ba0c2df1224f3f0db68d7f8dbc5447a0f066cc/helm/charts/nats/templates/_helpers.tpl#L102-L104) for consistency. Using `global` also helps in case `nauth` is used as a subchart (can be shared across all subcharts, see [doc](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values)) and is a common practice (e.g. cert-manager's [`.Values.global.commonLabels `](https://github.com/cert-manager/cert-manager/blob/9668922e1d443c985864854659f2ab5aa7322c68/deploy/charts/cert-manager/templates/_helpers.tpl#L159C8-L161))
* Cover new variable with tests
* Make all resources to use the same template for labels

Other:
* Re-run `cd charts/ && helm-docs .`
* Add missing `README.md.gotmpl` for `nauth-crds`