### PR TITLE
docs(adr): create ADR for import/export split

### DIFF
--- a/adr/0005-extract-import-and-export-crds-from-account-crd.md
+++ b/adr/0005-extract-import-and-export-crds-from-account-crd.md
@@ -1,4 +1,4 @@
-# ADR-5: Split import and export CRDs from Account CRD
+# ADR-5: Extract Import- and Export CRDs from Account CRD
 
 Date: 2026-03-26
 
@@ -11,13 +11,13 @@ Splitting the import and export CRDs from the Account CRD would allow for better
 
 ## Status
 
-In progress
+Accepted
 
 ## Context
 
 There exists several identified issues or improvements related to imports and exports, such as: validation of imports
 and matching exports, import and export using activation tokens, support for grouping of related imports and exports (
-for example, jetstream related API topics), getting rid of need to apply imports and exports in correct order.
+for example, JetStream related API subjects).
 
 All these are concerns of imports and exports, and might benefit from the split as well as make the account resources
 more robust and easier to manage.
@@ -36,7 +36,7 @@ they are important to keep in mind when evaluating the options.
 
 - How to handle partial failures, for example, if one of the imports or exports is invalid, should the entire account
   be left out / invalidated or should the valid imports and exports still be applied?
-- Account JWT must be reconciled before imports and exports, otherwise the account might be left in a "broken" state.
+- Account CRD must be reconciled before imports and exports, otherwise the account might be left in a "broken" state.
 - Changes in imports and exports must be reflected in the account JWT, which means that the account JWT must be
   reconciled after any change in imports and exports.
 - How to present reconciliation state in a good way in tools such as `kubectl`, `k9s` and `argoCD`?
@@ -49,7 +49,7 @@ they are important to keep in mind when evaluating the options.
 
 * Cross-cluster imports/exports
 * import and export activation tokens
-* import and export drift detection and Approval workflows
+* import and export drift detection and approval workflows
 
 ## Options
 
@@ -65,7 +65,6 @@ separate CRD.
 
 Same as Option 1 but with separate CRDs for imports and exports.
 Better for separating import and export specific fields and concerns.
-For example `export` has `TokenReq (bool)` field, while `import` has `Token` field.
 
 ### Option 3 - One import/export per import/export CRD
 
@@ -93,12 +92,12 @@ fragments directly in `Account`.
 ## Decision
 
 * Extract import/export to separate CRDs
+* First release must support what is supported today by inline imports and exports
 * Deprecate the import and export fields in `Account` CRD.
 * Use `Option 4 - Contract-based imports/exports` as a target vision
-* First release must support what is supported today by inline imports and exports
-* `tokenReq` and `revocations` in export will be deferred, as these are not implemented today  
+* `tokenReq` and `revocations` in export will be deferred, as these are not implemented today
 
 ## Consequences
 
-* Import and export CRDs can reconcile by themselves. 
+* Import and export CRDs can reconcile by themselves.
 * Failing import and export CRDs will not block account reconciliation.

--- a/adr/0005-extract-import-and-export-crds-from-account-crd.md
+++ b/adr/0005-extract-import-and-export-crds-from-account-crd.md
@@ -1,7 +1,6 @@
-# ADR-5: Extract Import- and Export CRDs from Account CRD
+# ADR-5: Separate AccountImport and AccountExport CRDs and deprecate inline importing and exporting in Account CRD
 
 Date: 2026-03-26
-
 ## Problem statement
 
 The `Account` CRD is currently used to manage everything related to the account, which includes limits, imports and
@@ -91,10 +90,10 @@ fragments directly in `Account`.
 
 ## Decision
 
-* Extract import/export to separate CRDs
+* Extract import/export to separate CRDs (`option 2`).
 * First release must support what is supported today by inline imports and exports
 * Deprecate the import and export fields in `Account` CRD.
-* Use `Option 4 - Contract-based imports/exports` as a target vision
+* Use `Option 4 - Contract-based imports/exports` as a target vision (not all features might be necessary)
 * `tokenReq` and `revocations` in export will be deferred, as these are not implemented today
 
 ## Consequences

