### PR TITLE
chore: git ignore approval tests temp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ go.work.sum
 # Kuttl
 kubeconfig
 test/logs/
+
+# Approval Tests
+**/.approval_tests_temp


### PR DESCRIPTION
When approval tests are run a `.approval_tests_temp` folder with logs and checks is generated, which should not be version controlled.

Signed-off-by: Thobias Karlsson <thobias.karlsson@gmail.com>

