### PR TITLE
refactor: move outbound ports into internal/ports/outbound

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -8,25 +8,25 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 )
 
 type AccountManager struct {
-	natsClient            ports.NatsClient
-	accountReader         ports.AccountReader
+	natsClient            outbound.NatsClient
+	accountReader         outbound.AccountReader
 	clusterTargetResolver clusterTargetResolver
 	secretManager         secretManager
 }
 
 func NewAccountManager(
-	natsClient ports.NatsClient,
-	accountReader ports.AccountReader,
-	natsClusterReader ports.NatsClusterReader,
-	secretClient ports.SecretClient,
-	configMapReader ports.ConfigMapReader,
+	natsClient outbound.NatsClient,
+	accountReader outbound.AccountReader,
+	natsClusterReader outbound.NatsClusterReader,
+	secretClient outbound.SecretClient,
+	configMapReader outbound.ConfigMapReader,
 	config *Config,
 ) (*AccountManager, error) {
 	ccr, err := newClusterTargetResolverImpl(natsClusterReader, secretClient, configMapReader, config)
@@ -41,8 +41,8 @@ func NewAccountManager(
 }
 
 func newAccountManager(
-	natsClient ports.NatsClient,
-	accountReader ports.AccountReader,
+	natsClient outbound.NatsClient,
+	accountReader outbound.AccountReader,
 	clusterTargetResolver clusterTargetResolver,
 	secretManager secretManager,
 ) (*AccountManager, error) {

--- a/internal/core/accountClaims.go
+++ b/internal/core/accountClaims.go
@@ -9,7 +9,7 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
 )
 
@@ -23,7 +23,7 @@ func newAccountClaimsBuilder(
 	displayName string,
 	spec v1alpha1.AccountSpec,
 	accountPublicKey string,
-	accountReader ports.AccountReader,
+	accountReader outbound.AccountReader,
 ) *accountClaimsBuilder {
 	claim := jwt.NewAccountClaims(accountPublicKey)
 	claim.Name = displayName

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -7,7 +7,7 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/nkeys"
 )
 
@@ -49,16 +49,16 @@ type clusterTargetResolver interface {
 }
 
 type clusterTargetResolverImpl struct {
-	natsClusterReader ports.NatsClusterReader
-	secretReader      ports.SecretReader
-	configMapReader   ports.ConfigMapReader
+	natsClusterReader outbound.NatsClusterReader
+	secretReader      outbound.SecretReader
+	configMapReader   outbound.ConfigMapReader
 	config            *Config
 }
 
 func newClusterTargetResolverImpl(
-	natsClusterReader ports.NatsClusterReader,
-	secretReader ports.SecretReader,
-	configMapReader ports.ConfigMapReader,
+	natsClusterReader outbound.NatsClusterReader,
+	secretReader outbound.SecretReader,
+	configMapReader outbound.ConfigMapReader,
 	config *Config,
 ) (*clusterTargetResolverImpl, error) {
 	if config == nil {

--- a/internal/core/mocks_test.go
+++ b/internal/core/mocks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
@@ -150,7 +150,7 @@ func (s *SecretClientMock) mockLabelError(namespacedName domain.NamespacedName, 
 	s.On("Label", mock.Anything, namespacedName, labels).Return(err)
 }
 
-var _ ports.SecretClient = (*SecretClientMock)(nil)
+var _ outbound.SecretClient = (*SecretClientMock)(nil)
 
 /* ****************************************************
 * User JWT Signer
@@ -191,16 +191,16 @@ type NatsClientMock struct {
 	mock.Mock
 }
 
-func (n *NatsClientMock) Connect(natsURL string, userCreds domain.NatsUserCreds) (ports.NatsConnection, error) {
+func (n *NatsClientMock) Connect(natsURL string, userCreds domain.NatsUserCreds) (outbound.NatsConnection, error) {
 	args := n.Called(natsURL, userCreds)
-	return args.Get(0).(ports.NatsConnection), args.Error(1)
+	return args.Get(0).(outbound.NatsConnection), args.Error(1)
 }
 
-func (n *NatsClientMock) mockConnect(natsURL string, userCreds domain.NatsUserCreds, result ports.NatsConnection) {
+func (n *NatsClientMock) mockConnect(natsURL string, userCreds domain.NatsUserCreds, result outbound.NatsConnection) {
 	n.On("Connect", natsURL, userCreds).Return(result, nil)
 }
 
-var _ ports.NatsClient = (*NatsClientMock)(nil)
+var _ outbound.NatsClient = (*NatsClientMock)(nil)
 
 func NewNatsConnectionMock() *NatsConnectionMock {
 	return &NatsConnectionMock{}
@@ -265,10 +265,10 @@ func (n *NatsConnectionMock) mockDeleteAccountJWTCatch(catch func(jwt string)) {
 		})
 }
 
-var _ ports.NatsConnection = (*NatsConnectionMock)(nil)
+var _ outbound.NatsConnection = (*NatsConnectionMock)(nil)
 
 /* ****************************************************
-* ports.AccountReader Resolver
+* outbound.AccountReader Resolver
 *****************************************************/
 
 type AccountReaderMock struct {
@@ -296,7 +296,7 @@ func (a *AccountReaderMock) mockGetCallback(ctx interface{}, accountRef interfac
 	return call
 }
 
-var _ ports.AccountReader = &AccountReaderMock{}
+var _ outbound.AccountReader = &AccountReaderMock{}
 
 /* ****************************************************
 * NatsCluster Resolver
@@ -325,10 +325,10 @@ func (m *NatsClusterReaderMock) mockGetNatsClusterError(ctx context.Context, clu
 	m.On("Get", ctx, clusterRef).Return(nil, err)
 }
 
-var _ ports.NatsClusterReader = (*NatsClusterReaderMock)(nil)
+var _ outbound.NatsClusterReader = (*NatsClusterReaderMock)(nil)
 
 /* ****************************************************
-* ports.ConfigMapReader Mock
+* outbound.ConfigMapReader Mock
 *****************************************************/
 type ConfigMapReaderMock struct {
 	mock.Mock
@@ -347,4 +347,4 @@ func (m *ConfigMapReaderMock) mockGet(ctx context.Context, namespacedName domain
 	m.On("Get", ctx, namespacedName).Return(result, nil)
 }
 
-var _ ports.ConfigMapReader = (*ConfigMapReaderMock)(nil)
+var _ outbound.ConfigMapReader = (*ConfigMapReaderMock)(nil)

--- a/internal/core/secret.go
+++ b/internal/core/secret.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/nkeys"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,10 +31,10 @@ type secretManager interface {
 }
 
 type secretManagerImpl struct {
-	secretClient ports.SecretClient
+	secretClient outbound.SecretClient
 }
 
-func newSecretManagerImpl(secretClient ports.SecretClient) (*secretManagerImpl, error) {
+func newSecretManagerImpl(secretClient outbound.SecretClient) (*secretManagerImpl, error) {
 	if secretClient == nil {
 		return nil, fmt.Errorf("secret client is required")
 	}

--- a/internal/core/user.go
+++ b/internal/core/user.go
@@ -7,8 +7,8 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,10 +27,10 @@ type UserJWTSigner interface {
 
 type UserManager struct {
 	userJWTSigner UserJWTSigner
-	secretClient  ports.SecretClient
+	secretClient  outbound.SecretClient
 }
 
-func NewUserManager(userJWTSigner UserJWTSigner, secretClient ports.SecretClient) *UserManager {
+func NewUserManager(userJWTSigner UserJWTSigner, secretClient outbound.SecretClient) *UserManager {
 	return &UserManager{
 		userJWTSigner: userJWTSigner,
 		secretClient:  secretClient,

--- a/internal/k8s/account.go
+++ b/internal/k8s/account.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -53,4 +53,4 @@ func isReady(account *v1alpha1.Account) bool {
 }
 
 // Compile-time assertion that implementation satisfies the ports interface
-var _ ports.AccountReader = (*AccountClient)(nil)
+var _ outbound.AccountReader = (*AccountClient)(nil)

--- a/internal/k8s/cluster.go
+++ b/internal/k8s/cluster.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,4 +34,4 @@ func (c *NatsClusterClient) Get(ctx context.Context, clusterRef domain.Namespace
 }
 
 // Compile-time assertion that implementation satisfies the ports interface
-var _ ports.NatsClusterReader = (*NatsClusterClient)(nil)
+var _ outbound.NatsClusterReader = (*NatsClusterClient)(nil)

--- a/internal/k8s/configmap/configmap.go
+++ b/internal/k8s/configmap/configmap.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,4 +63,4 @@ func (c *Client) Get(ctx context.Context, configMapRef domain.NamespacedName) (m
 }
 
 // Compile-time assertion that implementation satisfies the ports interface
-var _ ports.ConfigMapReader = (*Client)(nil)
+var _ outbound.ConfigMapReader = (*Client)(nil)

--- a/internal/k8s/secret/secret.go
+++ b/internal/k8s/secret/secret.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/k8s"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -210,4 +210,4 @@ func isManagedSecret(meta *metav1.ObjectMeta) bool {
 }
 
 // Compile-time assertion that implementation satisfies the ports interface
-var _ ports.SecretClient = (*Client)(nil)
+var _ outbound.SecretClient = (*Client)(nil)

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/WirelessCar/nauth/internal/domain"
-	"github.com/WirelessCar/nauth/internal/ports"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/nats.go"
 )
 
@@ -36,7 +36,7 @@ func NewClient() *Client {
 	return &Client{}
 }
 
-func (n *Client) Connect(natsURL string, userCreds domain.NatsUserCreds) (ports.NatsConnection, error) {
+func (n *Client) Connect(natsURL string, userCreds domain.NatsUserCreds) (outbound.NatsConnection, error) {
 	if natsURL == "" {
 		return nil, fmt.Errorf("NATS URL is required")
 	}
@@ -155,5 +155,5 @@ func (n *Connection) connect() error {
 }
 
 // Compile-time assertion that implementations fulfills ports
-var _ ports.NatsClient = (*Client)(nil)
-var _ ports.NatsConnection = (*Connection)(nil)
+var _ outbound.NatsClient = (*Client)(nil)
+var _ outbound.NatsConnection = (*Connection)(nil)

--- a/internal/ports/outbound/k8s.go
+++ b/internal/ports/outbound/k8s.go
@@ -1,4 +1,4 @@
-package ports
+package outbound
 
 import (
 	"context"

--- a/internal/ports/outbound/nats.go
+++ b/internal/ports/outbound/nats.go
@@ -1,4 +1,4 @@
-package ports
+package outbound
 
 import (
 	"github.com/WirelessCar/nauth/internal/domain"


### PR DESCRIPTION
## Summary

Move the outbound port contracts from `internal/ports` into `internal/ports/outbound`.

## Why

This is another step in separating the core logic from its external dependencies according to the hexagonal structure.

These interfaces define outbound dependencies used by the application core, so they belong under `internal/ports/outbound` rather than directly under `internal/ports`.

## What Changed

- moved the Kubernetes- and NATS-related outbound port contracts into `internal/ports/outbound`
- renamed the package from `ports` to `outbound`
- updated the affected imports and interface references across the codebase

## Notes

No intended behavior change. This is a structural refactor to make the package layout better reflect the architecture.

