### PR TITLE
deprecate: `NATS_URL` and implicit secrets lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Nauth requires the **system account user credentials** and the [**operator signi
 
 You can provide and resolve these secrets in three ways:
 
+> [!WARNING]
+> `NATS_URL` and the implicit label-based lookup path are deprecated and will be sunset in favor of explicit `NatsClusterRef` + `NatsCluster` resources (tracking: [#102](https://github.com/WirelessCar/nauth/issues/102)).
+
 **A.** For single-cluster deployments, set `NATS_CLUSTER_REF` on the nauth controller (`namespace/name`, for example `nats/my-nats-cluster`) and define the secrets in that referenced `NatsCluster` (`spec.operatorSigningKeySecretRef` and `spec.systemAccountUserCredsSecretRef`).
    - Default behavior (`NATS_CLUSTER_REF_OPTIONAL=false`) is strict mode: account-level `spec.natsClusterRef` must match `NATS_CLUSTER_REF`.
    - `NATS_CLUSTER_REF_OPTIONAL=true` is explicit opt-in default mode: accounts without `spec.natsClusterRef` use `NATS_CLUSTER_REF`, while accounts may override with their own ref.
@@ -42,7 +45,7 @@ You can provide and resolve these secrets in three ways:
 
 **B.** Define an explicit `spec.natsClusterRef` reference in each `Account` CR to a specific `NatsCluster`.
 
-**C.** Use the legacy label-based lookup:
+**C. (Deprecated)** Use the legacy label-based lookup together with `NATS_URL`:
    - `nauth.io/secret-type: system-account-user-creds`
    - `nauth.io/secret-type: operator-sign`
 

--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -19,7 +19,7 @@
 | nameOverride | string | `""` | Override the chart name |
 | namespace | object | `{"nameOverride":""}` | Override the namespace |
 | namespaced | bool | `false` | If true, limits the scope of nauth to a single namespace. Otherwise, all namespaces will be watched. |
-| nats.url | string | `""` | Legacy implicit lookup URL. Use only when `nats.clusterRef.name` is empty; must not be set together with `nats.clusterRef.name`. |
+| nats.url | string | `""` | DEPRECATED legacy implicit lookup URL (`NATS_URL`). Prefer `nats.clusterRef.*`; `nats.url` is valid only when `nats.clusterRef.name` is empty and must not be set together with it (sunset tracked in `#102`). |
 | nats.clusterRef | object | `{"name":"","namespace":"","optional":false}` | Operator NatsCluster reference object. Set `name` to enable operator-level binding. |
 | nats.clusterRef.name | string | `""` | NatsCluster resource name. Leave empty to disable operator-level binding. |
 | nats.clusterRef.namespace | string | `""` | NatsCluster resource namespace. When empty and `name` is set, defaults to the chart namespace. |

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -9,9 +9,11 @@ global:
   # custom.label.team: team-potato
 
 nats:
-  # -- Legacy implicit lookup URL.
+  # -- DEPRECATED: Legacy implicit lookup URL. See `nats.clusterRef` for replacement.
+  # -- Prefer explicit `nats.clusterRef.*` together with `NatsClusterRef` + `NatsCluster`.
   # -- Used only when `nats.clusterRef.name` is empty.
   # -- Must not be set together with `nats.clusterRef.name`.
+  # // TODO: [#102][#144] Sunset `nats.url`/`NATS_URL` and implicit operator signing key/system account credentials lookup.
   url: ""
 
   # -- Operator-level NatsCluster configuration.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -226,6 +226,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO: [#102][#144] Sunset NATS_URL in favor of explicit NatsClusterRef + NatsCluster resources.
 	defaultNatsURL := os.Getenv("NATS_URL")
 
 	var operatorNatsCluster *account.OperatorNatsCluster

--- a/examples/nauth/manifests/scenarios/cluster-ref/cluster-ref.yaml
+++ b/examples/nauth/manifests/scenarios/cluster-ref/cluster-ref.yaml
@@ -1,4 +1,4 @@
-# Cluster-ref scenario: using NatsClusterRef instead of legacy NATS_URL + label-based secrets.
+# Cluster-ref scenario: using NatsClusterRef instead of deprecated NATS_URL + label-based secrets.
 #
 # Prerequisites:
 # - Create an operator signing key secret (e.g. my-operator-signing-key) with key "seed"

--- a/internal/account/cluster.go
+++ b/internal/account/cluster.go
@@ -152,7 +152,11 @@ func (r *clusterTargetResolverImpl) resolveTarget(ctx context.Context, clusterRe
 	return target, nil
 }
 
+// resolveTargetFromImplicitLookup performs a best-effort resolution of cluster connection details based on the presence
+// of a default NATS URL and labeled secrets in the operator namespace.
+// Deprecated: This method relies on legacy patterns and will sunset in a future release.
 func (r *clusterTargetResolverImpl) resolveTargetFromImplicitLookup(ctx context.Context) (*clusterTarget, error) {
+	// TODO: [#102][#144] Sunset label-based secret lookup.
 	if r.config.DefaultNatsURL == "" {
 		return nil, fmt.Errorf("default NATS URL is not configured for implicit cluster lookup")
 	}
@@ -187,6 +191,7 @@ func (r *clusterTargetResolverImpl) resolveSysAdminCreds(ctx context.Context, cl
 	return userCreds, nil
 }
 
+// Deprecated: This method relies on legacy patterns and will sunset in a future release.
 func (r *clusterTargetResolverImpl) resolveSysAdminCredsViaLabels(ctx context.Context, namespace string) (*ports.NatsUserCreds, error) {
 	labels := map[string]string{
 		k8s.LabelSecretType: k8s.SecretTypeSystemAccountUserCreds,
@@ -216,6 +221,7 @@ func (r *clusterTargetResolverImpl) resolveOperatorSigningKey(ctx context.Contex
 	return opSigningKey, nil
 }
 
+// Deprecated: This method relies on legacy patterns and will sunset in a future release.
 func (r *clusterTargetResolverImpl) resolveOperatorSigningKeyViaLabels(ctx context.Context, namespace string) (ports.NatsOperatorSigningKey, error) {
 	labels := map[string]string{k8s.LabelSecretType: k8s.SecretTypeOperatorSign}
 	seed, err := r.resolveSecretByLabels(ctx, namespace, labels)

--- a/internal/account/config.go
+++ b/internal/account/config.go
@@ -11,8 +11,13 @@ import (
 
 type Config struct {
 	OperatorNatsCluster *OperatorNatsCluster
-	OperatorNamespace   string
-	DefaultNatsURL      string
+	// OperatorNamespace is the Kubernetes namespace where the operator is deployed.
+	// TODO: [#102][#144] When sunsetting DefaultNatsURL, remove this field if it no longer serves a purpose.
+	OperatorNamespace string
+	// DefaultNatsURL is a comma-separated list of NATS server URLs to use when OperatorNatsCluster is not configured.
+	// Deprecated: This field is deprecated and will be removed in a future release.
+	// TODO: [#102][#144] Sunset DefaultNatsURL (NATS_URL)
+	DefaultNatsURL string
 }
 
 func NewConfig(operatorNatsCluster *OperatorNatsCluster, operatorNamespace string, defaultNatsURL string) (*Config, error) {


### PR DESCRIPTION
After introducing the explicit `NatsClusterRef` and `NatsCluster` CRD's together with the `nats.clusterRef`/`NATS_CLUSTER_REF` parameters we should avoid the error-prone legacy implicit lookup of NATS cluster target secrets.

Issue: #144

