### PR TITLE
fix: default to operator namespace for default cluster ref

### DIFF
--- a/internal/account/factory.go
+++ b/internal/account/factory.go
@@ -64,7 +64,7 @@ func (f *ManagerFactory) ForAccount(ctx context.Context, acct *v1alpha1.Account)
 		return NewManager(f.accounts, natsClient, f.secretClient, mgrOpts...), nil
 	}
 
-	cluster, err := f.resolveNatsClusterForAccount(ctx, clusterRef, acct.GetNamespace())
+	cluster, err := f.resolveNatsClusterForAccount(ctx, clusterRef, f.nauthNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/account/factory_test.go
+++ b/internal/account/factory_test.go
@@ -65,7 +65,7 @@ func (suite *FactoryTestSuite) Test_ForAccount_ShouldSucceed_WhenLegacyNoCluster
 	require.Nil(suite.T(), manager.natsCluster)
 }
 
-func (suite *FactoryTestSuite) Test_ForAccount_ShouldSucceed_WhenDefaultClusterRefIsSet() {
+func (suite *FactoryTestSuite) Test_ForAccount_ShouldSucceed_WhenDefaultClusterRefIsSetFullyQualified() {
 	// Given a manager factory with a default NATS cluster reference
 	unitUnderTest := NewManagerFactory(suite.clustersMock, suite.accountsMock, suite.secretsMock, suite.configMapMock, defaultNatsClusterRef, "controller-namespace", "nats://nats:4222")
 
@@ -90,6 +90,47 @@ func (suite *FactoryTestSuite) Test_ForAccount_ShouldSucceed_WhenDefaultClusterR
 		},
 	}
 	suite.clustersMock.On("GetNatsCluster", suite.ctx, defaultNatsClusterRefNamespace, defaultNatsClusterRefName).
+		Return(cluster, nil).
+		Once()
+
+	// When creating an account manager for the account
+	result, err := unitUnderTest.ForAccount(suite.ctx, acct)
+
+	// Then the operation should succeed
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), result)
+
+	manager := result.(*Manager)
+	require.Equal(suite.T(), cluster, manager.natsCluster)
+}
+
+func (suite *FactoryTestSuite) Test_ForAccount_ShouldSucceed_WhenDefaultClusterRefIsSetWithNameOnly() {
+	// Given a manager factory with a default NATS cluster reference
+	natsClusterName := "single-nats-cluster"
+	controllerNamespace := "controller-namespace"
+	unitUnderTest := NewManagerFactory(suite.clustersMock, suite.accountsMock, suite.secretsMock, suite.configMapMock, natsClusterName, controllerNamespace, "nats://nats:4222")
+
+	// And an account without a cluster reference
+	acct := &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "account-name",
+			Namespace: "account-namespace",
+		},
+		Spec: v1alpha1.AccountSpec{},
+	}
+
+	cluster := &v1alpha1.NatsCluster{
+		Spec: v1alpha1.NatsClusterSpec{
+			URL: "nats://cluster:4222",
+			OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+				Name: "operator-signing-key",
+			},
+			SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+				Name: "system-account-user-creds",
+			},
+		},
+	}
+	suite.clustersMock.On("GetNatsCluster", suite.ctx, controllerNamespace, natsClusterName).
 		Return(cluster, nil).
 		Once()
 


### PR DESCRIPTION
When the operator default cluster reference is set without namespace, we should default to the operator/controller namespace instead of the account namespace.

Signed-off-by: Thobias Karlsson <thobias.karlsson@gmail.com>