--- a/adr/0005-split-import-and-export-crds-from-account-crd.md
+++ b/adr/0005-split-import-and-export-crds-from-account-crd.md
@@ -1,0 +1,291 @@
+# ADR-5: Split import and export CRDs from Account CRD
+
+Date: 2026-03-26
+
+## Problem statement
+
+The `Account` CRD is currently used to manage everything related to the account, which includes limits, imports and
+exports. If any of these settings are broken, especially imports and exports, it can affect the entire account.
+
+Splitting the import and export CRDs from the Account CRD would allow for better separation of concerns.
+
+## Status
+
+In progress
+
+_Allowed values: In progress/Accepted/Superceeded/Rejected/Obsolete._
+
+## Context
+
+There exists several identified issues or improvements related to imports and exports, such as: validation of imports
+and matching exports, import and export using activation tokens, support for grouping of related imports and exports (
+for example, jetstream related API topics), getting rid of need to apply imports and exports in correct order.
+
+All these are concerns of imports and exports, and might benefit from the split as well as make the account resources
+more robust and easier to manage.
+
+It is still the responsibility of the `Account` CRD, to reconcile all the imports and exports that belong to the
+account.
+
+This ADR describes some options for splitting import / export into separate CRDs. It aims to scope the split into
+features that exist today and only introduce new features if they are necessary or small enough. Other features are
+deferred.
+
+### Out of Scope - Deferred to future ADRs
+
+* Cross-cluster imports/exports
+* import and export activation tokens
+* import and export drift detection and Approval workflows
+
+### Concerns
+
+These concerns have been lifted during the writing of the ADR. They are not necessarily all solved by the solutions, but
+they are important to keep in mind when evaluating the options.
+
+- How to handle partial failures, for example, if one of the imports or exports is invalid, should the entire account
+  be left out / invalidated or should the valid imports and exports still be applied?
+- Account JWT must be reconciled before imports and exports, otherwise the account might be left in a "broken" state.
+- Changes in imports and exports must be reflected in the account JWT, which means that the account JWT must be
+  reconciled after any change in imports and exports.
+- How to present the data in a good way in `kubectl` and `k9s`?
+- How to handle overlapping subjects for same target account, from one or more CRs?
+- Can an account in one namespace reference exports/imports in another namespace?
+- Will import/export activation tokens work with these options?
+- Must use deterministic ordering of imports/exports, so that reconciliation does not go into loop.
+
+## Options
+
+### Option 1 - AccountImportExport CRD
+
+Imports and exports are simply moved to a separate CRD, but they are still managed together. The new CRD has a reference
+to the account. This option is in essence the same as the current state, but with imports and exports moved to a
+separate CRD.
+
+```yaml
+# simplified example of the new CRD structure
+AccountImportExport A:
+    account: A
+    imports:
+        - foo.> from Account B
+        - bar.> from Account C
+    exports:
+        - def.> to Account X
+
+AccountImportExport B:
+    account: B
+    exports:
+        - foo.> to Account A
+
+AccountImportExport C:
+    account: C
+    exports:
+        - bar.> to Account A
+
+# alternative for A, can be used if it makes sense to split imports/exports
+AccountImportExport A1:
+    account: A
+    imports:
+        - foo.> from Account B
+
+AccountImportExport A2:
+    account: A
+    imports:
+        - bar.> from Account C
+
+AccountImportExport A3:
+    account: A
+    exports:
+        - def.> to Account X
+```
+
+#### Benefits
+
+- Allows for easiest migration of the existing imports and exports to the new CRD.
+
+#### Drawbacks
+
+- Invites users to define both Export and Import in the same file, even if that's not desired.
+- It's harder to present the data in a good way in `kubectl` and `k9s` as the columns might differ.
+
+### Option 2 - Separate AccountImport and AccountExport CRDs
+
+Same as Option 1 but with separate CRDs for imports and exports.
+Better for separating import and export specific fields and concerns.
+For example `export` has `TokenReq (bool)` field, while `import` has `Token` field.
+
+```yaml
+# simplified example of the new CRD structure
+AccountImport A:
+    account: A
+    imports:
+        - foo.> from Account B
+        - bar.> from Account C
+
+AccountExport A:
+    account: A
+    exports:
+        - def.> to Account X
+```
+
+#### Benefits
+
+- Allows for configuration that affects all listed subjects.
+- Allows for configuration of individual subjects.
+- Less verbose but still allows user to define one import or export per AccountXport if so desired.
+- Allows grouping of related imports and exports, for example, all jetstream related API topics can be grouped together
+  in one CRD.
+    - And as a consequence, it is "all or nothing" for that group, which makes sense when it comes to jetstream.
+
+#### Drawbacks
+
+- Needs to handle partial failures.
+
+### Option 3 - One import/export per import/export CRD
+
+Each import and export is represented as a separate CRD.
+This allows for better granularity and easier management of individual imports and exports,
+but it can lead to a large number of CRDs if there are many imports and exports.
+
+```yaml
+# simplified example of the new CRD structure
+AccountImport A1:
+    account: A
+    subject: foo.>
+    fromAccount: B
+
+AccountImport A2:
+    account: A
+    subject: bar.>
+    fromAccount: C
+
+AccountExport A3:
+    account: A
+    subject: def.>
+    toAccount: X
+```
+
+#### Benefits:
+
+- Very granular validation, i.e. an entire group of rules wouldn't be left out just because one of the subjects are
+  conflicting or invalid.
+
+#### Drawbacks:
+
+- Extremely verbose, at least if we think about import/export for JetStream stuff.
+
+### Option 4 - Contract-based imports/exports
+
+`AccountExport` represents an explicit contract owned by the exporting account.
+`AccountImport` represents an import binding owned by the importing account and references a specific `AccountExport`.
+
+Instead of only defining raw import/export fragments, this option models the relationship between importer and exporter
+as first-class resources. The `Account` CRD remains responsible for reconciling the final account JWT from all ready
+import/export resources belonging to the account.
+
+The key idea is that both sides describe their own part of the relationship:
+
+* the exporter publishes what it is willing to expose
+* the importer declares which export it wants to consume
+
+This makes the relationship explicit, easier to validate, and easier to reason about than embedding raw import/export
+fragments directly in `Account`.
+
+**Example**
+
+```yaml
+AccountExport:
+    name: orders-and-stock-info     # unique name, referenced in imports
+    namespace: namespace-a
+    accountName: Account A          # parent account, expected to be in same namespace
+    rules:
+        -   name: "orders"          # human-readable name
+            subject: "orders.>"     # example: orders.<region>.<id> (orders.eu-west-1.12345) 
+            type: service           # service/stream
+            responseType: Singleton # service response type
+        -   name: "stock-info"
+            subject: "stock-info"
+            type: stream
+```
+
+```yaml
+
+AccountImport:
+    name: account-a-eu-orders         # unique name
+    namespace: namespace-b
+    accountName: Account B            # parent account, expected to be in same namespace
+    exportRef: # reference to the export this import wants to consume
+        name: orders-and-stock-info   # must match the export name
+        namespace: namespace-a
+    exportAccountName: Account A      # expected exporting account, used for validation
+    ruleBindings:
+        -   name: "orders eu-west-1"        # human-readable name
+            subject: "orders.eu-west-1.>"   # must match or be a subset of an export rule subject
+            type: service                   # must match the export rule type
+            localSubject: "eu.orders.>"     # optional local subject 
+```
+
+In this example:
+
+* Account A says: "I export these subjects and I allow any account to import them"
+* Account B says: "I want to import only eu-west-1 related orders from the export, and rename the local subject."
+* NAuth only renders final account JWT on the export account when `AccountExport` is ready
+* NAuth only renders final account JWT on the import account when `AccountImport` is ready
+
+#### How validation and readiness work
+
+This option introduces a fail-closed readiness model.
+
+`AccountExport` validates the exporter-owned side of the contract.
+`AccountImport` validates the importer-owned side of the contract.
+
+Only ready `AccountExport` and ready `AccountImport` resources contribute to the final rendered account JWT.
+
+This makes partial failures easier to reason about:
+
+* if one import is invalid, that import becomes `Ready=False`
+* any invalid rule makes the entire resource `Ready=False`
+* other valid imports and exports can still remain usable
+* the final account state only includes resources that are ready
+
+For example, if an import references a subject that does not exist as whole or subset in the export, that import does
+not become active.
+
+#### How conflicts are handled
+
+Because multiple imports and exports may contribute to the final account state, the controller must resolve them
+deterministically.
+
+This includes:
+
+* deterministic ordering of imports and exports
+* conflict detection when subjects overlap
+* clear reporting when two resources cannot be merged safely
+
+To identify conflicts, we will use nats.io's JWT imports validation function.
+
+#### Benefits:
+
+* Imports and Exports can be created in any order.
+* Allows for exporting of group of related subjects, for example, all JetStream API subjects.
+* Open to future improvements such as restricted exports (handling activation tokens) and approval workflows.
+
+#### Drawbacks:
+
+* More complex controller logic to handle the relationships and validation
+
+#### Working Notes
+
+These documents are working documents and notes related to the options. They might be incomplete and are not meant to be
+part of the final ADR, but they are included here for reference.
+
+* [appendix: Reconcile flow](worklog/0005/option-4-appendix-reconcile-flow.md)
+* [appendix: Resource relationships and reconcile triggers](worklog/0005/option-4-appendix-resource-relationships.md)
+* [appendix: Future improvements and notes](worklog/0005/option-4-appendix-future-improvements.md)
+
+## Decision
+
+Option 4 - Contract-based imports/exports
+
+## Consequences
+
+TBD

