### PR TITLE
ci(deps): bump Trivy to latest version

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           docker build -t ghcr.io/wirelesscar/nauth-operator:${{ github.sha }} .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: 'ghcr.io/wirelesscar/nauth-operator:${{ github.sha }}'
           format: 'template'


### PR DESCRIPTION
Fixes a Trivy vulnerability.

Ref: https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
Hash: 57a97c7e7821a5776cebc9bb87c984fa69cba8f1

Signed-off-by: Thobias Karlsson <thobias.karlsson@gmail.com>
