### PR TITLE
refactor: make NatsClusterTarget part of the domain

### DIFF
--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -399,7 +399,7 @@ func (a *Manager) SignUserJWT(ctx context.Context, accountRef domain.NamespacedN
 	}, nil
 }
 
-func (a *Manager) resolveClusterTarget(ctx context.Context, account *v1alpha1.Account) (*clusterTarget, error) {
+func (a *Manager) resolveClusterTarget(ctx context.Context, account *v1alpha1.Account) (*domain.NatsClusterTarget, error) {
 	natsClusterRef := account.Spec.NatsClusterRef
 	if natsClusterRef != nil && natsClusterRef.Namespace == "" {
 		natsClusterRef = natsClusterRef.DeepCopy()

--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -24,7 +24,7 @@ type ManagerTestSuite struct {
 	opSignKeyPublic string
 	sauCreds        domain.NatsUserCreds
 	natsURL         string
-	clusterTarget   clusterTarget
+	clusterTarget   domain.NatsClusterTarget
 
 	accountReaderMock         *AccountReaderMock
 	natsClientMock            *NatsClientMock
@@ -45,7 +45,7 @@ func (t *ManagerTestSuite) SetupTest() {
 		AccountID: "FAKE_SYS_ACCOUNT_ID",
 	}
 	t.natsURL = "nats://nats:4222"
-	t.clusterTarget = clusterTarget{
+	t.clusterTarget = domain.NatsClusterTarget{
 		NatsURL:            t.natsURL,
 		OperatorSigningKey: t.opSignKey,
 		SystemAdminCreds:   t.sauCreds,
@@ -558,17 +558,17 @@ func newClusterTargetResolverMock() *clusterTargetResolverMock {
 	return &clusterTargetResolverMock{}
 }
 
-func (m *clusterTargetResolverMock) GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*clusterTarget, error) {
+func (m *clusterTargetResolverMock) GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*domain.NatsClusterTarget, error) {
 	args := m.Called(ctx, accountClusterRef)
-	return args.Get(0).(*clusterTarget), args.Error(1)
+	return args.Get(0).(*domain.NatsClusterTarget), args.Error(1)
 }
 
-func (m *clusterTargetResolverMock) mockGetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef, result *clusterTarget) {
+func (m *clusterTargetResolverMock) mockGetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef, result *domain.NatsClusterTarget) {
 	m.On("GetClusterTarget", ctx, accountClusterRef).Return(result, nil)
 }
 
 func (m *clusterTargetResolverMock) mockGetClusterTargetError(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef, err error) {
-	m.On("GetClusterTarget", ctx, accountClusterRef).Return((*clusterTarget)(nil), err)
+	m.On("GetClusterTarget", ctx, accountClusterRef).Return((*domain.NatsClusterTarget)(nil), err)
 }
 
 var _ clusterTargetResolver = (*clusterTargetResolverMock)(nil)

--- a/internal/account/cluster.go
+++ b/internal/account/cluster.go
@@ -11,41 +11,8 @@ import (
 	"github.com/nats-io/nkeys"
 )
 
-type clusterTarget struct {
-	NatsURL            string
-	SystemAdminCreds   domain.NatsUserCreds
-	OperatorSigningKey domain.NatsOperatorSigningKey
-}
-
-func (c *clusterTarget) validate() error {
-	if c.NatsURL == "" {
-		return fmt.Errorf("NATS URL is required")
-	}
-	if err := c.SystemAdminCreds.Validate(); err != nil {
-		return fmt.Errorf("invalid system admin credentials: %w", err)
-	}
-	if c.OperatorSigningKey == nil {
-		return fmt.Errorf("operator signing key is required")
-	}
-	return nil
-}
-
-func newClusterTarget(natsURL string, systemAdminCreds domain.NatsUserCreds, operatorSigningKey domain.NatsOperatorSigningKey) (*clusterTarget, error) {
-	result := &clusterTarget{
-		NatsURL:            natsURL,
-		SystemAdminCreds:   systemAdminCreds,
-		OperatorSigningKey: operatorSigningKey,
-	}
-
-	if err := result.validate(); err != nil {
-		return nil, fmt.Errorf("invalid clusterTarget: %w", err)
-	}
-
-	return result, nil
-}
-
 type clusterTargetResolver interface {
-	GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*clusterTarget, error)
+	GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*domain.NatsClusterTarget, error)
 }
 
 type clusterTargetResolverImpl struct {
@@ -102,8 +69,8 @@ func (r *clusterTargetResolverImpl) validate() error {
 	return nil
 }
 
-func (r *clusterTargetResolverImpl) GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*clusterTarget, error) {
-	var result *clusterTarget
+func (r *clusterTargetResolverImpl) GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*domain.NatsClusterTarget, error) {
+	var result *domain.NatsClusterTarget
 	var err error
 	if accountClusterRef != nil {
 		acClusterRef := domain.NewNamespacedName(accountClusterRef.Namespace, accountClusterRef.Name)
@@ -123,13 +90,13 @@ func (r *clusterTargetResolverImpl) GetClusterTarget(ctx context.Context, accoun
 	if err != nil {
 		return nil, fmt.Errorf("resolve cluster target: %w", err)
 	}
-	if err = result.validate(); err != nil {
+	if err = result.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid cluster target: %w", err)
 	}
 	return result, nil
 }
 
-func (r *clusterTargetResolverImpl) resolveTarget(ctx context.Context, clusterRef domain.NamespacedName) (*clusterTarget, error) {
+func (r *clusterTargetResolverImpl) resolveTarget(ctx context.Context, clusterRef domain.NamespacedName) (*domain.NatsClusterTarget, error) {
 	cluster, err := r.natsClusterReader.Get(ctx, clusterRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve NATS cluster %s: %w", clusterRef, err)
@@ -146,7 +113,7 @@ func (r *clusterTargetResolverImpl) resolveTarget(ctx context.Context, clusterRe
 	if err != nil {
 		return nil, fmt.Errorf("resolve operator signing key for NatsCluster %s: %w", clusterRef, err)
 	}
-	target, err := newClusterTarget(natsURL, *sysAdminCreds, opSigningKey)
+	target, err := domain.NewNatsClusterTarget(natsURL, *sysAdminCreds, opSigningKey)
 	if err != nil {
 		return nil, fmt.Errorf("create cluster target for NatsCluster %s: %w", clusterRef, err)
 	}
@@ -156,7 +123,7 @@ func (r *clusterTargetResolverImpl) resolveTarget(ctx context.Context, clusterRe
 // resolveTargetFromImplicitLookup performs a best-effort resolution of cluster connection details based on the presence
 // of a default NATS URL and labeled secrets in the operator namespace.
 // Deprecated: This method relies on legacy patterns and will sunset in a future release.
-func (r *clusterTargetResolverImpl) resolveTargetFromImplicitLookup(ctx context.Context) (*clusterTarget, error) {
+func (r *clusterTargetResolverImpl) resolveTargetFromImplicitLookup(ctx context.Context) (*domain.NatsClusterTarget, error) {
 	// TODO: [#102][#144] Sunset label-based secret lookup.
 	if r.config.DefaultNatsURL == "" {
 		return nil, fmt.Errorf("default NATS URL is not configured for implicit cluster lookup")
@@ -172,7 +139,7 @@ func (r *clusterTargetResolverImpl) resolveTargetFromImplicitLookup(ctx context.
 	if err != nil {
 		return nil, fmt.Errorf("resolve operator signing key via labels: %w", err)
 	}
-	target, err := newClusterTarget(r.config.DefaultNatsURL, *sysAdminCreds, opSigningKey)
+	target, err := domain.NewNatsClusterTarget(r.config.DefaultNatsURL, *sysAdminCreds, opSigningKey)
 	if err != nil {
 		return nil, fmt.Errorf("create cluster target from implicit lookup: %w", err)
 	}

--- a/internal/account/cluster_test.go
+++ b/internal/account/cluster_test.go
@@ -57,7 +57,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenLegacyImplici
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
+	require.Equal(t.T(), &domain.NatsClusterTarget{
 		NatsURL:            "nats://nats:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,
@@ -97,7 +97,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenOperatorClust
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
+	require.Equal(t.T(), &domain.NatsClusterTarget{
 		NatsURL:            "nats://my-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,
@@ -137,7 +137,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
+	require.Equal(t.T(), &domain.NatsClusterTarget{
 		NatsURL:            "nats://ac-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,
@@ -177,7 +177,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
+	require.Equal(t.T(), &domain.NatsClusterTarget{
 		NatsURL:            "nats://my-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,
@@ -221,7 +221,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
+	require.Equal(t.T(), &domain.NatsClusterTarget{
 		NatsURL:            "nats://ac-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,

--- a/internal/domain/nats.go
+++ b/internal/domain/nats.go
@@ -55,3 +55,36 @@ func (n *NatsUserCreds) Validate() error {
 	}
 	return nil
 }
+
+type NatsClusterTarget struct {
+	NatsURL            string
+	SystemAdminCreds   NatsUserCreds
+	OperatorSigningKey NatsOperatorSigningKey
+}
+
+func (c *NatsClusterTarget) Validate() error {
+	if c.NatsURL == "" {
+		return fmt.Errorf("NATS URL is required")
+	}
+	if err := c.SystemAdminCreds.Validate(); err != nil {
+		return fmt.Errorf("invalid system admin credentials: %w", err)
+	}
+	if c.OperatorSigningKey == nil {
+		return fmt.Errorf("operator signing key is required")
+	}
+	return nil
+}
+
+func NewNatsClusterTarget(natsURL string, systemAdminCreds NatsUserCreds, operatorSigningKey NatsOperatorSigningKey) (*NatsClusterTarget, error) {
+	result := &NatsClusterTarget{
+		NatsURL:            natsURL,
+		SystemAdminCreds:   systemAdminCreds,
+		OperatorSigningKey: operatorSigningKey,
+	}
+
+	if err := result.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid NatsClusterTarget: %w", err)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
To be able to extract the cluster resolvement/management from the core `account` package we need to make the interface related structs part of the domain.