--- a/adr/0005-split-import-and-export-crds-from-account-crd.md
+++ b/adr/0005-split-import-and-export-crds-from-account-crd.md
@@ -13,8 +13,6 @@ Splitting the import and export CRDs from the Account CRD would allow for better
 
 In progress
 
-_Allowed values: In progress/Accepted/Superceeded/Rejected/Obsolete._
-
 ## Context
 
 There exists several identified issues or improvements related to imports and exports, such as: validation of imports
@@ -31,12 +29,6 @@ This ADR describes some options for splitting import / export into separate CRDs
 features that exist today and only introduce new features if they are necessary or small enough. Other features are
 deferred.
 
-### Out of Scope - Deferred to future ADRs
-
-* Cross-cluster imports/exports
-* import and export activation tokens
-* import and export drift detection and Approval workflows
-
 ### Concerns
 
 These concerns have been lifted during the writing of the ADR. They are not necessarily all solved by the solutions, but
@@ -47,13 +39,21 @@ they are important to keep in mind when evaluating the options.
 - Account JWT must be reconciled before imports and exports, otherwise the account might be left in a "broken" state.
 - Changes in imports and exports must be reflected in the account JWT, which means that the account JWT must be
   reconciled after any change in imports and exports.
-- How to present the data in a good way in `kubectl` and `k9s`?
+- How to present reconciliation state in a good way in tools such as `kubectl`, `k9s` and `argoCD`?
 - How to handle overlapping subjects for same target account, from one or more CRs?
 - Can an account in one namespace reference exports/imports in another namespace?
 - Will import/export activation tokens work with these options?
 - Must use deterministic ordering of imports/exports, so that reconciliation does not go into loop.
 
+### Out of Scope - Deferred to future ADRs
+
+* Cross-cluster imports/exports
+* import and export activation tokens
+* import and export drift detection and Approval workflows
+
 ## Options
+
+See [work log](worklog/0005/options.md) for details about options.
 
 ### Option 1 - AccountImportExport CRD
 
@@ -61,117 +61,17 @@ Imports and exports are simply moved to a separate CRD, but they are still manag
 to the account. This option is in essence the same as the current state, but with imports and exports moved to a
 separate CRD.
 
-```yaml
-# simplified example of the new CRD structure
-AccountImportExport A:
-    account: A
-    imports:
-        - foo.> from Account B
-        - bar.> from Account C
-    exports:
-        - def.> to Account X
-
-AccountImportExport B:
-    account: B
-    exports:
-        - foo.> to Account A
-
-AccountImportExport C:
-    account: C
-    exports:
-        - bar.> to Account A
-
-# alternative for A, can be used if it makes sense to split imports/exports
-AccountImportExport A1:
-    account: A
-    imports:
-        - foo.> from Account B
-
-AccountImportExport A2:
-    account: A
-    imports:
-        - bar.> from Account C
-
-AccountImportExport A3:
-    account: A
-    exports:
-        - def.> to Account X
-```
-
-#### Benefits
-
-- Allows for easiest migration of the existing imports and exports to the new CRD.
-
-#### Drawbacks
-
-- Invites users to define both Export and Import in the same file, even if that's not desired.
-- It's harder to present the data in a good way in `kubectl` and `k9s` as the columns might differ.
-
 ### Option 2 - Separate AccountImport and AccountExport CRDs
 
 Same as Option 1 but with separate CRDs for imports and exports.
 Better for separating import and export specific fields and concerns.
 For example `export` has `TokenReq (bool)` field, while `import` has `Token` field.
 
