### PR TITLE
refactor: move nats domain structs to `domain` package

### DIFF
--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/WirelessCar/nauth/internal/controller"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/mock"
@@ -23,7 +22,7 @@ type ManagerTestSuite struct {
 
 	opSignKey       nkeys.KeyPair
 	opSignKeyPublic string
-	sauCreds        ports.NatsUserCreds
+	sauCreds        domain.NatsUserCreds
 	natsURL         string
 	clusterTarget   clusterTarget
 
@@ -41,7 +40,7 @@ func (t *ManagerTestSuite) SetupTest() {
 
 	t.opSignKey, _ = nkeys.CreateOperator()
 	t.opSignKeyPublic, _ = t.opSignKey.PublicKey()
-	t.sauCreds = ports.NatsUserCreds{
+	t.sauCreds = domain.NatsUserCreds{
 		Creds:     []byte("FAKE_CREDENTIALS"),
 		AccountID: "FAKE_SYS_ACCOUNT_ID",
 	}

--- a/internal/account/cluster.go
+++ b/internal/account/cluster.go
@@ -13,8 +13,8 @@ import (
 
 type clusterTarget struct {
 	NatsURL            string
-	SystemAdminCreds   ports.NatsUserCreds
-	OperatorSigningKey ports.NatsOperatorSigningKey
+	SystemAdminCreds   domain.NatsUserCreds
+	OperatorSigningKey domain.NatsOperatorSigningKey
 }
 
 func (c *clusterTarget) validate() error {
@@ -30,7 +30,7 @@ func (c *clusterTarget) validate() error {
 	return nil
 }
 
-func newClusterTarget(natsURL string, systemAdminCreds ports.NatsUserCreds, operatorSigningKey ports.NatsOperatorSigningKey) (*clusterTarget, error) {
+func newClusterTarget(natsURL string, systemAdminCreds domain.NatsUserCreds, operatorSigningKey domain.NatsOperatorSigningKey) (*clusterTarget, error) {
 	result := &clusterTarget{
 		NatsURL:            natsURL,
 		SystemAdminCreds:   systemAdminCreds,
@@ -179,14 +179,14 @@ func (r *clusterTargetResolverImpl) resolveTargetFromImplicitLookup(ctx context.
 	return target, nil
 }
 
-func (r *clusterTargetResolverImpl) resolveSysAdminCreds(ctx context.Context, cluster *v1alpha1.NatsCluster) (*ports.NatsUserCreds, error) {
+func (r *clusterTargetResolverImpl) resolveSysAdminCreds(ctx context.Context, cluster *v1alpha1.NatsCluster) (*domain.NatsUserCreds, error) {
 	secretKeyRef := cluster.Spec.SystemAccountUserCredsSecretRef
 	secretRef := domain.NewNamespacedName(cluster.GetNamespace(), secretKeyRef.Name)
 	creds, err := r.resolveSecret(ctx, secretRef, secretKeyRef.Key)
 	if err != nil {
 		return nil, fmt.Errorf("resolve system account user creds for secret %s/%s: %w", cluster.GetNamespace(), secretRef.Name, err)
 	}
-	userCreds, err := ports.NewNatsUserCreds(creds)
+	userCreds, err := domain.NewNatsUserCreds(creds)
 	if err != nil {
 		return nil, fmt.Errorf("invalid system account user creds in secret %s/%s: %w", cluster.GetNamespace(), secretRef.Name, err)
 	}
@@ -194,7 +194,7 @@ func (r *clusterTargetResolverImpl) resolveSysAdminCreds(ctx context.Context, cl
 }
 
 // Deprecated: This method relies on legacy patterns and will sunset in a future release.
-func (r *clusterTargetResolverImpl) resolveSysAdminCredsViaLabels(ctx context.Context, namespace domain.Namespace) (*ports.NatsUserCreds, error) {
+func (r *clusterTargetResolverImpl) resolveSysAdminCredsViaLabels(ctx context.Context, namespace domain.Namespace) (*domain.NatsUserCreds, error) {
 	labels := map[string]string{
 		k8s.LabelSecretType: k8s.SecretTypeSystemAccountUserCreds,
 	}
@@ -203,14 +203,14 @@ func (r *clusterTargetResolverImpl) resolveSysAdminCredsViaLabels(ctx context.Co
 		return nil, fmt.Errorf("resolve system account user creds via labels in namespace %s: %w", namespace, err)
 	}
 
-	userCreds, err := ports.NewNatsUserCreds(creds)
+	userCreds, err := domain.NewNatsUserCreds(creds)
 	if err != nil {
 		return nil, fmt.Errorf("invalid system account user creds found via labels in namespace %s: %w", namespace, err)
 	}
 	return userCreds, nil
 }
 
-func (r *clusterTargetResolverImpl) resolveOperatorSigningKey(ctx context.Context, cluster *v1alpha1.NatsCluster) (ports.NatsOperatorSigningKey, error) {
+func (r *clusterTargetResolverImpl) resolveOperatorSigningKey(ctx context.Context, cluster *v1alpha1.NatsCluster) (domain.NatsOperatorSigningKey, error) {
 	secretKeyRef := cluster.Spec.OperatorSigningKeySecretRef
 	secretRef := domain.NewNamespacedName(cluster.GetNamespace(), secretKeyRef.Name)
 	keyData, err := r.resolveSecret(ctx, secretRef, secretKeyRef.Key)
@@ -225,7 +225,7 @@ func (r *clusterTargetResolverImpl) resolveOperatorSigningKey(ctx context.Contex
 }
 
 // Deprecated: This method relies on legacy patterns and will sunset in a future release.
-func (r *clusterTargetResolverImpl) resolveOperatorSigningKeyViaLabels(ctx context.Context, namespace domain.Namespace) (ports.NatsOperatorSigningKey, error) {
+func (r *clusterTargetResolverImpl) resolveOperatorSigningKeyViaLabels(ctx context.Context, namespace domain.Namespace) (domain.NatsOperatorSigningKey, error) {
 	labels := map[string]string{k8s.LabelSecretType: k8s.SecretTypeOperatorSign}
 	seed, err := r.resolveSecretByLabels(ctx, namespace, labels)
 	if err != nil {

--- a/internal/account/cluster_test.go
+++ b/internal/account/cluster_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/require"
@@ -507,7 +506,7 @@ func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *v1alpha1.NatsClusterRe
 	return u
 }
 
-func (t *ClusterTestSuite) generateSecrets() (ports.NatsOperatorSigningKey, ports.NatsUserCreds) {
+func (t *ClusterTestSuite) generateSecrets() (domain.NatsOperatorSigningKey, domain.NatsUserCreds) {
 	opSign, _ := nkeys.CreateOperator()
 
 	acKey, _ := nkeys.CreateAccount()
@@ -528,7 +527,7 @@ func (t *ClusterTestSuite) generateSecrets() (ports.NatsOperatorSigningKey, port
 	if err != nil {
 		t.Failf("failed to format SAU creds", "error: %v", err)
 	}
-	sauNatsUserCreds, err := ports.NewNatsUserCreds(sauCreds)
+	sauNatsUserCreds, err := domain.NewNatsUserCreds(sauCreds)
 	if err != nil {
 		t.Failf("failed to create NatsUserCreds from SAU creds", "error: %v", err)
 	}

--- a/internal/account/mocks_test.go
+++ b/internal/account/mocks_test.go
@@ -147,12 +147,12 @@ type NatsClientMock struct {
 	mock.Mock
 }
 
-func (n *NatsClientMock) Connect(natsURL string, userCreds ports.NatsUserCreds) (ports.NatsConnection, error) {
+func (n *NatsClientMock) Connect(natsURL string, userCreds domain.NatsUserCreds) (ports.NatsConnection, error) {
 	args := n.Called(natsURL, userCreds)
 	return args.Get(0).(ports.NatsConnection), args.Error(1)
 }
 
-func (n *NatsClientMock) mockConnect(natsURL string, userCreds ports.NatsUserCreds, result ports.NatsConnection) {
+func (n *NatsClientMock) mockConnect(natsURL string, userCreds domain.NatsUserCreds, result ports.NatsConnection) {
 	n.On("Connect", natsURL, userCreds).Return(result, nil)
 }
 

--- a/internal/domain/nats.go
+++ b/internal/domain/nats.go
@@ -1,0 +1,57 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/nats-io/jwt/v2"
+	"github.com/nats-io/nkeys"
+)
+
+type NatsOperatorSigningKey nkeys.KeyPair
+
+type NatsUserCreds struct {
+	Creds     []byte
+	AccountID string
+}
+
+func NewNatsUserCreds(creds []byte) (*NatsUserCreds, error) {
+	if len(creds) == 0 {
+		return nil, fmt.Errorf("NATS User Credentials cannot be empty")
+	}
+
+	userJWT, err := jwt.ParseDecoratedJWT(creds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user credentials JWT: %w", err)
+	}
+
+	userClaims, err := jwt.DecodeUserClaims(userJWT)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode user claims from JWT: %w", err)
+	}
+
+	accountID := userClaims.IssuerAccount
+	if accountID == "" {
+		return nil, fmt.Errorf("user credentials JWT does not contain an issuer account ID")
+	}
+
+	n := &NatsUserCreds{
+		Creds:     creds,
+		AccountID: accountID,
+	}
+
+	if err := n.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid NATS user credentials: %w", err)
+	}
+
+	return n, nil
+}
+
+func (n *NatsUserCreds) Validate() error {
+	if len(n.Creds) == 0 {
+		return fmt.Errorf("credentials cannot be empty")
+	}
+	if n.AccountID == "" {
+		return fmt.Errorf("user credentials must include an account ID")
+	}
+	return nil
+}

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/ports"
 	"github.com/nats-io/nats.go"
 )
@@ -35,7 +36,7 @@ func NewClient() *Client {
 	return &Client{}
 }
 
-func (n *Client) Connect(natsURL string, userCreds ports.NatsUserCreds) (ports.NatsConnection, error) {
+func (n *Client) Connect(natsURL string, userCreds domain.NatsUserCreds) (ports.NatsConnection, error) {
 	if natsURL == "" {
 		return nil, fmt.Errorf("NATS URL is required")
 	}
@@ -57,7 +58,7 @@ func (n *Client) Connect(natsURL string, userCreds ports.NatsUserCreds) (ports.N
 
 type Connection struct {
 	natsURL   string
-	userCreds ports.NatsUserCreds
+	userCreds domain.NatsUserCreds
 	conn      *nats.Conn
 }
 

--- a/internal/ports/nats.go
+++ b/internal/ports/nats.go
@@ -1,63 +1,11 @@
 package ports
 
 import (
-	"fmt"
-
-	"github.com/nats-io/jwt/v2"
-	"github.com/nats-io/nkeys"
+	"github.com/WirelessCar/nauth/internal/domain"
 )
 
-type NatsOperatorSigningKey nkeys.KeyPair
-
-type NatsUserCreds struct {
-	Creds     []byte
-	AccountID string
-}
-
-func NewNatsUserCreds(creds []byte) (*NatsUserCreds, error) {
-	if len(creds) == 0 {
-		return nil, fmt.Errorf("NATS User Credentials cannot be empty")
-	}
-
-	userJWT, err := jwt.ParseDecoratedJWT(creds)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse user credentials JWT: %w", err)
-	}
-
-	userClaims, err := jwt.DecodeUserClaims(userJWT)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode user claims from JWT: %w", err)
-	}
-
-	accountID := userClaims.IssuerAccount
-	if accountID == "" {
-		return nil, fmt.Errorf("user credentials JWT does not contain an issuer account ID")
-	}
-
-	n := &NatsUserCreds{
-		Creds:     creds,
-		AccountID: accountID,
-	}
-
-	if err := n.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid NATS user credentials: %w", err)
-	}
-
-	return n, nil
-}
-
-func (n *NatsUserCreds) Validate() error {
-	if len(n.Creds) == 0 {
-		return fmt.Errorf("credentials cannot be empty")
-	}
-	if n.AccountID == "" {
-		return fmt.Errorf("user credentials must include an account ID")
-	}
-	return nil
-}
-
 type NatsClient interface {
-	Connect(natsURL string, userCreds NatsUserCreds) (NatsConnection, error)
+	Connect(natsURL string, userCreds domain.NatsUserCreds) (NatsConnection, error)
 }
 
 type NatsConnection interface {


### PR DESCRIPTION
To prepare for `NatsCluster` reconciliation  we should extract the cluster specific code out from `account` package so that it may be re-used by other controllers/managers. This is a prep for this refactoring.
