### PR TITLE
feat: remove unnecessary Owner domain struct

### DIFF
--- a/internal/account/mocks_test.go
+++ b/internal/account/mocks_test.go
@@ -24,8 +24,8 @@ type SecretClientMock struct {
 	mock.Mock
 }
 
-func (s *SecretClientMock) Apply(ctx context.Context, secretOwner *ports.Owner, meta metav1.ObjectMeta, valueMap map[string]string) error {
-	args := s.Called(ctx, secretOwner, meta, valueMap)
+func (s *SecretClientMock) Apply(ctx context.Context, owner metav1.Object, meta metav1.ObjectMeta, valueMap map[string]string) error {
+	args := s.Called(ctx, owner, meta, valueMap)
 	return args.Error(0)
 }
 

--- a/internal/account/secret_test.go
+++ b/internal/account/secret_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -243,7 +242,7 @@ func (t *SecretManagerTestSuite) Test_ApplyRootSecret_ShouldSucceed() {
 	var caughtMeta metav1.ObjectMeta
 	t.secretClientMock.mockApply(
 		t.ctx,
-		(*ports.Owner)(nil),
+		nil,
 		mock.Anything,
 		map[string]string{
 			k8s.DefaultSecretKeyName: string(rootSeed),
@@ -274,7 +273,7 @@ func (t *SecretManagerTestSuite) Test_ApplySignSecret_ShouldSucceed() {
 	var caughtMeta metav1.ObjectMeta
 	t.secretClientMock.mockApply(
 		t.ctx,
-		(*ports.Owner)(nil),
+		nil,
 		mock.Anything,
 		map[string]string{
 			k8s.DefaultSecretKeyName: string(signSeed),

--- a/internal/k8s/secret/secret.go
+++ b/internal/k8s/secret/secret.go
@@ -26,7 +26,7 @@ func NewClient(client client.Client) *Client {
 	}
 }
 
-func (k *Client) Apply(ctx context.Context, owner *ports.Owner, meta metav1.ObjectMeta, valueMap map[string]string) error {
+func (k *Client) Apply(ctx context.Context, owner metav1.Object, meta metav1.ObjectMeta, valueMap map[string]string) error {
 	if !isManagedSecret(&meta) {
 		return fmt.Errorf("label %s not supplied by secret %s/%s", k8s.LabelManaged, meta.Namespace, meta.Name)
 	}
@@ -40,7 +40,7 @@ func (k *Client) Apply(ctx context.Context, owner *ports.Owner, meta metav1.Obje
 			StringData: valueMap,
 		}
 		if owner != nil {
-			if err := controllerutil.SetControllerReference(owner.Owner, newSecret, k.client.Scheme()); err != nil {
+			if err := controllerutil.SetControllerReference(owner, newSecret, k.client.Scheme()); err != nil {
 				return fmt.Errorf("failed to link secret to owner: %w", err)
 			}
 		}
@@ -68,12 +68,11 @@ func (k *Client) Apply(ctx context.Context, owner *ports.Owner, meta metav1.Obje
 	return nil
 }
 
-func addOwnerReferenceIfNotExists(secret *v1.Secret, secretOwner *ports.Owner) error {
-	if secretOwner == nil {
+func addOwnerReferenceIfNotExists(secret *v1.Secret, owner metav1.Object) error {
+	if owner == nil {
 		return nil
 	}
 
-	owner := secretOwner.Owner
 	rtObj, ok := owner.(runtime.Object)
 
 	if !ok {

--- a/internal/ports/k8s.go
+++ b/internal/ports/k8s.go
@@ -30,10 +30,6 @@ func (n NamespacedName) String() string {
 	return fmt.Sprintf("%s/%s", n.Namespace, n.Name)
 }
 
-type Owner struct {
-	Owner metav1.Object
-}
-
 type ConfigMapReader interface {
 	Get(ctx context.Context, namespace string, name string) (map[string]string, error)
 }
@@ -45,7 +41,7 @@ type SecretReader interface {
 
 type SecretClient interface {
 	SecretReader
-	Apply(ctx context.Context, owner *Owner, meta metav1.ObjectMeta, valueMap map[string]string) error
+	Apply(ctx context.Context, owner metav1.Object, meta metav1.ObjectMeta, valueMap map[string]string) error
 	Delete(ctx context.Context, namespace string, name string) error
 	DeleteByLabels(ctx context.Context, namespace string, labels map[string]string) error
 	Label(ctx context.Context, namespace, name string, labels map[string]string) error

--- a/internal/user/mocks_test.go
+++ b/internal/user/mocks_test.go
@@ -23,8 +23,8 @@ type SecretClientMock struct {
 }
 
 // ApplySecret implements ports.SecretStorer.
-func (s *SecretClientMock) Apply(ctx context.Context, secretOwner *ports.Owner, meta metav1.ObjectMeta, valueMap map[string]string) error {
-	args := s.Called(ctx, secretOwner, meta, valueMap)
+func (s *SecretClientMock) Apply(ctx context.Context, owner metav1.Object, meta metav1.ObjectMeta, valueMap map[string]string) error {
+	args := s.Called(ctx, owner, meta, valueMap)
 	return args.Error(0)
 }
 

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -72,9 +72,6 @@ func (u *Manager) CreateOrUpdate(ctx context.Context, state *v1alpha1.User) erro
 		return fmt.Errorf("failed to format user credentials: %w", err)
 	}
 
-	secretOwner := &ports.Owner{
-		Owner: state,
-	}
 	secretMeta := metav1.ObjectMeta{
 		Name:      state.GetUserSecretName(),
 		Namespace: state.GetNamespace(),
@@ -86,7 +83,7 @@ func (u *Manager) CreateOrUpdate(ctx context.Context, state *v1alpha1.User) erro
 	secretValue := map[string]string{
 		k8s.UserCredentialSecretKeyName: string(userCreds),
 	}
-	err = u.secretClient.Apply(ctx, secretOwner, secretMeta, secretValue)
+	err = u.secretClient.Apply(ctx, state, secretMeta, secretValue)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We consider both the nAuth v1alpha1 CRDs and k8s types our first class citizen. Hence removing unnecessary wrapping of the Owner struct and relying solely on the k8s `metav1.Object`.