-```yaml
-# simplified example of the new CRD structure
-AccountImport A:
-    account: A
-    imports:
-        - foo.> from Account B
-        - bar.> from Account C
-
-AccountExport A:
-    account: A
-    exports:
-        - def.> to Account X
-```
-
-#### Benefits
-
-- Allows for configuration that affects all listed subjects.
-- Allows for configuration of individual subjects.
-- Less verbose but still allows user to define one import or export per AccountXport if so desired.
-- Allows grouping of related imports and exports, for example, all jetstream related API topics can be grouped together
-  in one CRD.
-    - And as a consequence, it is "all or nothing" for that group, which makes sense when it comes to jetstream.
-
-#### Drawbacks
-
-- Needs to handle partial failures.
-
 ### Option 3 - One import/export per import/export CRD
 
 Each import and export is represented as a separate CRD.
 This allows for better granularity and easier management of individual imports and exports,
 but it can lead to a large number of CRDs if there are many imports and exports.
-
-```yaml
-# simplified example of the new CRD structure
-AccountImport A1:
-    account: A
-    subject: foo.>
-    fromAccount: B
-
-AccountImport A2:
-    account: A
-    subject: bar.>
-    fromAccount: C
-
-AccountExport A3:
-    account: A
-    subject: def.>
-    toAccount: X
-```
-
-#### Benefits:
-
-- Very granular validation, i.e. an entire group of rules wouldn't be left out just because one of the subjects are
-  conflicting or invalid.
-
-#### Drawbacks:
-
-- Extremely verbose, at least if we think about import/export for JetStream stuff.
 
 ### Option 4 - Contract-based imports/exports
 
@@ -190,102 +90,15 @@ The key idea is that both sides describe their own part of the relationship:
 This makes the relationship explicit, easier to validate, and easier to reason about than embedding raw import/export
 fragments directly in `Account`.
 
-**Example**
-
-```yaml
-AccountExport:
-    name: orders-and-stock-info     # unique name, referenced in imports
-    namespace: namespace-a
-    accountName: Account A          # parent account, expected to be in same namespace
-    rules:
-        -   name: "orders"          # human-readable name
-            subject: "orders.>"     # example: orders.<region>.<id> (orders.eu-west-1.12345) 
-            type: service           # service/stream
-            responseType: Singleton # service response type
-        -   name: "stock-info"
-            subject: "stock-info"
-            type: stream
-```
-
-```yaml
-
-AccountImport:
-    name: account-a-eu-orders         # unique name
-    namespace: namespace-b
-    accountName: Account B            # parent account, expected to be in same namespace
-    exportRef: # reference to the export this import wants to consume
-        name: orders-and-stock-info   # must match the export name
-        namespace: namespace-a
-    exportAccountName: Account A      # expected exporting account, used for validation
-    ruleBindings:
-        -   name: "orders eu-west-1"        # human-readable name
-            subject: "orders.eu-west-1.>"   # must match or be a subset of an export rule subject
-            type: service                   # must match the export rule type
-            localSubject: "eu.orders.>"     # optional local subject 
-```
-
-In this example:
-
-* Account A says: "I export these subjects and I allow any account to import them"
-* Account B says: "I want to import only eu-west-1 related orders from the export, and rename the local subject."
-* NAuth only renders final account JWT on the export account when `AccountExport` is ready
-* NAuth only renders final account JWT on the import account when `AccountImport` is ready
-
-#### How validation and readiness work
-
-This option introduces a fail-closed readiness model.
-
-`AccountExport` validates the exporter-owned side of the contract.
-`AccountImport` validates the importer-owned side of the contract.
-
-Only ready `AccountExport` and ready `AccountImport` resources contribute to the final rendered account JWT.
-
-This makes partial failures easier to reason about:
-
-* if one import is invalid, that import becomes `Ready=False`
-* any invalid rule makes the entire resource `Ready=False`
-* other valid imports and exports can still remain usable
-* the final account state only includes resources that are ready
-
-For example, if an import references a subject that does not exist as whole or subset in the export, that import does
-not become active.
-
-#### How conflicts are handled
-
-Because multiple imports and exports may contribute to the final account state, the controller must resolve them
-deterministically.
-
-This includes:
-
-* deterministic ordering of imports and exports
-* conflict detection when subjects overlap
-* clear reporting when two resources cannot be merged safely
-
-To identify conflicts, we will use nats.io's JWT imports validation function.
-
-#### Benefits:
-
-* Imports and Exports can be created in any order.
-* Allows for exporting of group of related subjects, for example, all JetStream API subjects.
-* Open to future improvements such as restricted exports (handling activation tokens) and approval workflows.
-
-#### Drawbacks:
-
-* More complex controller logic to handle the relationships and validation
-
-#### Working Notes
-
-These documents are working documents and notes related to the options. They might be incomplete and are not meant to be
-part of the final ADR, but they are included here for reference.
-
-* [appendix: Reconcile flow](worklog/0005/option-4-appendix-reconcile-flow.md)
-* [appendix: Resource relationships and reconcile triggers](worklog/0005/option-4-appendix-resource-relationships.md)
-* [appendix: Future improvements and notes](worklog/0005/option-4-appendix-future-improvements.md)
-
 ## Decision
 
