### PR TITLE
feat: utilize nats-io jwt claims validation prior to signing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ godebug default=go1.25
 
 require (
 	github.com/approvals/go-approval-tests v1.8.0
-	github.com/nats-io/jwt/v2 v2.8.0
+	github.com/nats-io/jwt/v2 v2.8.1
 	github.com/nats-io/nats.go v1.49.0
 	github.com/nats-io/nkeys v0.4.15
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nats-io/jwt/v2 v2.8.0 h1:K7uzyz50+yGZDO5o772eRE7atlcSEENpL7P+b74JV1g=
-github.com/nats-io/jwt/v2 v2.8.0/go.mod h1:me11pOkwObtcBNR8AiMrUbtVOUGkqYjMQZ6jnSdVUIA=
+github.com/nats-io/jwt/v2 v2.8.1 h1:V0xpGuD/N8Mi+fQNDynXohVvp7ZztevW5io8CUWlPmU=
+github.com/nats-io/jwt/v2 v2.8.1/go.mod h1:nWnOEEiVMiKHQpnAy4eXlizVEtSfzacZ1Q43LIRavZg=
 github.com/nats-io/nats.go v1.49.0 h1:yh/WvY59gXqYpgl33ZI+XoVPKyut/IcEaqtsiuTJpoE=
 github.com/nats-io/nats.go v1.49.0/go.mod h1:fDCn3mN5cY8HooHwE2ukiLb4p4G4ImmzvXyJt+tGwdw=
 github.com/nats-io/nkeys v0.4.15 h1:JACV5jRVO9V856KOapQ7x+EY8Jo3qw1vJt/9Jpwzkk4=

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -143,13 +143,11 @@ func (a *Manager) Create(ctx context.Context, state *v1alpha1.Account) (*control
 		signingKey(accountSigningPublicKey).
 		build()
 	if err != nil {
-		accountName := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
-		return nil, fmt.Errorf("failed to build NATS account claims for %s during creation: %w", accountName, err)
+		return nil, fmt.Errorf("failed to build NATS account claims during creation: %w", err)
 	}
-	signedJwt, err := natsClaims.Encode(cluster.OperatorSigningKey)
+	signedJwt, err := signAccountJWT(natsClaims, cluster.OperatorSigningKey)
 	if err != nil {
-		accountName := fmt.Sprintf("%s-%s", state.GetNamespace(), state.GetName())
-		return nil, fmt.Errorf("failed to sign account jwt for %s during creation: %w", accountName, err)
+		return nil, fmt.Errorf("failed to sign account jwt during creation: %w", err)
 	}
 
 	conn, err := a.natsClient.Connect(cluster.NatsURL, cluster.SystemAdminCreds)
@@ -170,6 +168,15 @@ func (a *Manager) Create(ctx context.Context, state *v1alpha1.Account) (*control
 		AccountSignedBy: operatorSigningPublicKey,
 		Claims:          &nauthClaims,
 	}, nil
+}
+
+func signAccountJWT(claims *jwt.AccountClaims, operatorSigningKey nkeys.KeyPair) (string, error) {
+	claimsVal := &jwt.ValidationResults{}
+	claims.Validate(claimsVal)
+	if errs := claimsVal.Errors(); len(errs) > 0 {
+		return "", fmt.Errorf("account claims validation failed: %v", errs)
+	}
+	return claims.Encode(operatorSigningKey)
 }
 
 func (a *Manager) Update(ctx context.Context, state *v1alpha1.Account) (*controller.AccountResult, error) {
@@ -367,6 +374,11 @@ func (a *Manager) SignUserJWT(ctx context.Context, accountRef domain.NamespacedN
 	}
 	if claims.IssuerAccount == "" {
 		claims.IssuerAccount = accountID
+	}
+	claimsVal := &jwt.ValidationResults{}
+	claims.Validate(claimsVal)
+	if errs := claimsVal.Errors(); len(errs) > 0 {
+		return nil, fmt.Errorf("claims validation failed during user JWT signing: %v", claimsVal.Errors())
 	}
 	accountSecrets, err := a.secretManager.GetSecrets(ctx, accountRef, accountID)
 	if err != nil {

--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -363,6 +363,36 @@ func (t *ManagerTestSuite) Test_Delete_ShouldSucceed() {
 	t.Equal([]interface{}{accountID}, deleteClaims.Data["accounts"])
 }
 
+func (t *ManagerTestSuite) Test_signAccountJWT_ShouldFailWhenInvalidClaims() {
+	// Given
+	acRoot, _ := nkeys.CreateAccount()
+	acPub, _ := acRoot.PublicKey()
+	opSign, _ := nkeys.CreateOperator()
+	claims := jwt.NewAccountClaims(acPub)
+
+	acOtherRoot, _ := nkeys.CreateAccount()
+	acOtherPub, _ := acOtherRoot.PublicKey()
+	claims.Imports.Add(&jwt.Import{
+		Name:    "import-once",
+		Type:    jwt.Service,
+		Subject: "foo",
+		Account: acOtherPub,
+	})
+	claims.Imports.Add(&jwt.Import{
+		Name:    "import-twice",
+		Type:    jwt.Service,
+		Subject: "foo",
+		Account: acOtherPub,
+	})
+
+	// When
+	accountJWT, err := signAccountJWT(claims, opSign)
+
+	// Then
+	t.Empty(accountJWT)
+	t.ErrorContains(err, "account claims validation failed: [overlapping subject namespace for \"foo\" and \"foo\"")
+}
+
 func (t *ManagerTestSuite) Test_SignUserJWT_ShouldSucceed() {
 	// Given
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
@@ -459,6 +489,36 @@ func (t *ManagerTestSuite) Test_SignUserJWT_ShouldFailWhenClaimsIssuerAccountDoe
 	t.Nil(result)
 	t.ErrorContains(err, "claims issuer account ID some-other-account-id does not match "+
 		accountID+" bound to account \"account-namespace/account-name\" during user JWT signing")
+}
+
+func (t *ManagerTestSuite) Test_SignUserJWT_ShouldFailWhenClaimsValidationFails() {
+	// Given
+	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
+	accountRootKey, _ := nkeys.CreateAccount()
+	accountID, _ := accountRootKey.PublicKey()
+
+	account := &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "account-namespace",
+			Name:      "account-name",
+			Labels: map[string]string{
+				k8s.LabelAccountID: accountID,
+			},
+		},
+	}
+	t.accountReaderMock.mockGet(t.ctx, accountRef, account)
+
+	userKey, _ := nkeys.CreateUser()
+	userKeyPublic, _ := userKey.PublicKey()
+	claims := jwt.NewUserClaims(userKeyPublic)
+	claims.Locale = "funky-BUSINESS"
+
+	// When
+	result, err := t.unitUnderTest.SignUserJWT(t.ctx, accountRef, claims)
+
+	// Then
+	t.Nil(result)
+	t.ErrorContains(err, "claims validation failed during user JWT signing: [could not parse iana time zone by name")
 }
 
 /* ****************************************************

--- a/internal/account/approvals/claims_test.TestClaims.exports.input.yaml
+++ b/internal/account/approvals/claims_test.TestClaims.exports.input.yaml
@@ -26,6 +26,6 @@ exports:
     serviceLatency:
       sampling: 25
       results: "metrics.latency.results"
-    accountTokenPosition: 1234
+    accountTokenPosition: 2
     advertise: true
     allowTrace: true

--- a/internal/account/approvals/claims_test.TestClaims.exports.output.nats.approved.json
+++ b/internal/account/approvals/claims_test.TestClaims.exports.output.nats.approved.json
@@ -16,7 +16,7 @@
         "type": "stream"
       },
       {
-        "account_token_position": 1234,
+        "account_token_position": 2,
         "advertise": true,
         "allow_trace": true,
         "name": "my-complex",

--- a/internal/account/approvals/claims_test.TestClaims.exports.output.nauth.approved.yaml
+++ b/internal/account/approvals/claims_test.TestClaims.exports.output.nauth.approved.yaml
@@ -9,7 +9,7 @@ exports:
 - name: my-stream
   subject: events.>
   type: stream
-- accountTokenPosition: 1234
+- accountTokenPosition: 2
   advertise: true
   allowTrace: true
   name: my-complex

--- a/internal/account/approvals/claims_test.TestClaims.imports-multi-js-fc.input.yaml
+++ b/internal/account/approvals/claims_test.TestClaims.imports-multi-js-fc.input.yaml
@@ -1,0 +1,13 @@
+imports:
+  - name: account-a-fc
+    accountRef:
+      namespace: my-namespace
+      name: account-a
+    subject: $JS.FC.>
+    type: service
+  - name: account-b-fc
+    accountRef:
+      namespace: my-namespace
+      name: account-b
+    subject: $JS.FC.>
+    type: service

--- a/internal/account/approvals/claims_test.TestClaims.imports-multi-js-fc.output.nats.approved.json
+++ b/internal/account/approvals/claims_test.TestClaims.imports-multi-js-fc.output.nats.approved.json
@@ -1,0 +1,51 @@
+{
+  "iat": 1700000000,
+  "iss": "OD32J3IJ3TNSPNAG2MHKB7F77ETVXGUBYMGXQ2ONNJCKPM5RXO7XWTFD",
+  "jti": "TEST-JWT-ID-STATIC-FOR-APPROVAL-TESTS",
+  "name": "test-namespace/test-account",
+  "nats": {
+    "authorization": {},
+    "default_permissions": {
+      "pub": {},
+      "sub": {}
+    },
+    "imports": [
+      {
+        "account": "A000000000000000000000000000000000000ACCOUNTAMYNAMESPACE",
+        "name": "account-a-fc",
+        "subject": "$JS.FC.\u003e",
+        "type": "service"
+      },
+      {
+        "account": "A000000000000000000000000000000000000ACCOUNTBMYNAMESPACE",
+        "name": "account-b-fc",
+        "subject": "$JS.FC.\u003e",
+        "type": "service"
+      }
+    ],
+    "limits": {
+      "conn": -1,
+      "consumer": -1,
+      "data": -1,
+      "disk_max_stream_bytes": -1,
+      "disk_storage": -1,
+      "exports": -1,
+      "imports": -1,
+      "leaf": -1,
+      "max_ack_pending": -1,
+      "mem_max_stream_bytes": -1,
+      "mem_storage": -1,
+      "payload": -1,
+      "streams": -1,
+      "subs": -1,
+      "wildcards": true
+    },
+    "signing_keys": [
+      "ACI73NE4LXWVHSYSFXY73WTZVKIKE54PQUMRDYA4EUFYFGEGHKTPCOI4",
+      "ADCECGT44IBBMSNGOEZTVK2QUQSVTJW6FABW7JBFFTITDBHMP6TXM4XG"
+    ],
+    "type": "account",
+    "version": 2
+  },
+  "sub": "AAJCK7774DXTQZAFJLSQIVU76UHGXFZNJVWMT4F7PNRBCYM75LS75UYE"
+}

--- a/internal/account/approvals/claims_test.TestClaims.imports-multi-js-fc.output.nauth.approved.yaml
+++ b/internal/account/approvals/claims_test.TestClaims.imports-multi-js-fc.output.nauth.approved.yaml
@@ -1,0 +1,37 @@
+accountLimits:
+  conn: -1
+  exports: -1
+  imports: -1
+  leaf: -1
+  wildcards: true
+displayName: test-namespace/test-account
+imports:
+- account: A000000000000000000000000000000000000ACCOUNTAMYNAMESPACE
+  accountRef:
+    name: ""
+    namespace: ""
+  name: account-a-fc
+  subject: $JS.FC.>
+  type: service
+- account: A000000000000000000000000000000000000ACCOUNTBMYNAMESPACE
+  accountRef:
+    name: ""
+    namespace: ""
+  name: account-b-fc
+  subject: $JS.FC.>
+  type: service
+jetStreamLimits:
+  consumer: -1
+  diskMaxStreamBytes: -1
+  diskStorage: -1
+  maxAckPending: -1
+  memMaxStreamBytes: -1
+  memStorage: -1
+  streams: -1
+natsLimits:
+  data: -1
+  payload: -1
+  subs: -1
+signingKeys:
+- key: ACI73NE4LXWVHSYSFXY73WTZVKIKE54PQUMRDYA4EUFYFGEGHKTPCOI4
+- key: ADCECGT44IBBMSNGOEZTVK2QUQSVTJW6FABW7JBFFTITDBHMP6TXM4XG

--- a/internal/account/claims.go
+++ b/internal/account/claims.go
@@ -186,12 +186,6 @@ func newClaimsBuilder(
 			}
 		}
 		claim.Imports = imports
-
-		err := validateImports(imports)
-		if err != nil {
-			errs = append(errs, err)
-			claim.Imports = nil
-		}
 	}
 
 	return &claimsBuilder{
@@ -203,24 +197,6 @@ func newClaimsBuilder(
 func (b *claimsBuilder) signingKey(signingKey string) *claimsBuilder {
 	b.claim.SigningKeys.Add(signingKey)
 	return b
-}
-
-func validateImports(imports jwt.Imports) error {
-	seenSubjects := make(map[string]bool, len(imports))
-
-	for _, importClaim := range imports {
-		subject := string(importClaim.Subject)
-		if importClaim.LocalSubject != "" {
-			subject = string(importClaim.LocalSubject)
-		}
-
-		if seenSubjects[subject] {
-			return fmt.Errorf("conflicting import subject found: %s", subject)
-		}
-		seenSubjects[subject] = true
-	}
-
-	return nil
 }
 
 func (b *claimsBuilder) build() (*jwt.AccountClaims, error) {

--- a/internal/account/claims_test.go
+++ b/internal/account/claims_test.go
@@ -68,7 +68,7 @@ func TestClaims(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, natsClaims)
 			// Ensure that the NATS JWT can be encoded
-			natsJwt, err := natsClaims.Encode(opSigningKey)
+			natsJwt, err := signAccountJWT(natsClaims, opSigningKey)
 			require.NoError(t, err)
 			require.NotEmpty(t, natsJwt)
 


### PR DESCRIPTION
Instead of doing our own minimalistic claims validation we should rely on the existing validation mechanism provided by the nats-io jwt lib.

Bump nats-io/jwt/v2 to v2.8.1 ensure multi-import of same service from different accounts (applicable in e.g. JetStream Flow Control case (`$JS.FC.>`). Verify using local test.

Closes: #165
