### PR TITLE
feat: Add account name as label in root + sign keys

### DIFF
--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -107,68 +107,135 @@ func (a *Manager) valid() bool {
 func (a *Manager) Create(ctx context.Context, state *natsv1alpha1.Account) (*controller.AccountResult, error) {
 	operatorSigningKeyPair, err := a.getOperatorSigningKeyPair(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get operator signing key pair from seed: %w", err)
+		return nil, fmt.Errorf("failed to get operator signing key pair from seed during creation: %w", err)
 	}
 
-	accountKeyPair, _ := nkeys.CreateAccount()
-	accountPublicKey, _ := accountKeyPair.PublicKey()
+	var accountPublicKey string
+	var accountSigningPublicKey string
+	var accountKeyPair nkeys.KeyPair
+	var accountSigningKeyPair nkeys.KeyPair
+
+	secrets, err := a.getAccountSecretsByAccountName(ctx, state.GetNamespace(), state.GetName())
+	if err == nil {
+		accountSecret := secrets[k8s.SecretTypeAccountRoot]
+		if len(accountSecret) == 0 {
+			return nil, fmt.Errorf("no account root secret found during creation: %w", err)
+		}
+		accountSeed := accountSecret[k8s.DefaultSecretKeyName]
+		if len(accountSeed) == 0 {
+			return nil, fmt.Errorf("no account root seed secret key '%s' found during creation: %w", k8s.DefaultSecretKeyName, err)
+		}
+		accountKeyPair, err = nkeys.FromSeed([]byte(accountSeed))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account key pair from existing seed during creation: %w", err)
+		}
+		accountPublicKey, err = accountKeyPair.PublicKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account public key from existing secret during creation: %w", err)
+		}
+
+		accountSigningSecret := secrets[k8s.SecretTypeAccountSign]
+		if len(accountSigningSecret) == 0 {
+			return nil, fmt.Errorf("no account signing secret found during creation: %w", err)
+		}
+		accountSigningSeed := accountSigningSecret[k8s.DefaultSecretKeyName]
+		if len(accountSigningSeed) == 0 {
+			return nil, fmt.Errorf("no account signing secret key '%s' found during creation: %w", k8s.DefaultSecretKeyName, err)
+		}
+		accountSigningKeyPair, err = nkeys.FromSeed([]byte(accountSigningSeed))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account signing key pair from existing seed during creation: %w", err)
+		}
+		accountSigningPublicKey, err = accountSigningKeyPair.PublicKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account signing public key from existing secret during creation: %w", err)
+		}
+	} else {
+		accountKeyPair, err = nkeys.CreateAccount()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create account key pair during creation: %w", err)
+		}
+		accountPublicKey, err = accountKeyPair.PublicKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account public key during creation: %w", err)
+		}
+
+		accountSigningKeyPair, err = nkeys.CreateAccount()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create account signing key pair during creation: %w", err)
+		}
+		accountSigningPublicKey, err = accountSigningKeyPair.PublicKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account signing public key during creation: %w", err)
+		}
+	}
+
 	accountSecretMeta := metav1.ObjectMeta{
 		Name:      getAccountRootSecretName(state.GetName(), accountPublicKey),
 		Namespace: state.GetNamespace(),
 		Labels: map[string]string{
-			k8s.LabelAccountID:  accountPublicKey,
-			k8s.LabelSecretType: k8s.SecretTypeAccountRoot,
-			k8s.LabelManaged:    k8s.LabelManagedValue,
+			k8s.LabelAccountID:   accountPublicKey,
+			k8s.LabelAccountName: state.GetName(),
+			k8s.LabelSecretType:  k8s.SecretTypeAccountRoot,
+			k8s.LabelManaged:     k8s.LabelManagedValue,
 		},
 	}
-	accountSeed, _ := accountKeyPair.Seed()
+	accountSeed, err := accountKeyPair.Seed()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account seed during creation: %w", err)
+	}
 	accountSecretValue := map[string]string{k8s.DefaultSecretKeyName: string(accountSeed)}
 
 	if err := a.secretClient.Apply(ctx, nil, accountSecretMeta, accountSecretValue); err != nil {
 		return nil, err
 	}
 