-Option 4 - Contract-based imports/exports
+* Extract import/export to separate CRDs
+* Deprecate the import and export fields in `Account` CRD.
+* Use `Option 4 - Contract-based imports/exports` as a target vision
+* First release must support what is supported today by inline imports and exports
+* `tokenReq` and `revocations` in export will be deferred, as these are not implemented today  
 
 ## Consequences
 
-TBD
+* Import and export CRDs can reconcile by themselves. 
+* Failing import and export CRDs will not block account reconciliation.

--- a/adr/worklog/0005/option-4-appendix-future-improvements.md
+++ b/adr/worklog/0005/option-4-appendix-future-improvements.md
@@ -1,0 +1,134 @@
+# Option 4 - Future improvements and Notes
+
+## How updates and drift are handled
+
+`AccountImport` binds to an `AccountExport` (`exportRef`) and asserts the expected exporting account
+(`exporterAccountRef`).
+
+`ruleBindings[].expected` declares optional invariants that the referenced export rule must satisfy.
+If any expected field does not match the resolved export rule, the `AccountImport` is not ready.
+
+`updatePolicy` does not affect validation semantics. It only controls whether the import automatically adopts upstream
+export changes that continue to satisfy the declared expectations.
+
+This means compatible upstream changes can be handled in two ways:
+
+* `automatic`: the import adopts the updated export state automatically
+* `manual`: drift is detected and surfaced, and the import stops advancing until the change is explicitly accepted
+
+This gives a clearer operational model for upstream changes without weakening validation.
+
+## Public and restricted exports and allow-lists
+
+Introducing restricted import requires import/export activation tokens to be implemented. This has its own complexity,
+and is therefore deferred to the future.
+
+Things to consider:
+
+* signing keys
+* signed tokens, one for each subject
+* token distribution and rotation
+
+```yaml
+AccountExport:
+    allowedAccountRefs: # only these accounts are allowed to import this export
+        -   name: Account B
+            namespace: namespace-b
+```
+
+Public exports are the default and do not require any additional fields.
+Any account can reference a public export.
+
+## Full example
+
+```yaml
+AccountExport:
+    name: jetstream-api
+    namespace: namespace-a
+    accountRef:
+        name: Account A           # expected to be in same namespace
+        namespace: namespace-a
+    access:
+        mode: restricted       # restricted = only allowed accounts can import, public = any account can import
+        allowedAccountRefs: # only needed if mode is restricted, otherwise ignored
+            -   name: Account B
+                namespace: namespace-b
+    rules:
+        -   name: info              # unique name for reference in import
+            subject: "$JS.API.INFO"
+            type: service
+            responseType: single
+        -   name: stream-info
+            subject: "$JS.API.STREAM.INFO.*"
+            type: service
+            responseType: single
+        -   name: with-extra-options
+            subject: "my.subject.>"
+            type: stream
+            options: # this is optional extra parameters (example struct below)
+                advertise: true
+                allowTrace: true  
+```
+
+`rules[].name` must be unique within the export and is used for reference in the import.
+
+```go
+package v1alpha2
+
+type AccountExportRule struct {
+    Name         string       `json:"name,omitempty"`
+    Subject      Subject      `json:"subject,omitempty"`
+    Type         ExportType   `json:"type,omitempty"`
+    ResponseType ResponseType `json:"responseType,omitempty"`
+
+    ExportOptions *ExportOptions `json:"options,omitempty"`
+}
+
+type ExportOptions struct {
+    Revocations          RevocationList   `json:"revocations,omitempty"`
+    AccountTokenPosition *uint            `json:"accountTokenPosition,omitempty"`
+    Advertise            *bool            `json:"advertise,omitempty"`
+    ResponseThreshold    *metav1.Duration `json:"responseThreshold,omitempty"`
+    AllowTrace           *bool            `json:"allowTrace,omitempty"`
+    Latency              *ServiceLatency  `json:"latency,omitempty"`
+}
+
+```
+
+And the corresponding import:
+
+```yaml
+AccountImport:
+    name: account-a-jetstream
+    namespace: namespace-b
+    accountRef:
+        name: Account B
+        namespace: namespace-b
+    exporterAccountRef:
+        name: Account A
+        namespace: namespace-a
+    exportRef:
+        name: jetstream-api
+        namespace: namespace-a
+    updatePolicy: automatic             # automatic (default) = advance status when export changes compatibly, 
+    # manual = detect drift and stop advancing until spec says to accept it
+    localSubjectPrefix: ext.account-a   # optional prefix to add to all imported subjects, for example, to avoid conflicts with local subjects
+    ruleBindings: # required, non-empty list
+        -   name: info                  # export rule name
+            expected: # validation only fields 
+                subject: "$JS.API.INFO"     # validate remote exported subject
+                type: service               # validate type   
+            importOptions:
+                localSubject: "ext.account-a.$JS.API.INFO"    # overrides local subject for this exported rule
+                allowTrace: true            # optional override, allowing trace
+        -   name: stream-info
+        -   name: with-extra-options
+
+```
+
+**Imported subject resolution order**
+
+* If localSubject is defined, the imported subject is the localSubject.
+* If localSubjectPrefix is defined, the imported subject is localSubjectPrefix + "." + export subject.
+* Otherwise, the imported subject is the same as the export subject.
+

