### PR TITLE
feat!: remove legacy implicit cluster configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ Nauth requires the **system account user credentials** and the [**operator signi
 
 You can provide and resolve these secrets in three ways:
 
-> [!WARNING]
-> `NATS_URL` and the implicit label-based lookup path are deprecated and will be sunset in favor of explicit `NatsClusterRef` + `NatsCluster` resources (tracking: [#102](https://github.com/WirelessCar/nauth/issues/102)).
-
 **A.** For single-cluster deployments, set `NATS_CLUSTER_REF` on the nauth controller (`namespace/name`, for example `nats/my-nats-cluster`) and define the secrets in that referenced `NatsCluster` (`spec.operatorSigningKeySecretRef` and `spec.systemAccountUserCredsSecretRef`).
    - Default behavior (`NATS_CLUSTER_REF_OPTIONAL=false`) is strict mode: account-level `spec.natsClusterRef` must match `NATS_CLUSTER_REF`.
    - `NATS_CLUSTER_REF_OPTIONAL=true` is explicit opt-in default mode: accounts without `spec.natsClusterRef` use `NATS_CLUSTER_REF`, while accounts may override with their own ref.
@@ -44,10 +41,6 @@ You can provide and resolve these secrets in three ways:
      3) Remove `NATS_CLUSTER_REF` and rely on explicit `spec.natsClusterRef` in each `Account`.
 
 **B.** Define an explicit `spec.natsClusterRef` reference in each `Account` CR to a specific `NatsCluster`.
-
-**C. (Deprecated)** Use the legacy label-based lookup together with `NATS_URL`:
-   - `nauth.io/secret-type: system-account-user-creds`
-   - `nauth.io/secret-type: operator-sign`
 
 You can see a full [operator example setup here](./examples/nauth/manifests/operator.yaml.md). 
 For a more secrets related example on how to set up NAuth using explicit secrets lookup based on `NatsClusterRef` and `NatsCluster` resources, see the [cluster reference scenario](./examples/nauth/manifests/scenarios/cluster-ref/README.md).

--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -19,7 +19,6 @@
 | nameOverride | string | `""` | Override the chart name |
 | namespace | object | `{"nameOverride":""}` | Override the namespace |
 | namespaced | bool | `false` | If true, limits the scope of nauth to a single namespace. Otherwise, all namespaces will be watched. |
-| nats.url | string | `""` | DEPRECATED legacy implicit lookup URL (`NATS_URL`). Prefer `nats.clusterRef.*`; `nats.url` is valid only when `nats.clusterRef.name` is empty and must not be set together with it (sunset tracked in `#102`). |
 | nats.clusterRef | object | `{"name":"","namespace":"","optional":false}` | Operator NatsCluster reference object. Set `name` to enable operator-level binding. |
 | nats.clusterRef.name | string | `""` | NatsCluster resource name. Leave empty to disable operator-level binding. |
 | nats.clusterRef.namespace | string | `""` | NatsCluster resource namespace. When empty and `name` is set, defaults to the chart namespace. |

--- a/charts/nauth/templates/deployment.yaml
+++ b/charts/nauth/templates/deployment.yaml
@@ -42,13 +42,6 @@ spec:
             {{- end }}
           name: manager
           env:
-            {{- if and .Values.nats.url .Values.nats.clusterRef.name }}
-            {{- fail "nats.url and nats.clusterRef.name cannot both be set" }}
-            {{- end }}
-            {{- if .Values.nats.url }}
-            - name: NATS_URL
-              value: {{ .Values.nats.url | quote }}
-            {{- end }}
             {{- if .Values.nats.clusterRef.name }}
             - name: NATS_CLUSTER_REF
               value: {{ default (include "nauth.namespaceName" .) .Values.nats.clusterRef.namespace }}/{{ .Values.nats.clusterRef.name }}

--- a/charts/nauth/tests/deployment_nats_cluster_env_test.yaml
+++ b/charts/nauth/tests/deployment_nats_cluster_env_test.yaml
@@ -152,13 +152,3 @@ tests:
           content:
             name: NATS_CLUSTER_REF_OPTIONAL
             value: "false"
-
-  - it: fails when nats.url and nats.clusterRef.name are both set
-    set:
-      nats:
-        url: nats://nats.nats.svc.cluster.local:4222
-        clusterRef:
-          name: shared-cluster
-    asserts:
-      - failedTemplate:
-          errorMessage: "nats.url and nats.clusterRef.name cannot both be set"

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -9,13 +9,6 @@ global:
   # custom.label.team: team-potato
 
 nats:
-  # -- DEPRECATED: Legacy implicit lookup URL. See `nats.clusterRef` for replacement.
-  # -- Prefer explicit `nats.clusterRef.*` together with `NatsClusterRef` + `NatsCluster`.
-  # -- Used only when `nats.clusterRef.name` is empty.
-  # -- Must not be set together with `nats.clusterRef.name`.
-  # // TODO: [#102][#144] Sunset `nats.url`/`NATS_URL` and implicit operator signing key/system account credentials lookup.
-  url: ""
-
   # -- Operator-level NatsCluster configuration.
   # -- Set `clusterRef.name` to bind the operator to one NATS cluster.
   # -- `clusterRef.namespace` is optional and defaults to the release namespace.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -224,9 +224,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: [#102][#144] Sunset NATS_URL in favor of explicit NatsClusterRef + NatsCluster resources.
-	defaultNatsURL := os.Getenv("NATS_URL")
-
 	var operatorNatsCluster *core.OperatorNatsCluster
 	natsClusterRef := strings.TrimSpace(os.Getenv("NATS_CLUSTER_REF"))
 	natsClusterRefOptional := false
@@ -263,7 +260,7 @@ func main() {
 		namespace = string(controllerNamespace)
 	}
 
-	config, err := core.NewConfig(operatorNatsCluster, domain.Namespace(namespace), defaultNatsURL)
+	config, err := core.NewConfig(operatorNatsCluster, domain.Namespace(namespace))
 	if err != nil {
 		setupLog.Error(err, "invalid configuration")
 		os.Exit(1)

--- a/examples/nauth/manifests/scenarios/cluster-ref/README.md
+++ b/examples/nauth/manifests/scenarios/cluster-ref/README.md
@@ -1,6 +1,6 @@
 # Cluster-ref scenario
 
-This scenario demonstrates the **cluster approach**: using `NatsCluster` and `natsClusterRef` instead of the legacy `NATS_URL` environment variable and label-based secrets.
+This scenario demonstrates the **cluster approach**: using `NatsCluster` and `natsClusterRef`.
 
 ## Overview
 

--- a/examples/nauth/manifests/scenarios/cluster-ref/cluster-ref.yaml
+++ b/examples/nauth/manifests/scenarios/cluster-ref/cluster-ref.yaml
@@ -1,4 +1,4 @@
-# Cluster-ref scenario: using NatsClusterRef instead of deprecated NATS_URL + label-based secrets.
+# Cluster-ref scenario: using NatsClusterRef to reference a NatsCluster for Account.
 #
 # Prerequisites:
 # - Create an operator signing key secret (e.g. my-operator-signing-key) with key "seed"
@@ -6,7 +6,7 @@
 # - Create a ConfigMap or Secret containing the NATS URL (see nats-url-config below)
 #
 # This approach allows multiple NatsClusters in the cluster and lets Accounts/Users
-# target a specific cluster via natsClusterRef instead of relying on NATS_URL env var.
+# target a specific cluster via natsClusterRef.
 ---
 apiVersion: v1
 kind: Namespace

--- a/internal/adapter/outbound/k8s/secret_types.go
+++ b/internal/adapter/outbound/k8s/secret_types.go
@@ -6,11 +6,9 @@ const (
 )
 
 const (
-	SecretTypeAccountRoot            = "account-root"
-	SecretTypeAccountSign            = "account-sign"
-	SecretTypeOperatorSign           = "operator-sign"
-	SecretTypeSystemAccountUserCreds = "system-account-user-creds"
-	SecretTypeUserCredentials        = "user-creds"
-	DefaultSecretKeyName             = "default"
-	UserCredentialSecretKeyName      = "user.creds"
+	SecretTypeAccountRoot       = "account-root"
+	SecretTypeAccountSign       = "account-sign"
+	SecretTypeUserCredentials   = "user-creds"
+	DefaultSecretKeyName        = "default"
+	UserCredentialSecretKeyName = "user.creds"
 )

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -152,7 +152,7 @@ func (r *ClusterManager) GetClusterTarget(ctx context.Context, accountClusterRef
 	} else if opClusterRef := r.operatorClusterRef(); opClusterRef != nil {
 		result, err = r.resolveTarget(ctx, *opClusterRef)
 	} else {
-		result, err = r.resolveTargetFromImplicitLookup(ctx)
+		return nil, fmt.Errorf("no cluster reference provided and no operator cluster configured")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("resolve cluster target: %w", err)
@@ -198,32 +198,6 @@ func (r *ClusterManager) resolveTargetFromCluster(ctx context.Context, cluster *
 	return target, nil
 }
 
-// resolveTargetFromImplicitLookup performs a best-effort resolution of cluster connection details based on the presence
-// of a default NATS URL and labeled secrets in the operator namespace.
-// Deprecated: This method relies on legacy patterns and will sunset in a future release.
-func (r *ClusterManager) resolveTargetFromImplicitLookup(ctx context.Context) (*clusterTarget, error) {
-	// TODO: [#102][#144] Sunset label-based secret lookup.
-	if r.config.DefaultNatsURL == "" {
-		return nil, fmt.Errorf("default NATS URL is not configured for implicit cluster lookup")
-	}
-	if r.config.OperatorNamespace == "" {
-		return nil, fmt.Errorf("operator namespace is required for implicit cluster lookup")
-	}
-	sysAdminCreds, err := r.resolveSysAdminCredsViaLabels(ctx, r.config.OperatorNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("resolve system account user creds via labels: %w", err)
-	}
-	opSigningKey, err := r.resolveOperatorSigningKeyViaLabels(ctx, r.config.OperatorNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("resolve operator signing key via labels: %w", err)
-	}
-	target, err := newClusterTarget(r.config.DefaultNatsURL, *sysAdminCreds, opSigningKey)
-	if err != nil {
-		return nil, fmt.Errorf("create cluster target from implicit lookup: %w", err)
-	}
-	return target, nil
-}
-
 func (r *ClusterManager) resolveSysAdminCreds(ctx context.Context, cluster *v1alpha1.NatsCluster) (*domain.NatsUserCreds, error) {
 	secretKeyRef := cluster.Spec.SystemAccountUserCredsSecretRef
 	secretRef := domain.NewNamespacedName(cluster.GetNamespace(), secretKeyRef.Name)
@@ -234,23 +208,6 @@ func (r *ClusterManager) resolveSysAdminCreds(ctx context.Context, cluster *v1al
 	userCreds, err := domain.NewNatsUserCreds(creds)
 	if err != nil {
 		return nil, fmt.Errorf("invalid user creds: %w", err)
-	}
-	return userCreds, nil
-}
-
-// Deprecated: This method relies on legacy patterns and will sunset in a future release.
-func (r *ClusterManager) resolveSysAdminCredsViaLabels(ctx context.Context, namespace domain.Namespace) (*domain.NatsUserCreds, error) {
-	labels := map[string]string{
-		k8s.LabelSecretType: k8s.SecretTypeSystemAccountUserCreds,
-	}
-	creds, err := r.resolveSecretByLabels(ctx, namespace, labels)
-	if err != nil {
-		return nil, fmt.Errorf("resolve system account user creds via labels in namespace %s: %w", namespace, err)
-	}
-
-	userCreds, err := domain.NewNatsUserCreds(creds)
-	if err != nil {
-		return nil, fmt.Errorf("invalid system account user creds found via labels in namespace %s: %w", namespace, err)
 	}
 	return userCreds, nil
 }
@@ -267,38 +224,6 @@ func (r *ClusterManager) resolveOperatorSigningKey(ctx context.Context, cluster 
 		return nil, fmt.Errorf("invalid operator signing key: %w", err)
 	}
 	return opSigningKey, nil
-}
-
-// Deprecated: This method relies on legacy patterns and will sunset in a future release.
-func (r *ClusterManager) resolveOperatorSigningKeyViaLabels(ctx context.Context, namespace domain.Namespace) (domain.NatsOperatorSigningKey, error) {
-	labels := map[string]string{k8s.LabelSecretType: k8s.SecretTypeOperatorSign}
-	seed, err := r.resolveSecretByLabels(ctx, namespace, labels)
-	if err != nil {
-		return nil, fmt.Errorf("resolve operator signing key via labels: %w", err)
-	}
-	keyPair, err := nkeys.FromSeed(seed)
-	if err != nil {
-		return nil, fmt.Errorf("invalid operator signing key in secret found via labels in namespace %s: %w", namespace, err)
-	}
-	return keyPair, err
-}
-
-func (r *ClusterManager) resolveSecretByLabels(ctx context.Context, namespace domain.Namespace, labels map[string]string) ([]byte, error) {
-	secrets, err := r.secretReader.GetByLabels(ctx, namespace, labels)
-	if err != nil {
-		return nil, fmt.Errorf("get secrets by labels %v in namespace %q: %w", labels, namespace, err)
-	}
-	if len(secrets.Items) == 0 {
-		return nil, fmt.Errorf("no secrets found with labels %v in namespace %q", labels, namespace)
-	}
-	if len(secrets.Items) > 1 {
-		return nil, fmt.Errorf("multiple secrets found with labels %v in namespace %q, expected exactly one", labels, namespace)
-	}
-	value, ok := secrets.Items[0].Data[k8s.DefaultSecretKeyName]
-	if !ok {
-		return nil, fmt.Errorf("secret %s/%s found with labels %v does not contain key %q", namespace, secrets.Items[0].Name, labels, k8s.DefaultSecretKeyName)
-	}
-	return value, nil
 }
 
 func (r *ClusterManager) resolveSecret(ctx context.Context, namespacedName domain.NamespacedName, key string) ([]byte, error) {

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -43,37 +43,13 @@ func TestClusterManager_TestSuite(t *testing.T) {
 	suite.Run(t, new(ClusterTestSuite))
 }
 
-func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenLegacyImplicitLookup() {
-	// Given
-	unitUnderTest := t.newUnitUnderTest(nil, false, "nats", "nats://nats:4222")
-
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-	t.secretClientMock.mockGetByLabelsSimple("nats", map[string]string{k8s.LabelSecretType: k8s.SecretTypeOperatorSign},
-		k8s.DefaultSecretKeyName, opSignSeed)
-	t.secretClientMock.mockGetByLabelsSimple("nats", map[string]string{k8s.LabelSecretType: k8s.SecretTypeSystemAccountUserCreds},
-		k8s.DefaultSecretKeyName, sauCreds.Creds)
-
-	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, nil)
-
-	// Then
-	require.NoError(t.T(), err)
-	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
-		NatsURL:            "nats://nats:4222",
-		SystemAdminCreds:   sauCreds,
-		OperatorSigningKey: opSignKey,
-	}, result)
-}
-
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenOperatorClusterRef() {
 	// Given
 	opClusterRef := &v1alpha1.NatsClusterRef{
 		Namespace: "my-namespace",
 		Name:      "my-cluster",
 	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats", "")
+	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats")
 
 	opSignKey, sauCreds := t.generateSecrets()
 	opSignSeed, _ := opSignKey.Seed()
@@ -109,7 +85,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenOperatorClust
 
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountClusterRef() {
 	// Given´
-	unitUnderTest := t.newUnitUnderTest(nil, false, "nats", "")
+	unitUnderTest := t.newUnitUnderTest(nil, false, "nats")
 
 	acClusterRef := &v1alpha1.NatsClusterRef{
 		Namespace: "ac-namespace",
@@ -153,7 +129,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 		Namespace: "my-namespace",
 		Name:      "my-cluster",
 	}
-	unitUnderTest := t.newUnitUnderTest(clusterRef, false, "nats", "")
+	unitUnderTest := t.newUnitUnderTest(clusterRef, false, "nats")
 
 	opSignKey, sauCreds := t.generateSecrets()
 	opSignSeed, _ := opSignKey.Seed()
@@ -193,7 +169,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 		Namespace: "op-namespace",
 		Name:      "op-cluster",
 	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, true, "nats", "")
+	unitUnderTest := t.newUnitUnderTest(opClusterRef, true, "nats")
 
 	acClusterRef := &v1alpha1.NatsClusterRef{
 		Namespace: "ac-namespace",
@@ -237,7 +213,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenAccountClusterRe
 		Namespace: "op-namespace",
 		Name:      "op-cluster",
 	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats", "")
+	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats")
 
 	acClusterRef := &v1alpha1.NatsClusterRef{
 		Namespace: "ac-namespace",
@@ -258,7 +234,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenOperatorClusterN
 		Namespace: "my-namespace",
 		Name:      "my-cluster",
 	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats", "")
+	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats")
 
 	t.natsClusterResolverMock.mockGetNatsClusterError(t.ctx, domain.NewNamespacedName("my-namespace", "my-cluster"),
 		fmt.Errorf("the root cause"))
@@ -271,13 +247,25 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenOperatorClusterN
 	require.Nil(t.T(), result)
 }
 
+func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenNeitherAccountNorOperatorClusterRefDefined() {
+	// Given
+	unitUnderTest := t.newUnitUnderTest(nil, false, "nats")
+
+	// When
+	result, err := unitUnderTest.GetClusterTarget(t.ctx, nil)
+
+	// Then
+	require.ErrorContains(t.T(), err, "no cluster reference provided and no operator cluster configured")
+	require.Nil(t.T(), result)
+}
+
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenAccountClusterNotFound() {
 	// Given
 	opClusterRef := &v1alpha1.NatsClusterRef{
 		Namespace: "op-namespace",
 		Name:      "op-cluster",
 	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, true, "nats", "")
+	unitUnderTest := t.newUnitUnderTest(opClusterRef, true, "nats")
 
 	acClusterRef := &v1alpha1.NatsClusterRef{
 		Namespace: "ac-namespace",
@@ -307,30 +295,6 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenAccountClusterRe
 
 	// Then
 	require.ErrorContains(t.T(), err, "invalid account cluster reference: namespace required")
-	require.Nil(t.T(), result)
-}
-
-func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenLegacyLookupAndDefaultNatsURLNotProvided() {
-	// Given
-	unitUnderTest := t.newUnitUnderTest(nil, false, "nats", "")
-
-	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, nil)
-
-	// Then
-	require.ErrorContains(t.T(), err, "resolve cluster target: default NATS URL is not configured for implicit cluster lookup")
-	require.Nil(t.T(), result)
-}
-
-func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenLegacyLookupAndOperatorNamespaceNotProvided() {
-	// Given
-	unitUnderTest := t.newUnitUnderTest(nil, false, "", "nats://nats:4222")
-
-	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, nil)
-
-	// Then
-	require.ErrorContains(t.T(), err, "resolve cluster target: operator namespace is required for implicit cluster lookup")
 	require.Nil(t.T(), result)
 }
 
@@ -587,10 +551,10 @@ func (t *ClusterTestSuite) Test_Validate_ShouldFail_WhenVerifySystemAccountAcces
 }
 
 func (t *ClusterTestSuite) newUnitUnderTestWithDefaults() *ClusterManager {
-	return t.newUnitUnderTest(nil, false, "", "")
+	return t.newUnitUnderTest(nil, false, "")
 }
 
-func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *v1alpha1.NatsClusterRef, opClusterOptional bool, opNamespace domain.Namespace, defaultNatsURL string) *ClusterManager {
+func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *v1alpha1.NatsClusterRef, opClusterOptional bool, opNamespace domain.Namespace) *ClusterManager {
 	var operatorNatsCluster *OperatorNatsCluster
 	var err error
 	if opClusterRef != nil {
@@ -601,7 +565,7 @@ func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *v1alpha1.NatsClusterRe
 		}
 	}
 
-	config, err := NewConfig(operatorNatsCluster, opNamespace, defaultNatsURL)
+	config, err := NewConfig(operatorNatsCluster, opNamespace)
 	if err != nil {
 		t.Failf("failed to create operator config", "error: %v", err)
 		return nil

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
@@ -13,19 +12,13 @@ import (
 type Config struct {
 	OperatorNatsCluster *OperatorNatsCluster
 	// OperatorNamespace is the Kubernetes namespace where the operator is deployed.
-	// TODO: [#102][#144] When sunsetting DefaultNatsURL, remove this field if it no longer serves a purpose.
 	OperatorNamespace domain.Namespace
-	// DefaultNatsURL is a comma-separated list of NATS server URLs to use when OperatorNatsCluster is not configured.
-	// Deprecated: This field is deprecated and will be removed in a future release.
-	// TODO: [#102][#144] Sunset DefaultNatsURL (NATS_URL)
-	DefaultNatsURL string
 }
 
-func NewConfig(operatorNatsCluster *OperatorNatsCluster, operatorNamespace domain.Namespace, defaultNatsURL string) (*Config, error) {
+func NewConfig(operatorNatsCluster *OperatorNatsCluster, operatorNamespace domain.Namespace) (*Config, error) {
 	config := &Config{
 		OperatorNatsCluster: operatorNatsCluster,
 		OperatorNamespace:   operatorNamespace,
-		DefaultNatsURL:      defaultNatsURL,
 	}
 	if err := config.validate(); err != nil {
 		return nil, err
@@ -34,9 +27,6 @@ func NewConfig(operatorNatsCluster *OperatorNatsCluster, operatorNamespace domai
 }
 
 func (c *Config) validate() error {
-	if c.OperatorNatsCluster != nil && c.DefaultNatsURL != "" {
-		return fmt.Errorf("operator NATS cluster and default NATS URL cannot both be set; when operator NATS cluster is configured it supersedes default NATS URL")
-	}
 	if c.OperatorNatsCluster != nil {
 		if err := c.OperatorNatsCluster.validate(); err != nil {
 			return fmt.Errorf("invalid operator NATS cluster: %w", err)
@@ -45,32 +35,6 @@ func (c *Config) validate() error {
 	if c.OperatorNamespace != "" {
 		if err := c.OperatorNamespace.Validate(); err != nil {
 			return fmt.Errorf("invalid operator namespace %q: %s", c.OperatorNamespace, err)
-		}
-	}
-	if c.DefaultNatsURL != "" {
-		if err := validateNatsURLs(c.DefaultNatsURL); err != nil {
-			return fmt.Errorf("invalid default NATS URL %q: %w", c.DefaultNatsURL, err)
-		}
-	}
-
-	return nil
-}
-
-func validateNatsURLs(value string) error {
-	for _, natsURL := range strings.Split(value, ",") {
-		if strings.TrimSpace(natsURL) == "" {
-			return fmt.Errorf("contains an empty URL entry")
-		}
-
-		parsedURL, err := url.Parse(natsURL)
-		if err != nil {
-			return fmt.Errorf("parse URL %q: %w", natsURL, err)
-		}
-		if parsedURL.Scheme == "" {
-			return fmt.Errorf("URL %q must include a scheme", natsURL)
-		}
-		if parsedURL.Host == "" {
-			return fmt.Errorf("URL %q must include a host", natsURL)
 		}
 	}
 

--- a/internal/core/config_blackbox_test.go
+++ b/internal/core/config_blackbox_test.go
@@ -77,7 +77,7 @@ func TestNewOperatorNatsCluster(t *testing.T) {
 
 func TestNewConfig(t *testing.T) {
 	t.Run("should_succeed_when_all_values_are_empty", func(t *testing.T) {
-		config, err := core.NewConfig(nil, "", "")
+		config, err := core.NewConfig(nil, "")
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
@@ -90,40 +90,6 @@ func TestNewConfig(t *testing.T) {
 		if config.OperatorNamespace != "" {
 			t.Fatalf("expected empty namespace, got %q", config.OperatorNamespace)
 		}
-		if config.DefaultNatsURL != "" {
-			t.Fatalf("expected empty default NATS URL, got %q", config.DefaultNatsURL)
-		}
-	})
-
-	t.Run("should_succeed_when_namespace_and_default_nats_url_are_valid", func(t *testing.T) {
-		config, err := core.NewConfig(nil, "operator-system", "nats://n1:4222,nats://n2:4222")
-		if err != nil {
-			t.Fatalf("expected success, got error: %v", err)
-		}
-		if config.OperatorNamespace != "operator-system" {
-			t.Fatalf("expected trimmed namespace, got %q", config.OperatorNamespace)
-		}
-		if config.DefaultNatsURL != "nats://n1:4222,nats://n2:4222" {
-			t.Fatalf("expected trimmed default NATS URL, got %q", config.DefaultNatsURL)
-		}
-	})
-
-	t.Run("should_fail_when_both_operator_cluster_and_default_nats_url_are_set", func(t *testing.T) {
-		cluster, err := core.NewOperatorNatsCluster(v1alpha1.NatsClusterRef{
-			Namespace: "operator-system",
-			Name:      "nats-main",
-		}, false)
-		if err != nil {
-			t.Fatalf("failed to create operator cluster: %v", err)
-		}
-
-		config, err := core.NewConfig(cluster, "operator-system", "nats://localhost:4222")
-		if err == nil {
-			t.Fatalf("expected error, got success with config=%+v", config)
-		}
-		if !strings.Contains(err.Error(), "supersedes default NATS URL") {
-			t.Fatalf("expected precedence error message, got %q", err.Error())
-		}
 	})
 
 	t.Run("should_fail_when_operator_cluster_is_invalid_even_if_constructed_directly", func(t *testing.T) {
@@ -132,7 +98,7 @@ func TestNewConfig(t *testing.T) {
 				Namespace: "invalid_namespace",
 				Name:      "nats-main",
 			},
-		}, "", "")
+		}, "")
 		if err == nil {
 			t.Fatalf("expected error, got success with config=%+v", config)
 		}
@@ -142,7 +108,7 @@ func TestNewConfig(t *testing.T) {
 	})
 
 	t.Run("should_fail_when_operator_namespace_is_invalid", func(t *testing.T) {
-		config, err := core.NewConfig(nil, " invalid_namespace ", "")
+		config, err := core.NewConfig(nil, " invalid_namespace ")
 		if err == nil {
 			t.Fatalf("expected error, got success with config=%+v", config)
 		}
@@ -150,43 +116,4 @@ func TestNewConfig(t *testing.T) {
 			t.Fatalf("expected operator namespace validation error, got %q", err.Error())
 		}
 	})
-
-	urlErrorCases := []struct {
-		testName       string
-		defaultNatsURL string
-		expectedError  string
-	}{
-		{
-			testName:       "should_fail_when_default_nats_url_contains_empty_entry",
-			defaultNatsURL: "nats://localhost:4222,,nats://localhost:4223",
-			expectedError:  "contains an empty URL entry",
-		},
-		{
-			testName:       "should_fail_when_default_nats_url_cannot_be_parsed",
-			defaultNatsURL: "nats://[::1",
-			expectedError:  "parse URL",
-		},
-		{
-			testName:       "should_fail_when_default_nats_url_has_no_scheme",
-			defaultNatsURL: "//localhost:4222",
-			expectedError:  "must include a scheme",
-		},
-		{
-			testName:       "should_fail_when_default_nats_url_has_no_host",
-			defaultNatsURL: "nats://",
-			expectedError:  "must include a host",
-		},
-	}
-
-	for _, tc := range urlErrorCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			config, err := core.NewConfig(nil, "", tc.defaultNatsURL)
-			if err == nil {
-				t.Fatalf("expected error, got success with config=%+v", config)
-			}
-			if !strings.Contains(err.Error(), tc.expectedError) {
-				t.Fatalf("expected error containing %q, got %q", tc.expectedError, err.Error())
-			}
-		})
-	}
 }

--- a/internal/core/mocks_test.go
+++ b/internal/core/mocks_test.go
@@ -110,11 +110,6 @@ func (s *SecretClientMock) mockGetByLabelsSimplified(namespace domain.Namespace,
 	s.mockGetByLabels(namespace, labels, secretList)
 }
 
-func (s *SecretClientMock) mockGetByLabelsSimple(namespace domain.Namespace, labels map[string]string, key string, value []byte) {
-	result := &corev1.SecretList{Items: []corev1.Secret{{Data: map[string][]byte{key: value}}}}
-	s.mockGetByLabels(namespace, labels, result)
-}
-
 func (s *SecretClientMock) Delete(ctx context.Context, namespacedName domain.NamespacedName) error {
 	args := s.Called(ctx, namespacedName)
 	return args.Error(0)

--- a/local/README.md
+++ b/local/README.md
@@ -35,7 +35,7 @@ The task scripts live under `.mise-tasks/nauth` and can be run individually.
 ## Local overrides
 
 - `local/nats/values.yaml`: NATS chart overrides for the test environment.
-- `local/nauth/values.yaml`: Nauth chart overrides for the test environment (no legacy `nats.url` override).
+- `local/nauth/values.yaml`: Nauth chart overrides for the test environment.
 - `local/nauth/manifests/operator.yaml`: shared bootstrap manifests applied during setup, including `NatsCluster` (`local-nats`) and referenced secrets.
 - `local/prometheus/values.yaml`: Prometheus chart overrides (if used).
 


### PR DESCRIPTION
## Summary

Remove the remaining legacy implicit cluster configuration path and require explicit `NatsCluster`-based configuration.

## Why

Before `NatsCluster` and `NatsClusterRef` existed, nAuth could be configured implicitly through:
- the `NATS_URL` environment variable
- Kubernetes secrets discovered by label using:
  - `nauth.io/secret-type: operator-sign`
  - `nauth.io/secret-type: system-account-user-creds`

That legacy model is now fully removed. Cluster URL and the required secret references must instead be declared explicitly in a `NatsCluster` resource, which is then referenced by the operator and/or individual resources through `NatsClusterRef`.

## Notes

This commit also cleans up tests, scripts, and documentation so the legacy configuration model is no longer present in the codebase.

BREAKING CHANGE: The legacy implicit cluster configuration path has been removed. nAuth no longer supports configuring cluster access through `NATS_URL` plus label-based secret discovery. Deployments must now define a `NatsCluster` resource with explicit `url` or `urlFrom`, `operatorSigningKeySecretRef`, and `systemAccountUserCredsSecretRef`, and reference it through `NATS_CLUSTER_REF` environment variable and/or `Account` CRD `spec.natsClusterRef`.

Closes: #144

Signed-off-by: Thobias Karlsson <thobias.karlsson@gmail.com>