-	accountSigningKeyPair, _ := nkeys.CreateAccount()
-	accountSigningPublicKey, _ := accountSigningKeyPair.PublicKey()
 	accountSigningSecretMeta := metav1.ObjectMeta{
 		Name:      getAccountSignSecretName(state.GetName(), accountPublicKey),
 		Namespace: state.GetNamespace(),
 		Labels: map[string]string{
-			k8s.LabelAccountID:  accountPublicKey,
-			k8s.LabelSecretType: k8s.SecretTypeAccountSign,
-			k8s.LabelManaged:    k8s.LabelManagedValue,
+			k8s.LabelAccountID:   accountPublicKey,
+			k8s.LabelAccountName: state.GetName(),
+			k8s.LabelSecretType:  k8s.SecretTypeAccountSign,
+			k8s.LabelManaged:     k8s.LabelManagedValue,
 		},
 	}
-	accountSigningSeed, _ := accountSigningKeyPair.Seed()
+	accountSigningSeed, err := accountSigningKeyPair.Seed()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account signing seed during creation: %w", err)
+	}
 	accountSignSeedSecretValue := map[string]string{k8s.DefaultSecretKeyName: string(accountSigningSeed)}
 
 	if err := a.secretClient.Apply(ctx, nil, accountSigningSecretMeta, accountSignSeedSecretValue); err != nil {
 		return nil, err
 	}
 
-	operatorSigningPublicKey, _ := operatorSigningKeyPair.PublicKey()
+	operatorSigningPublicKey, err := operatorSigningKeyPair.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator signing public key during creation: %w", err)
+	}
 
 	natsClaims, err := newClaimsBuilder(ctx, getDisplayName(state), state.Spec, accountPublicKey, a.accounts).
 		signingKey(accountSigningPublicKey).
 		build()
 	if err != nil {
 		accountName := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
-		return nil, fmt.Errorf("failed to build NATS account claims for %s: %w", accountName, err)
+		return nil, fmt.Errorf("failed to build NATS account claims for %s during creation: %w", accountName, err)
 	}
 	signedJwt, err := natsClaims.Encode(operatorSigningKeyPair)
 	if err != nil {
 		accountName := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
-		return nil, fmt.Errorf("failed to sign account jwt for %s: %w", accountName, err)
+		return nil, fmt.Errorf("failed to sign account jwt for %s during creation: %w", accountName, err)
 	}
 
 	err = a.natsClient.EnsureConnected(a.nauthNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to NATS cluster: %w", err)
+		return nil, fmt.Errorf("failed to connect to NATS cluster during creation: %w", err)
 	}
 	defer a.natsClient.Disconnect()
 	err = a.natsClient.UploadAccountJWT(signedJwt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upload account jwt: %w", err)
+		return nil, fmt.Errorf("failed to upload account jwt during creation: %w", err)
 	}
 
 	// Return immutable result - controller will apply to state