--- a/adr/worklog/0005/option-4-appendix-reconcile-flow.md
+++ b/adr/worklog/0005/option-4-appendix-reconcile-flow.md
@@ -1,0 +1,79 @@
+# Option 4 - Reconcile flow
+
+`Account` remains the only resource that renders the final account JWT.
+`AccountExport` and `AccountImport` reconcile their own readiness and status, and contribute validated inputs to the
+owning account.
+
+```mermaid
+flowchart TD
+    A0([Account changed])
+    E0([AccountExport changed])
+    I0([AccountImport changed])
+    A0 --> AC1[Reconcile Account]
+
+    subgraph Export_Reconcile[AccountExport reconcile]
+        E0 --> E1[Load AccountExport]
+        E1 --> E2[Load exporting Account from accountRef]
+        E2 --> E3{Exporting Account exists?}
+        E3 -- No --> E4[Set Ready=False<br/>record missing dependency]
+        E4 --> E5[Enqueue exporting Account]
+        E3 -- Yes --> E6[Validate access block<br/>and rule set]
+        E6 --> E7{Valid?}
+        E7 -- No --> E4
+        E7 -- Yes --> E8[Publish Ready=True<br/>record resolved contract metadata]
+        E8 --> E5
+    end
+
+    subgraph Import_Reconcile[AccountImport reconcile]
+        I0 --> I1[Load AccountImport]
+        I1 --> I2[Load importing Account from accountRef]
+        I2 --> I3[Load referenced AccountExport from exportRef]
+        I3 --> I4[Verify AccountExport.spec.accountRef<br/>matches exporterAccountRef]
+        I4 --> I5[Verify importing Account is allowed<br/>by export access policy]
+        I5 --> I6[Resolve ruleBindings by name<br/>from export rules]
+        I6 --> I7[Validate ruleBindings.expected<br/>against referenced export rules]
+        I7 --> I8[Validate importOptions and resolve subject<br/>localSubject > localSubjectPrefix > export subject]
+        I8 --> I9[Check duplicates, collisions,<br/>and importer-side narrowing rules]
+        I9 --> I10{Dependency and contract valid?}
+        I10 -- No --> I11[Set Ready=False<br/>record validation or dependency error]
+        I11 --> I12[Enqueue importing Account]
+        I10 -- Yes --> I13[Compare resolved import state<br/>with current export state]
+        I13 --> I14{Compatible upstream change detected?}
+        I14 -- No --> I15[Set Ready=True<br/>clear Drifted condition]
+        I14 -- Yes --> I16{updatePolicy}
+        I16 -- automatic --> I17[Adopt new resolved state<br/>set Ready=True]
+        I16 -- manual --> I18[Set Drifted=True and Ready=False<br/>do not adopt changed state]
+        I15 --> I12
+        I17 --> I12
+        I18 --> I12
+    end
+
+    E5 --> AC1
+    I12 --> AC1
+
+    subgraph Account_Reconcile[Account reconcile]
+        AC1 --> AC2[Validate base Account spec]
+        AC2 --> AC3[List AccountExports with matching accountRef]
+        AC3 --> AC4[List AccountImports with matching accountRef]
+        AC4 --> AC5[Include only Ready AccountExports<br/>and Ready AccountImports]
+        AC5 --> AC6[Sort deterministically<br/>namespace, name, rule name]
+        AC6 --> AC7[Merge base account + export rules + resolved imports]
+        AC7 --> AC8{Conflicts after merge?}
+        AC8 -- Yes --> AC9[Set Account NotReady/Degraded<br/>record conflict details]
+        AC8 -- No --> AC10[Render final Account JWT]
+        AC10 --> AC11[Persist Secret and update status]
+        AC11 --> AC12[Set Account Ready=True]
+    end
+```
+
+**Notes on the flow**
+
+* `AccountExport` validates the exporter-owned contract: exporting account existence, access policy, unique rule names,
+  valid rule definitions, and any export-only options.
+* `AccountImport` validates the importer-owned binding: importing account existence, referenced export existence,
+  `exporterAccountRef` match, allow-list membership, referenced rule existence, `ruleBindings[].expected`,
+  importer-local `importOptions`, and subject/collision rules.
+* `updatePolicy` only applies after the contract is otherwise valid. It does not weaken validation.
+* `manual` means compatible upstream export changes are detected and surfaced as drift instead of being adopted.
+  Until the import is updated to accept that change, it does not contribute to the rendered account JWT.
+

