### PR TITLE
feat: reconcile accounts when referenced NatsCluster changes

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -27,11 +27,14 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -147,6 +150,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Nothing has changed
 	if natsAccount.Status.ObservedGeneration == natsAccount.Generation && natsAccount.Status.OperatorVersion == operatorVersion {
+		// FIXME: Revise statement as we are now dependant on external (changeable) resources, like NatsCluster
 		return ctrl.Result{}, nil
 	}
 
@@ -175,6 +179,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// RECONCILE ACCOUNT
 	var result *domain.AccountResult
 
+	_, _ = r.getLabelNatsClusterRef(natsAccount) // FIXME: Supply the previous NatsClusterRef to the manager
 	if managementPolicy == k8s.LabelManagementPolicyObserveValue {
 		result, err = r.manager.Import(ctx, natsAccount)
 		if err != nil {
@@ -193,8 +198,10 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	natsAccount.Labels[k8s.LabelAccountID] = result.AccountID
 	natsAccount.Labels[k8s.LabelAccountSignedBy] = result.AccountSignedBy
+	r.setLabelNatsClusterRefLabel(result, natsAccount)
 
 	// UPDATE ACCOUNT STATUS
+	natsAccount.Status.Claims = v1alpha1.AccountClaims{}
 	if result.Claims != nil {
 		natsAccount.Status.Claims = *result.Claims
 	}
@@ -220,14 +227,75 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return r.reporter.status(ctx, natsAccount)
 }
 
+func (r *AccountReconciler) getLabelNatsClusterRef(natsAccount *v1alpha1.Account) (*domain.NamespacedName, error) {
+	return domain.ParseNamespacedName(natsAccount.Labels[LabelAccountNatsClusterRef])
+}
+
+func (r *AccountReconciler) setLabelNatsClusterRefLabel(result *domain.AccountResult, natsAccount *v1alpha1.Account) {
+	var natsClusterRef string
+	if result.NatsClusterRef != nil {
+		natsClusterRef = result.NatsClusterRef.Name
+		natsAccount.Labels[LabelAccountNatsClusterRef] = result.NatsClusterRef.String()
+	}
+	if natsClusterRef == "" {
+		natsClusterRef = LabelValueUnknown
+	}
+	natsAccount.Labels[LabelAccountNatsClusterRef] = natsClusterRef
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Account{}).
 		Named("account").
+		Watches(
+			&v1alpha1.NatsCluster{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForNatsCluster),
+		).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).
 		Complete(r)
