### PR TITLE
chore(workflows): bump github-script to v8 in issue-triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,7 +15,7 @@ jobs:
         if: >
           github.event.issue.author_association != 'OWNER' &&
           github.event.issue.author_association != 'MEMBER'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const label = "status/triage";


### PR DESCRIPTION
Github workflows shows a warning when running v7 of the github-script. Bumping to v8.

`[add-triage-label](https://github.com/WirelessCar/nauth/actions/runs/23245088060/job/67571287681#step:3:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@v7. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`

Signed-off-by: Henri Ropponen <henriropponen@gmail.com>