--- a/adr/worklog/0005/option-4-appendix-resource-relationships.md
+++ b/adr/worklog/0005/option-4-appendix-resource-relationships.md
@@ -1,0 +1,108 @@
+# Option 4 - Resource relationships and reconcile triggers
+
+An effective import/export contract in Option 4 involves four primary resources:
+
+1. the exporting `Account`
+2. the `AccountExport` owned by that account
+3. the importing `Account`
+4. the `AccountImport` owned by that account
+
+`AccountExport` represents an offer owned by the exporting account.
+`AccountImport` represents a binding owned by the importing account.
+The binding is only effective when both accounts exist, the referenced export exists, the referenced export belongs to
+the expected exporting account, and the export allows the importing account.
+
+```mermaid
+flowchart LR
+    EA[Exporting Account]
+    EX[AccountExport]
+    IA[Importing Account]
+    IM[AccountImport]
+    EA -->|owned via accountRef| EX
+    IA -->|owned via accountRef| IM
+    IM -->|references via exportRef| EX
+    IM -.->|asserts expected owner via exporterAccountRef| EA
+    EX -.->|allows via allowedAccountRefs| IA
+```
+
+**Readiness model**
+
+* `AccountExport` is `Ready` when:
+    * the exporting account exists
+    * the export spec is valid
+    * access policy is valid
+    * rule names are unique and all rules are valid
+* `AccountImport` is `Ready` when:
+    * the importing account exists
+    * the referenced export exists
+    * the export belongs to `exporterAccountRef`
+    * the importing account is allowed by the export
+    * every named `ruleBinding` resolves to an export rule
+    * every `ruleBindings[].expected` check passes
+    * `importOptions` are valid and do not broaden the export contract
+    * resolved local subjects are valid and non-conflicting
+    * no compatible upstream drift is waiting for manual acceptance
+
+This intentionally creates an asymmetry:
+
+* `AccountExport` is an offer and may exist without any import
+* `AccountImport` is a binding and depends on the export, the exporting account, and the importing account
+
+**Reconcile trigger model**
+
+Changes to any related resource must enqueue reconciliation of dependents. `Account` remains the only resource that
+renders the final JWT.
+
+```mermaid
+flowchart TD
+    EA0([Exporting Account changed])
+    EX0([AccountExport changed])
+    IA0([Importing Account changed])
+    IM0([AccountImport changed])
+    EA0 --> EXR1[Reconcile AccountExports with matching accountRef]
+    EA0 --> IMR1[Reconcile AccountImports whose export resolves through those AccountExports]
+    EA0 --> EAR[Reconcile exporting Account]
+    EX0 --> EXR2[Reconcile changed AccountExport]
+    EX0 --> IMR2[Reconcile AccountImports referencing this exportRef]
+    EX0 --> EAR2[Reconcile exporting Account]
+    IA0 --> IMR3[Reconcile AccountImports with matching accountRef]
+    IA0 --> IAR[Reconcile importing Account]
+    IM0 --> IMR4[Reconcile changed AccountImport]
+    IM0 --> IAR2[Reconcile importing Account]
+```
+
+**Expected behavior by changed resource**
+
+* **Exporting `Account` changed**
+    * reconcile `AccountExport` resources that reference it via `accountRef`
+    * reconcile `AccountImport` resources whose referenced exports are owned by that account
+    * reconcile that exporting `Account`
+
+* **`AccountExport` changed**
+    * reconcile that `AccountExport`
+    * reconcile all `AccountImport` resources that reference it via `exportRef`
+    * reconcile the exporting `Account`
+
+* **Importing `Account` changed**
+    * reconcile `AccountImport` resources that reference it via `accountRef`
+    * reconcile that importing `Account`
+
+* **`AccountImport` changed**
+    * reconcile that `AccountImport`
+    * reconcile the importing `Account`
+
+**Implementation hint**
+
+The controller will typically need field indexes for at least:
+
+* `AccountExport.spec.accountRef`
+* `AccountImport.spec.accountRef`
+* `AccountImport.spec.exportRef`
+
+This keeps the dependent requeues above practical without requiring broad scans.
+
+**Operational rule**
+
+Only ready `AccountExport` and ready `AccountImport` resources contribute to the final rendered account JWT.
+If any required related resource is deleted, becomes invalid, or drifts under `updatePolicy: manual`, the effective
+contract fails closed and must be excluded from the rendered account state until it becomes ready again.

--- a/adr/worklog/0005/options.md
+++ b/adr/worklog/0005/options.md
@@ -51,6 +51,7 @@ AccountImportExport A3:
 
 - Invites users to define both Export and Import in the same file, even if that's not desired.
 - It's harder to present the data in a good way in `kubectl` and `k9s` as the columns might differ.
+- Needs to handle partial failures.
 
 ## Option 2 - Separate AccountImport and AccountExport CRDs
 
@@ -217,6 +218,7 @@ To identify conflicts, we will use nats.io's JWT imports validation function.
 ### Drawbacks:
 
 * More complex controller logic to handle the relationships and validation
+* Needs to handle partial failures.
 
 ### Working Notes
 