@@ -183,7 +250,7 @@ func (a *Manager) Create(ctx context.Context, state *natsv1alpha1.Account) (*con
 func (a *Manager) Update(ctx context.Context, state *natsv1alpha1.Account) (*controller.AccountResult, error) {
 	operatorSigningKeyPair, err := a.getOperatorSigningKeyPair(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get operator signing key pair from seed: %w", err)
+		return nil, fmt.Errorf("failed to get operator signing key pair from seed during update: %w", err)
 	}
 
 	accountID := state.GetLabels()[k8s.LabelAccountID]
@@ -194,7 +261,7 @@ func (a *Manager) Update(ctx context.Context, state *natsv1alpha1.Account) (*con
 
 	if sysAccountID, err := a.getSystemAccountID(ctx, a.nauthNamespace); err != nil || sysAccountID == accountID {
 		if err != nil {
-			return nil, fmt.Errorf("failed to get system account ID: %w", err)
+			return nil, fmt.Errorf("failed to get system account ID during update: %w", err)
 		}
 
 		return nil, fmt.Errorf("updating system account is not supported, consider '%s: %s'", k8s.LabelManagementPolicy, k8s.LabelManagementPolicyObserveValue)
@@ -202,56 +269,65 @@ func (a *Manager) Update(ctx context.Context, state *natsv1alpha1.Account) (*con
 
 	accountSecret, ok := secrets[k8s.SecretTypeAccountRoot]
 	if !ok {
-		return nil, fmt.Errorf("secret for account not found")
+		return nil, fmt.Errorf("existing secret for account root not found during update")
 	}
 	accountSeed, ok := accountSecret[k8s.DefaultSecretKeyName]
 	if !ok {
-		return nil, fmt.Errorf("secret for account was malformed")
+		return nil, fmt.Errorf("existing secret for account root was malformed during update")
 	}
 	accountKeyPair, err := nkeys.FromSeed([]byte(accountSeed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account key pair from seed: %w", err)
+		return nil, fmt.Errorf("failed to get account key pair from existing seed during update: %w", err)
 	}
-	accountPublicKey, _ := accountKeyPair.PublicKey()
+	accountPublicKey, err := accountKeyPair.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account public key from existing seed during update: %w", err)
+	}
 
 	accountSigningSecret, ok := secrets[k8s.SecretTypeAccountSign]
 	if !ok {
-		return nil, fmt.Errorf("secret for account signing not found")
+		return nil, fmt.Errorf("existing secret for account signing not found during update")
 	}
 	accountSigningSeed, ok := accountSigningSecret[k8s.DefaultSecretKeyName]
 	if !ok {
-		return nil, fmt.Errorf("secret for account signing was malformed")
+		return nil, fmt.Errorf("existing secret for account signing was malformed during update")
 	}
 	accountSigningKeyPair, err := nkeys.FromSeed([]byte(accountSigningSeed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account key pair for signing from seed: %w", err)
+		return nil, fmt.Errorf("failed to get account signing key pair from existing seed during update: %w", err)
 	}
-	accountSigningPublicKey, _ := accountSigningKeyPair.PublicKey()
+	accountSigningPublicKey, err := accountSigningKeyPair.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account signing public key from existing seed during update: %w", err)
+	}
 
-	operatorSigningPublicKey, _ := operatorSigningKeyPair.PublicKey()
+	operatorSigningPublicKey, err := operatorSigningKeyPair.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator signing public key during update: %w", err)
+	}
 
 	natsClaims, err := newClaimsBuilder(ctx, getDisplayName(state), state.Spec, accountPublicKey, a.accounts).
 		signingKey(accountSigningPublicKey).
 		build()
 	if err != nil {
 		accountName := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
-		return nil, fmt.Errorf("failed to build NATS account claims for %s: %w", accountName, err)
+		return nil, fmt.Errorf("failed to build NATS account claims for %s during update: %w", accountName, err)
 	}
 	signedJwt, err := natsClaims.Encode(operatorSigningKeyPair)
 	if err != nil {
 		accountName := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
-		return nil, fmt.Errorf("failed to sign account jwt for %s: %w", accountName, err)
+		return nil, fmt.Errorf("failed to sign account jwt for %s during update: %w", accountName, err)
 	}
 
 	err = a.natsClient.EnsureConnected(a.nauthNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to NATS cluster: %w", err)
+		return nil, fmt.Errorf("failed to connect to NATS cluster during update: %w", err)
 	}
 	defer a.natsClient.Disconnect()
 
 	err = a.natsClient.UploadAccountJWT(signedJwt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upload account jwt: %w", err)
+		return nil, fmt.Errorf("failed to upload account jwt during update: %w", err)
 	}
 
 	nauthClaims := convertNatsAccountClaims(natsClaims)
@@ -265,68 +341,71 @@ func (a *Manager) Update(ctx context.Context, state *natsv1alpha1.Account) (*con
 func (a *Manager) Import(ctx context.Context, state *natsv1alpha1.Account) (*controller.AccountResult, error) {
 	operatorSigningKeyPair, err := a.getOperatorSigningKeyPair(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get operator signing key pair from seed: %w", err)
+		return nil, fmt.Errorf("failed to get operator signing key pair from seed during import: %w", err)
 	}
-	operatorSigningPublicKey, _ := operatorSigningKeyPair.PublicKey()
+	operatorSigningPublicKey, err := operatorSigningKeyPair.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator signing public key during import: %w", err)
+	}
 
 	accountID := state.GetLabels()[k8s.LabelAccountID]
 	if accountID == "" {
-		return nil, fmt.Errorf("account ID is missing for account %s", state.GetName())
+		return nil, fmt.Errorf("account ID is missing for account %s during import", state.GetName())
 	}
 
 	secrets, err := a.getAccountSecrets(ctx, state.GetNamespace(), accountID, state.GetName())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get secrets for account %s: %w", accountID, err)
+		return nil, fmt.Errorf("failed to get secrets for account %s during import: %w", accountID, err)
 	}
 
 	accountRootSecret, ok := secrets[k8s.SecretTypeAccountRoot]
 	if !ok {
-		return nil, fmt.Errorf("account root secret not found for account %s", accountID)
+		return nil, fmt.Errorf("existing account root secret not found for account %s during import", accountID)
 	}
 	accountRootSeed, ok := accountRootSecret[k8s.DefaultSecretKeyName]
 	if !ok {
-		return nil, fmt.Errorf("account root seed secret for account %s is malformed", accountID)
+		return nil, fmt.Errorf("existing account root seed secret for account %s is malformed during import", accountID)
 	}
 	accountRootKeyPair, err := nkeys.FromSeed([]byte(accountRootSeed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account key pair for account %s from seed: %w", accountID, err)
+		return nil, fmt.Errorf("failed to get account key pair for account %s from existing seed during import: %w", accountID, err)
 	}
 	accountRootPublicKey, err := accountRootKeyPair.PublicKey()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account key pair for account %s from seed: %w", accountID, err)
+		return nil, fmt.Errorf("failed to get account public key for account %s from existing seed during import: %w", accountID, err)
 	}
 	if accountRootPublicKey != accountID {
-		return nil, fmt.Errorf("account root seed does not match account ID: expected %s, got %s", accountID, accountRootPublicKey)
+		return nil, fmt.Errorf("account root seed does not match account ID during import: expected %s, got %s", accountID, accountRootPublicKey)
 	}
 
 	accountSigningSecret, ok := secrets[k8s.SecretTypeAccountSign]
 	if !ok {
-		return nil, fmt.Errorf("account sign secret not found for account %s", accountID)
+		return nil, fmt.Errorf("existing account signing secret not found for account %s during import", accountID)
 	}
 	accountSigningSeed, ok := accountSigningSecret[k8s.DefaultSecretKeyName]
 	if !ok {
-		return nil, fmt.Errorf("account sign secret for account %s is malformed", accountID)
+		return nil, fmt.Errorf("existing account signing secret for account %s is malformed during import", accountID)
 	}
 	_, err = nkeys.FromSeed([]byte(accountSigningSeed))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account key pair for signing from seed for account %s: %w", accountID, err)
+		return nil, fmt.Errorf("failed to get account signing key pair from existing seed for account %s during import: %w", accountID, err)
 	}
 
 	err = a.natsClient.EnsureConnected(a.nauthNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to NATS cluster: %w", err)
+		return nil, fmt.Errorf("failed to connect to NATS cluster during import: %w", err)
 	}
 	defer a.natsClient.Disconnect()
 	accountJWT, err := a.natsClient.LookupAccountJWT(accountID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lookup account jwt for account %s: %w", accountID, err)
+		return nil, fmt.Errorf("failed to lookup account jwt for account %s during import: %w", accountID, err)
 	}
 	if len(accountJWT) == 0 {
-		return nil, fmt.Errorf("account jwt for account %s not found", accountID)
+		return nil, fmt.Errorf("account jwt for account %s not found during import", accountID)
 	}
 	natsClaims, err := jwt.DecodeAccountClaims(accountJWT)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode account jwt for account %s: %w", accountID, err)
+		return nil, fmt.Errorf("failed to decode account jwt for account %s during import: %w", accountID, err)
 	}
 
 	nauthClaims := convertNatsAccountClaims(natsClaims)
@@ -341,9 +420,12 @@ func (a *Manager) Delete(ctx context.Context, state *natsv1alpha1.Account) error
 	accountName := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
 	operatorSigningKeyPair, err := a.getOperatorSigningKeyPair(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get operator signing key pair from seed: %w", err)
+		return fmt.Errorf("failed to get operator signing key pair from seed during deletion: %w", err)
 	}
-	operatorPublicKey, _ := operatorSigningKeyPair.PublicKey()
+	operatorPublicKey, err := operatorSigningKeyPair.PublicKey()
+	if err != nil {
+		return fmt.Errorf("failed to get operator signing public key during deletion: %w", err)
+	}
 
 	accountID := state.GetLabels()[k8s.LabelAccountID]
 
@@ -353,12 +435,12 @@ func (a *Manager) Delete(ctx context.Context, state *natsv1alpha1.Account) error
 
 	deleteJwt, err := deleteClaim.Encode(operatorSigningKeyPair)
 	if err != nil {
-		return fmt.Errorf("failed to sign account jwt for %s: %w", accountName, err)
+		return fmt.Errorf("failed to sign account jwt for %s during deletion: %w", accountName, err)
 	}
 
 	err = a.natsClient.EnsureConnected(a.nauthNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to connect to NATS cluster: %w", err)
+		return fmt.Errorf("failed to connect to NATS cluster during deletion: %w", err)
 	}
 	defer a.natsClient.Disconnect()
 
@@ -368,7 +450,8 @@ func (a *Manager) Delete(ctx context.Context, state *natsv1alpha1.Account) error
 	}
 
 	labels := map[string]string{
-		k8s.LabelAccountID: accountID,
+		k8s.LabelAccountID:   accountID,
+		k8s.LabelAccountName: state.GetName(),
 	}
 
 	return a.secretClient.DeleteByLabels(ctx, state.GetNamespace(), labels)
@@ -400,19 +483,28 @@ func (a *Manager) getOperatorSigningKeyPair(ctx context.Context) (nkeys.KeyPair,
 }
 
 func (a *Manager) getAccountSecrets(ctx context.Context, namespace, accountID, accountName string) (map[string]map[string]string, error) {
-	if secrets, err := a.getAccountSecretsByAccountID(ctx, namespace, accountName, accountID); err == nil {
-		return secrets, nil
+	secretsByAccountID, errByAccountID := a.getAccountSecretsByAccountID(ctx, namespace, accountID)
+	if errByAccountID == nil {
+		return secretsByAccountID, nil
 	}
+	err := fmt.Errorf("failed to get account secrets by id = %s: %w", accountID, errByAccountID)
 
-	secrets, err := a.getDeprecatedAccountSecretsByName(ctx, namespace, accountName, accountID)
-	if err != nil {
-		return nil, err
+	secretsByAccountName, errByAccountName := a.getAccountSecretsByAccountName(ctx, namespace, accountName)
+	if errByAccountName == nil {
+		return secretsByAccountName, nil
 	}
+	err = errors.Join(err, fmt.Errorf("failed to get account secrets by account name = %s: %w", accountName, errByAccountName))
 
-	return secrets, nil
+	secretsBySecretName, errBySecretName := a.getDeprecatedAccountSecretsByName(ctx, namespace, accountName, accountID)
+	if errBySecretName == nil {
+		return secretsBySecretName, nil
+	}
+	err = errors.Join(err, fmt.Errorf("failed to get account secrets by secret name (deprecated) for account name = %s: %w", accountName, errBySecretName))
+
+	return nil, err
 }
 
-func (a *Manager) getAccountSecretsByAccountID(ctx context.Context, namespace, accountName, accountID string) (map[string]map[string]string, error) {
+func (a *Manager) getAccountSecretsByAccountID(ctx context.Context, namespace, accountID string) (map[string]map[string]string, error) {
 	labels := map[string]string{
 		k8s.LabelAccountID: accountID,
 		k8s.LabelManaged:   k8s.LabelManagedValue,
@@ -422,26 +514,41 @@ func (a *Manager) getAccountSecretsByAccountID(ctx context.Context, namespace, a
 		return nil, err
 	}
 
-	if len(k8sSecrets.Items) < 2 {
-		return nil, fmt.Errorf("missing one or more secret(s) for account: %s-%s", namespace, accountName)
+	return a.getAccountSecretsFromK8sSecrets(k8sSecrets)
+}
+
+func (a *Manager) getAccountSecretsByAccountName(ctx context.Context, namespace, accountName string) (map[string]map[string]string, error) {
+	labels := map[string]string{
+		k8s.LabelAccountName: accountName,
+		k8s.LabelManaged:     k8s.LabelManagedValue,
+	}
+	k8sSecrets, err := a.secretClient.GetByLabels(ctx, namespace, labels)
+	if err != nil {
+		return nil, err
 	}
 
-	if len(k8sSecrets.Items) > 2 {
-		return nil, fmt.Errorf("more than 2 secrets found for account: %s-%s", namespace, accountName)
+	return a.getAccountSecretsFromK8sSecrets(k8sSecrets)
+}
+
+func (a *Manager) getAccountSecretsFromK8sSecrets(k8sSecrets *v1.SecretList) (map[string]map[string]string, error) {
+	if len(k8sSecrets.Items) != 2 {
+		return nil, fmt.Errorf("expected 2 secrets, got %d", len(k8sSecrets.Items))
 	}
 
 	secrets := make(map[string]map[string]string, len(k8sSecrets.Items))
 	for _, secret := range k8sSecrets.Items {
 		secretType := secret.GetLabels()[k8s.LabelSecretType]
 		if _, ok := secrets[secretType]; ok {
-			return nil, fmt.Errorf("multiple secrets of type (%s) found for account: %s-%s", secretType, namespace, accountName)
+			return nil, fmt.Errorf("multiple secrets of type '%s' found", secretType)
 		}
+
 		secretData := make(map[string]string, len(secret.Data))
 		for k, v := range secret.Data {
 			secretData[k] = string(v)
 		}
 		secrets[secretType] = secretData
 	}
+
 	return secrets, nil
 }
 

--- a/internal/k8s/labels.go
+++ b/internal/k8s/labels.go
@@ -2,6 +2,7 @@ package k8s
 
 const (
 	LabelAccountID                    = "account.nauth.io/id"
+	LabelAccountName                  = "account.nauth.io/name"
 	LabelAccountSignedBy              = "account.nauth.io/signed-by"
 	LabelUserID                       = "user.nauth.io/id"
 	LabelUserAccountID                = "user.nauth.io/account-id"

--- a/internal/user/user_test.go
+++ b/internal/user/user_test.go
@@ -220,6 +220,9 @@ func GetNewAccount() *v1alpha1.Account {
 func GetExistingAccount() *v1alpha1.Account {
 	const ControllerTypeReady = "Ready"
 	account := GetNewAccount()
+	account.Labels = map[string]string{
+		k8s.LabelAccountID: "ACEXISTINGACCOUNTID",
+	}
 	account.Status = v1alpha1.AccountStatus{
 		SigningKey: v1alpha1.KeyInfo{
 			Name: "OPERATORSIGNPUBKEY",


### PR DESCRIPTION
This PR addresses the issue of orphaned secrets created during reconciliation retries #83 by implementing deterministic labeling for account secrets #60.

## Problem
When the NAuth controller reconciles a new Account CR, it generates account keys and creates Kubernetes secrets before uploading the JWT to NATS. If the NATS upload fails (e.g., NATS is temporarily unavailable), the reconciliation loop retries. Since the account.nauth.io/id label hasn't been applied to the CR yet, the controller would generate a new ID and a new set of secrets on every retry, leading to a build-up of orphaned secrets.

## Solution
The controller now uses the account name as a deterministic identifier to locate existing secrets before creating new ones. By labeling secrets with `account.nauth.io/name`, the manager can recover and reuse previously generated keys even if the reconciliation process was interrupted.

Fixes #60 
Closes #83