### PR TITLE
ci: bump Pages actions for GitHub Actions node20 deprecation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,7 +34,7 @@ jobs:
           bun-version: latest
       
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       
       - name: Install dependencies
         working-directory: ./www
@@ -45,7 +45,7 @@ jobs:
         run: bun run build
       
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./www/dist/
 


### PR DESCRIPTION
## Summary

This PR updates the GitHub Pages workflow in response to GitHub Actions' Node.js 20 deprecation warning.

GitHub now warns that Node.js 20-based actions are deprecated, will be forced onto Node.js 24 by default starting June 2, 2026, and will be removed from runners on September 16, 2026. This branch updates the Pages workflow to the latest released action versions where that is straightforward, while explicitly keeping the standard Pages upload flow intact.

## Changes

- bump actions/configure-pages from v4 to v6
- bump actions/upload-pages-artifact from v3 to v4

## Why Not Replace upload-pages-artifact?

actions/upload-pages-artifact@v4 still depends on actions/upload-artifact@v4.6.2, which is the source of the remaining Node.js 20 warning.

Upstream is already tracking that here:

- https://github.com/actions/upload-pages-artifact/issues/138

This PR intentionally does not replace upload-pages-artifact with a custom tar/upload workaround. The goal is to:

- stay on the standard GitHub Pages workflow
- keep the workflow simple
- wait for an upstream fix and release instead of carrying local workaround logic

## Expected Result

After this PR:

- the workflow uses the latest standard Pages actions currently available for this setup
- the configure-pages warning should be addressed
- the upload-pages-artifact warning may still remain until upstream resolves issue #138

## Validation

This is a workflow-only change. No local test run was performed.