--- a/adr/worklog/0005/options.md
+++ b/adr/worklog/0005/options.md
@@ -1,0 +1,228 @@
+# Options
+
+## Option 1 - AccountImportExport CRD
+
+Imports and exports are simply moved to a separate CRD, but they are still managed together. The new CRD has a reference
+to the account. This option is in essence the same as the current state, but with imports and exports moved to a
+separate CRD.
+
+```yaml
+# simplified example of the new CRD structure
+AccountImportExport A:
+    account: A
+    imports:
+        - foo.> from Account B
+        - bar.> from Account C
+    exports:
+        - def.> to Account X
+
+AccountImportExport B:
+    account: B
+    exports:
+        - foo.> to Account A
+
+AccountImportExport C:
+    account: C
+    exports:
+        - bar.> to Account A
+
+# alternative for A, can be used if it makes sense to split imports/exports
+AccountImportExport A1:
+    account: A
+    imports:
+        - foo.> from Account B
+
+AccountImportExport A2:
+    account: A
+    imports:
+        - bar.> from Account C
+
+AccountImportExport A3:
+    account: A
+    exports:
+        - def.> to Account X
+```
+
+### Benefits
+
+- Allows for easiest migration of the existing imports and exports to the new CRD.
+
+### Drawbacks
+
+- Invites users to define both Export and Import in the same file, even if that's not desired.
+- It's harder to present the data in a good way in `kubectl` and `k9s` as the columns might differ.
+
+## Option 2 - Separate AccountImport and AccountExport CRDs
+
+Same as Option 1 but with separate CRDs for imports and exports.
+Better for separating import and export specific fields and concerns.
+For example `export` has `TokenReq (bool)` field, while `import` has `Token` field.
+
+```yaml
+# simplified example of the new CRD structure
+AccountImport A:
+    account: A
+    imports:
+        - foo.> from Account B
+        - bar.> from Account C
+
+AccountExport A:
+    account: A
+    exports:
+        - def.> to Account X
+```
+
+### Benefits
+
+- Allows for configuration that affects all listed subjects.
+- Allows for configuration of individual subjects.
+- Less verbose but still allows user to define one import or export per AccountXport if so desired.
+- Allows grouping of related imports and exports, for example, all jetstream related API topics can be grouped together
+  in one CRD.
+    - And as a consequence, it is "all or nothing" for that group, which makes sense when it comes to jetstream.
+
+### Drawbacks
+
+- Needs to handle partial failures.
+
+## Option 3 - One import/export per import/export CRD
+
+Each import and export is represented as a separate CRD.
+This allows for better granularity and easier management of individual imports and exports,
+but it can lead to a large number of CRDs if there are many imports and exports.
+
+```yaml
+# simplified example of the new CRD structure
+AccountImport A1:
+    account: A
+    subject: foo.>
+    fromAccount: B
+
+AccountImport A2:
+    account: A
+    subject: bar.>
+    fromAccount: C
+
+AccountExport A3:
+    account: A
+    subject: def.>
+    toAccount: X
+```
+
+### Benefits:
+
+- Very granular validation, i.e. an entire group of rules wouldn't be left out just because one of the subjects are
+  conflicting or invalid.
+
+### Drawbacks:
+
+- Extremely verbose, at least if we think about import/export for JetStream stuff.
+
+## Option 4 - Contract-based imports/exports
+
+`AccountExport` represents an explicit contract owned by the exporting account.
+`AccountImport` represents an import binding owned by the importing account and references a specific `AccountExport`.
+
+Instead of only defining raw import/export fragments, this option models the relationship between importer and exporter
+as first-class resources. The `Account` CRD remains responsible for reconciling the final account JWT from all ready
+import/export resources belonging to the account.
+
+The key idea is that both sides describe their own part of the relationship:
+
+* the exporter publishes what it is willing to expose
+* the importer declares which export it wants to consume
+
+This makes the relationship explicit, easier to validate, and easier to reason about than embedding raw import/export
+fragments directly in `Account`.
+
+**Example**
+
+```yaml
+AccountExport:
+    name: orders-and-stock-info     # unique name, referenced in imports
+    namespace: namespace-a
+    accountName: Account A          # parent account, expected to be in same namespace
+    rules:
+        -   name: "orders"          # human-readable name
+            subject: "orders.>"     # example: orders.<region>.<id> (orders.eu-west-1.12345) 
+            type: service           # service/stream
+            responseType: Singleton # service response type
+        -   name: "stock-info"
+            subject: "stock-info"
+            type: stream
+```
+
+```yaml
+
+AccountImport:
+    name: account-a-eu-orders         # unique name
+    namespace: namespace-b
+    accountName: Account B            # parent account, expected to be in same namespace
+    exportRef: # reference to the export this import wants to consume
+        name: orders-and-stock-info   # must match the export name
+        namespace: namespace-a
+    exportAccountName: Account A      # expected exporting account, used for validation
+    ruleBindings:
+        -   name: "orders eu-west-1"        # human-readable name
+            subject: "orders.eu-west-1.>"   # must match or be a subset of an export rule subject
+            type: service                   # must match the export rule type
+            localSubject: "eu.orders.>"     # optional local subject 
+```
+
+In this example:
+
+* Account A says: "I export these subjects and I allow any account to import them"
+* Account B says: "I want to import only eu-west-1 related orders from the export, and rename the local subject."
+* NAuth only renders final account JWT on the export account when `AccountExport` is ready
+* NAuth only renders final account JWT on the import account when `AccountImport` is ready
+
+### How validation and readiness work
+
+This option introduces a fail-closed readiness model.
+
+`AccountExport` validates the exporter-owned side of the contract.
+`AccountImport` validates the importer-owned side of the contract.
+
+Only ready `AccountExport` and ready `AccountImport` resources contribute to the final rendered account JWT.
+
+This makes partial failures easier to reason about:
+
+* if one import is invalid, that import becomes `Ready=False`
+* any invalid rule makes the entire resource `Ready=False`
+* other valid imports and exports can still remain usable
+* the final account state only includes resources that are ready
+
+For example, if an import references a subject that does not exist as whole or subset in the export, that import does
+not become active.
+
+### How conflicts are handled
+
+Because multiple imports and exports may contribute to the final account state, the controller must resolve them
+deterministically.
+
+This includes:
+
+* deterministic ordering of imports and exports
+* conflict detection when subjects overlap
+* clear reporting when two resources cannot be merged safely
+
+To identify conflicts, we will use nats.io's JWT imports validation function.
+
+### Benefits:
+
+* Imports and Exports can be created in any order.
+* Allows for exporting of group of related subjects, for example, all JetStream API subjects.
+* Open to future improvements such as restricted exports (handling activation tokens) and approval workflows.
+
+### Drawbacks:
+
+* More complex controller logic to handle the relationships and validation
+
+### Working Notes
+
+These documents are working documents and notes related to the options. They might be incomplete and are not meant to be
+part of the final ADR, but they are included here for reference.
+
+* [appendix: Reconcile flow](./option-4-appendix-reconcile-flow.md)
+* [appendix: Resource relationships and reconcile triggers](./option-4-appendix-resource-relationships.md)
+* [appendix: Future improvements and notes](./option-4-appendix-future-improvements.md)


### PR DESCRIPTION
## Problem statement

The `Account` CRD is currently used to manage everything related to the account, which includes limits, imports and
exports. If any of these settings are broken, especially imports and exports, it can affect the entire account.

Splitting the import and export CRDs from the Account CRD would allow for better separation of concerns.

## Files

* `0005-split-import-and-export-crds-from-account-crd.md` - The ADR itself
* `worklog/0005/` - Contains notes and ideas during creation of ADR. Not up to date, treat them as notes. 

Signed-off-by: Henri Ropponen <henriropponen@gmail.com>