+}
+
+func (r *AccountReconciler) requestsForNatsCluster(ctx context.Context, obj client.Object) []reconcile.Request {
+	natsCluster, ok := obj.(*v1alpha1.NatsCluster)
+	if !ok {
+		return nil
+	}
+	natsClusterRef := domain.NewNamespacedName(natsCluster.Namespace, natsCluster.Name)
+
+	if err := natsClusterRef.Validate(); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to parse NamespacedName from NatsCluster reference",
+			"namespace", natsCluster.Namespace,
+			"name", natsCluster.Name)
+		return []reconcile.Request{}
+	}
+
+	var requests []reconcile.Request
+	var accounts v1alpha1.AccountList
+	if err := r.List(ctx, &accounts, client.MatchingLabels{LabelAccountNatsClusterRef: natsClusterRef.String()}); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list accounts labelled with NatsCluster", "natsCluster", natsClusterRef)
+		return nil
+	}
+	for _, account := range accounts.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: account.Namespace,
+			Name:      account.Name,
+		}})
+	}
+
+	if err := r.List(ctx, &accounts, client.MatchingLabels{LabelAccountNatsClusterRef: LabelValueUnknown}); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list accounts labelled with unknown NatsCluster")
+		return nil
+	}
+	for _, account := range accounts.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: account.Namespace,
+			Name:      account.Name,
+		}})
+	}
+
+	return requests
 }

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -101,6 +101,7 @@ func (t *AccountControllerTestSuite) TearDownTest() {
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAccount() {
 	// Given
 	mockResult := &domain.AccountResult{
+		// FIXME: Consider NatsClusterRef
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},
@@ -151,6 +152,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdat
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldNotDeleteObservedAccount() {
 	// Given
 	mockResult := &domain.AccountResult{
+		// FIXME: Consider NatsClusterRef
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},
@@ -193,6 +195,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldNotDeleteObservedAccou
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldDeleteAccountMarkedForDeletion() {
 	// Given
 	mockResult := &domain.AccountResult{
+		// FIXME: Consider NatsClusterRef
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},
@@ -234,6 +237,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails()
 	// Given
 	deletionErr := fmt.Errorf("Unable to delete account")
 	mockResult := &domain.AccountResult{
+		// FIXME: Consider NatsClusterRef
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},
@@ -276,6 +280,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails()
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldImportObservedAccount() {
 	// Given
 	mockResult := &domain.AccountResult{
+		// FIXME: Consider NatsClusterRef
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},
@@ -301,6 +306,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldImportObservedAccount(
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVersionChanges() {
 	// Given
 	mockResult := &domain.AccountResult{
+		// FIXME: Consider NatsClusterRef
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -15,3 +15,8 @@ const (
 const (
 	EnvOperatorVersion = "OPERATOR_VERSION"
 )
+
+const (
+	LabelAccountNatsClusterRef = "account.nauth.io/nats-cluster-ref"
+	LabelValueUnknown          = "UNKNOWN"
+)

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -92,6 +92,7 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, state *v1alpha1.Acc
 	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, accountRef, fixedAccountID)
 	if fixedAccountID != "" {
 		// Update
+		// FIXME: Fail (or handle) if NatsCluster has changed, to prevent orphaned Account JWTs in other NATS cluster.
 		if !found {
 			return nil, fmt.Errorf("account secrets not found for account %s", fixedAccountID)
 		}
@@ -161,6 +162,8 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, state *v1alpha1.Acc
 		return nil, fmt.Errorf("failed to sign account jwt: %w", err)
 	}
 
+	// FIXME: Hash signedJwt and check with State + cluster
+
 	sysConn, err := a.natsSysClient.Connect(cluster.NatsURL, cluster.SystemAdminCreds)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to NATS cluster: %w", err)
@@ -176,6 +179,7 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, state *v1alpha1.Acc
 	return &domain.AccountResult{
 		AccountID:       accountPublicKey,
 		AccountSignedBy: operatorSigningPublicKey,
+		NatsClusterRef:  &cluster.Reference,
 		Claims:          &nauthClaims,
 	}, nil
 }
@@ -248,6 +252,7 @@ func (a *AccountManager) Import(ctx context.Context, state *v1alpha1.Account) (*
 	return &domain.AccountResult{
 		AccountID:       accountID,
 		AccountSignedBy: operatorSigningPublicKey,
+		NatsClusterRef:  &cluster.Reference,
 		Claims:          &nauthClaims,
 	}, nil
 }
@@ -262,6 +267,7 @@ func (a *AccountManager) Delete(ctx context.Context, state *v1alpha1.Account) er
 	if err != nil {
 		return fmt.Errorf("failed to resolve cluster target: %w", err)
 	}
+	// FIXME: Fail (or handle) if NatsCluster has changed, to prevent orphaned Account JWTs in other NATS cluster.
 
 	operatorPublicKey, err := cluster.OperatorSigningKey.PublicKey()
 	if err != nil {

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -13,6 +13,7 @@ import (
 )
 
 type clusterTarget struct {
+	Reference          domain.NamespacedName
 	NatsURL            string
 	SystemAdminCreds   domain.NatsUserCreds
 	OperatorSigningKey domain.NatsOperatorSigningKey
@@ -31,8 +32,14 @@ func (c *clusterTarget) validate() error {
 	return nil
 }
 
-func newClusterTarget(natsURL string, systemAdminCreds domain.NatsUserCreds, operatorSigningKey domain.NatsOperatorSigningKey) (*clusterTarget, error) {
+func newClusterTarget(
+	reference domain.NamespacedName,
+	natsURL string,
+	systemAdminCreds domain.NatsUserCreds,
+	operatorSigningKey domain.NatsOperatorSigningKey,
+) (*clusterTarget, error) {
 	result := &clusterTarget{
+		Reference:          reference,
 		NatsURL:            natsURL,
 		SystemAdminCreds:   systemAdminCreds,
 		OperatorSigningKey: operatorSigningKey,
@@ -191,7 +198,7 @@ func (r *ClusterManager) resolveTargetFromCluster(ctx context.Context, cluster *
 	if err != nil {
 		return nil, fmt.Errorf("resolve operator signing key for NatsCluster %s: %w", clusterRef, err)
 	}
-	target, err := newClusterTarget(natsURL, *sysAdminCreds, opSigningKey)
+	target, err := newClusterTarget(clusterRef, natsURL, *sysAdminCreds, opSigningKey)
 	if err != nil {
 		return nil, fmt.Errorf("create cluster target for NatsCluster %s: %w", clusterRef, err)
 	}

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -80,6 +80,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenOperatorClust
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
 	require.Equal(t.T(), &clusterTarget{
+		Reference:          domain.NewNamespacedName("my-namespace", "my-cluster"),
 		NatsURL:            "nats://my-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,
@@ -120,6 +121,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
 	require.Equal(t.T(), &clusterTarget{
+		Reference:          domain.NewNamespacedName("ac-namespace", "ac-cluster"),
 		NatsURL:            "nats://ac-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,
@@ -160,6 +162,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
 	require.Equal(t.T(), &clusterTarget{
+		Reference:          domain.NewNamespacedName("my-namespace", "my-cluster"),
 		NatsURL:            "nats://my-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,
@@ -204,6 +207,7 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountCluste
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
 	require.Equal(t.T(), &clusterTarget{
+		Reference:          domain.NewNamespacedName("ac-namespace", "ac-cluster"),
 		NatsURL:            "nats://ac-cluster:4222",
 		SystemAdminCreds:   sauCreds,
 		OperatorSigningKey: opSignKey,

--- a/internal/domain/k8s.go
+++ b/internal/domain/k8s.go
@@ -37,6 +37,18 @@ func NewNamespacedName(namespace, name string) NamespacedName {
 	return r
 }
 
+func ParseNamespacedName(namespacedName string) (*NamespacedName, error) {
+	parts := strings.SplitN(namespacedName, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid namespaced name %q: expected format <namespace>/<name>", namespacedName)
+	}
+	result := &NamespacedName{
+		Namespace: parts[0],
+		Name:      parts[1],
+	}
+	return result, result.Validate()
+}
+
 func (n NamespacedName) GetNamespace() Namespace {
 	return Namespace(n.Namespace)
 }

--- a/internal/domain/nauth.go
+++ b/internal/domain/nauth.go
@@ -5,5 +5,6 @@ import "github.com/WirelessCar/nauth/api/v1alpha1"
 type AccountResult struct {
 	AccountID       string
 	AccountSignedBy string
+	NatsClusterRef  *NamespacedName
 	Claims          *v1alpha1.AccountClaims
 }


### PR DESCRIPTION
## DRAFT NOTE
This is a draft PR with a bunch of `FIXME`s that needs to be handled and revised before this can be set to Ready.

## Summary

Reconcile `Account` resources when their related `NatsCluster` changes.

## Why

Accounts depend on cluster-derived state such as the cluster URL, system account credentials, and operator signing key. Those inputs can change even when the `Account` spec does not, so account reconciliation must also react to related `NatsCluster` updates.

## Notes

This change tracks the resolved `NatsCluster` on the account state and labels, and wires the account controller to enqueue affected accounts when a `NatsCluster` changes.

