### PR TITLE
feat: bind AccountExport CR to first found Account ID

### DIFF
--- a/api/v1alpha1/account_export_types.go
+++ b/api/v1alpha1/account_export_types.go
@@ -74,6 +74,9 @@ type AccountExportRule struct {
 
 // AccountExportStatus defines the observed state of AccountExport.
 type AccountExportStatus struct {
+	// AccountID is the ID of the account that this export is bound to.
+	// +optional
+	AccountID string `json:"accountID,omitempty"`
 	// Normalized claim for account to use
 	// +optional
 	Claim *AccountExportClaim `json:"claim,omitempty"`

--- a/charts/nauth-crds/crds/nauth.io_accountexports.yaml
+++ b/charts/nauth-crds/crds/nauth.io_accountexports.yaml
@@ -113,6 +113,10 @@ spec:
           status:
             description: AccountExportStatus defines the observed state of AccountExport.
             properties:
+              accountID:
+                description: AccountID is the ID of the account that this export is
+                  bound to.
+                type: string
               claim:
                 description: Normalized claim for account to use
                 properties:

--- a/charts/nauth/resources/crds/nauth.io_accountexports.yaml
+++ b/charts/nauth/resources/crds/nauth.io_accountexports.yaml
@@ -113,6 +113,10 @@ spec:
           status:
             description: AccountExportStatus defines the observed state of AccountExport.
             properties:
+              accountID:
+                description: AccountID is the ID of the account that this export is
+                  bound to.
+                type: string
               claim:
                 description: Normalized claim for account to use
                 properties:

--- a/examples/nauth/manifests/scenarios/account-export/accountexport.yaml
+++ b/examples/nauth/manifests/scenarios/account-export/accountexport.yaml
@@ -19,6 +19,17 @@ spec:
 
 ---
 apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-other-account
+  namespace: account-export-test
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+
+---
+apiVersion: nauth.io/v1alpha1
 kind: AccountExport
 metadata:
   name: my-account-export

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -90,9 +90,9 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if !natsAccount.DeletionTimestamp.IsZero() {
 		// The account is being deleted
 		meta.SetStatusCondition(&natsAccount.Status.Conditions, metav1.Condition{
-			Type:    controllerTypeReady,
+			Type:    conditionTypeReady,
 			Status:  metav1.ConditionFalse,
-			Reason:  controllerReasonReconciling,
+			Reason:  conditionReasonReconciling,
 			Message: "Deleting account",
 		})
 
@@ -117,7 +117,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			)
 		}
 
-		if controllerutil.ContainsFinalizer(natsAccount, controllerAccountFinalizer) {
+		if controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
 			if managementPolicy != v1alpha1.AccountManagementPolicyObserve {
 				if err := r.manager.Delete(ctx, natsAccount); err != nil {
 					return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to delete account: %w", err))
@@ -125,7 +125,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			// remove our finalizer from the list and update it.
-			controllerutil.RemoveFinalizer(natsAccount, controllerAccountFinalizer)
+			controllerutil.RemoveFinalizer(natsAccount, finalizerAccount)
 			if err := r.Update(ctx, natsAccount); err != nil {
 				log.Info("failed to remove finalizer", "name", natsAccount.Name, "error", err)
 				return ctrl.Result{}, err
@@ -135,7 +135,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	operatorVersion := os.Getenv(EnvOperatorVersion)
+	operatorVersion := os.Getenv(envOperatorVersion)
 
 	// Nothing has changed
 	if natsAccount.Status.ObservedGeneration == natsAccount.Generation && natsAccount.Status.OperatorVersion == operatorVersion {
@@ -145,8 +145,8 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// RECONCILE ACCOUNT - Set status & base properties
 
 	// Add finalizer if not present
-	if !controllerutil.ContainsFinalizer(natsAccount, controllerAccountFinalizer) {
-		controllerutil.AddFinalizer(natsAccount, controllerAccountFinalizer)
+	if !controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
+		controllerutil.AddFinalizer(natsAccount, finalizerAccount)
 		if err := r.Update(ctx, natsAccount); err != nil {
 			log.Info("Failed to add finalizer", "name", natsAccount.Name, "error", err)
 			return ctrl.Result{}, err
@@ -154,9 +154,9 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	meta.SetStatusCondition(&natsAccount.Status.Conditions, metav1.Condition{
-		Type:    controllerTypeReady,
+		Type:    conditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  controllerReasonReconciling,
+		Reason:  conditionReasonReconciling,
 		Message: "Reconciling account",
 	})
 	if err := r.Status().Update(ctx, natsAccount); err != nil {

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -76,10 +76,15 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	accountRef := domain.NewNamespacedName(state.Namespace, state.Spec.AccountName)
 	account, err := r.accountReader.Get(ctx, accountRef)
 	if err != nil {
-		statusWrapper.setAccountFoundFalse(err)
+		statusWrapper.setBoundToAccountNotFound(err)
 	} else {
 		accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
-		statusWrapper.setAccountFound(accountID)
+		boundAccountID := state.Status.AccountID
+		if boundAccountID != "" && boundAccountID != accountID {
+			statusWrapper.setBoundToAccountConflict(boundAccountID, accountID)
+		} else {
+			statusWrapper.setBoundToAccountOK(accountID)
+		}
 	}
 
 	claims, err := r.manager.CreateClaim(ctx, state)

--- a/internal/adapter/inbound/controller/account_export_status.go
+++ b/internal/adapter/inbound/controller/account_export_status.go
@@ -8,12 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	accountExportConditionTypeBoundToAccount   = "BoundToAccount"
-	accountExportConditionTypeValidRules       = "ValidRules"
-	accountExportConditionTypeAdoptedByAccount = "AdoptedByAccount"
-)
-
 type accountExportStatus struct {
 	accountExport *v1alpha1.AccountExport
 	failed        error
@@ -22,9 +16,9 @@ type accountExportStatus struct {
 func (s *accountExportStatus) setBoundToAccountOK(accountID string) {
 	s.accountExport.Status.AccountID = accountID
 	c := &metav1.Condition{
-		Type:               accountExportConditionTypeBoundToAccount,
+		Type:               conditionTypeBoundToAccount,
 		Status:             metav1.ConditionTrue,
-		Reason:             controllerReasonOK,
+		Reason:             conditionReasonOK,
 		Message:            fmt.Sprintf("Account ID: %s", accountID),
 		ObservedGeneration: s.accountExport.Generation,
 	}
@@ -34,7 +28,7 @@ func (s *accountExportStatus) setBoundToAccountOK(accountID string) {
 
 func (s *accountExportStatus) setBoundToAccountNotFound(err error) {
 	c := &metav1.Condition{
-		Type:               accountExportConditionTypeBoundToAccount,
+		Type:               conditionTypeBoundToAccount,
 		Status:             metav1.ConditionFalse,
 		Reason:             string(metav1.StatusReasonNotFound),
 		Message:            err.Error(),
@@ -46,9 +40,9 @@ func (s *accountExportStatus) setBoundToAccountNotFound(err error) {
 
 func (s *accountExportStatus) setBoundToAccountConflict(boundAccountID string, newAccountID string) {
 	c := &metav1.Condition{
-		Type:               accountExportConditionTypeBoundToAccount,
+		Type:               conditionTypeBoundToAccount,
 		Status:             metav1.ConditionFalse,
-		Reason:             string(metav1.StatusReasonConflict),
+		Reason:             conditionReasonConflict,
 		Message:            fmt.Sprintf("Account ID conflict: previously bound to %s, now found %s", boundAccountID, newAccountID),
 		ObservedGeneration: s.accountExport.Generation,
 	}
@@ -63,9 +57,9 @@ func (s *accountExportStatus) setStatusValidRules(rules []v1alpha1.AccountExport
 	}
 
 	c := &metav1.Condition{
-		Type:               accountExportConditionTypeValidRules,
+		Type:               conditionTypeValidRules,
 		Status:             metav1.ConditionTrue,
-		Reason:             controllerReasonOK,
+		Reason:             conditionReasonOK,
 		ObservedGeneration: s.accountExport.Generation,
 	}
 	meta.SetStatusCondition(s.accountExport.GetConditions(), *c)
@@ -74,9 +68,9 @@ func (s *accountExportStatus) setStatusValidRules(rules []v1alpha1.AccountExport
 
 func (s *accountExportStatus) setStatusValidRulesFalse(err error) {
 	c := &metav1.Condition{
-		Type:               accountExportConditionTypeValidRules,
+		Type:               conditionTypeValidRules,
 		Status:             metav1.ConditionFalse,
-		Reason:             controllerReasonInvalid,
+		Reason:             conditionReasonInvalid,
 		Message:            err.Error(),
 		ObservedGeneration: s.accountExport.Generation,
 	}
@@ -86,7 +80,7 @@ func (s *accountExportStatus) setStatusValidRulesFalse(err error) {
 
 func (s *accountExportStatus) setAdoptedByAccount() {
 	c := &metav1.Condition{
-		Type:               accountExportConditionTypeAdoptedByAccount,
+		Type:               conditionTypeAdoptedByAccount,
 		Status:             metav1.ConditionFalse,
 		Reason:             "NotImplemented",
 		Message:            "Not Implemented",
@@ -103,24 +97,24 @@ func (s *accountExportStatus) setFailed(err error) {
 
 func (s *accountExportStatus) evaluateReadyCondition() {
 	readyCondition := metav1.Condition{
-		Type:               controllerTypeReady,
+		Type:               conditionTypeReady,
 		ObservedGeneration: s.accountExport.Generation,
 	}
 
 	if s.failed != nil {
-		readyCondition.Reason = controllerReasonErrored
+		readyCondition.Reason = conditionReasonErrored
 		readyCondition.Message = s.failed.Error()
 	} else {
 		if s.isReady([]string{
-			accountExportConditionTypeBoundToAccount,
-			accountExportConditionTypeValidRules,
-			accountExportConditionTypeAdoptedByAccount,
+			conditionTypeBoundToAccount,
+			conditionTypeValidRules,
+			conditionTypeAdoptedByAccount,
 		}) {
 			readyCondition.Status = metav1.ConditionTrue
-			readyCondition.Reason = "Ready"
+			readyCondition.Reason = conditionReasonReady
 		} else {
 			readyCondition.Status = metav1.ConditionFalse
-			readyCondition.Reason = "NotReady"
+			readyCondition.Reason = conditionReasonNotReady
 		}
 	}
 	meta.SetStatusCondition(s.accountExport.GetConditions(), readyCondition)

--- a/internal/adapter/inbound/controller/account_export_status.go
+++ b/internal/adapter/inbound/controller/account_export_status.go
@@ -8,16 +8,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	accountExportConditionTypeBoundToAccount   = "BoundToAccount"
+	accountExportConditionTypeValidRules       = "ValidRules"
+	accountExportConditionTypeAdoptedByAccount = "AdoptedByAccount"
+)
+
 type accountExportStatus struct {
 	accountExport *v1alpha1.AccountExport
 	failed        error
 }
 
-func (s *accountExportStatus) setAccountFound(accountID string) {
+func (s *accountExportStatus) setBoundToAccountOK(accountID string) {
+	s.accountExport.Status.AccountID = accountID
 	c := &metav1.Condition{
-		Type:               "AccountFound",
+		Type:               accountExportConditionTypeBoundToAccount,
 		Status:             metav1.ConditionTrue,
-		Reason:             "Found",
+		Reason:             controllerReasonOK,
 		Message:            fmt.Sprintf("Account ID: %s", accountID),
 		ObservedGeneration: s.accountExport.Generation,
 	}
@@ -25,12 +32,24 @@ func (s *accountExportStatus) setAccountFound(accountID string) {
 	s.evaluateReadyCondition()
 }
 
-func (s *accountExportStatus) setAccountFoundFalse(err error) {
+func (s *accountExportStatus) setBoundToAccountNotFound(err error) {
 	c := &metav1.Condition{
-		Type:               "AccountFound",
+		Type:               accountExportConditionTypeBoundToAccount,
 		Status:             metav1.ConditionFalse,
-		Reason:             "Unknown",
+		Reason:             string(metav1.StatusReasonNotFound),
 		Message:            err.Error(),
+		ObservedGeneration: s.accountExport.Generation,
+	}
+	meta.SetStatusCondition(s.accountExport.GetConditions(), *c)
+	s.evaluateReadyCondition()
+}
+
+func (s *accountExportStatus) setBoundToAccountConflict(boundAccountID string, newAccountID string) {
+	c := &metav1.Condition{
+		Type:               accountExportConditionTypeBoundToAccount,
+		Status:             metav1.ConditionFalse,
+		Reason:             string(metav1.StatusReasonConflict),
+		Message:            fmt.Sprintf("Account ID conflict: previously bound to %s, now found %s", boundAccountID, newAccountID),
 		ObservedGeneration: s.accountExport.Generation,
 	}
 	meta.SetStatusCondition(s.accountExport.GetConditions(), *c)
@@ -39,13 +58,14 @@ func (s *accountExportStatus) setAccountFoundFalse(err error) {
 
 func (s *accountExportStatus) setStatusValidRules(rules []v1alpha1.AccountExportRule) {
 	s.accountExport.Status.Claim = &v1alpha1.AccountExportClaim{
-		Rules: rules,
+		Rules:              rules,
+		ObservedGeneration: s.accountExport.Generation,
 	}
 
 	c := &metav1.Condition{
-		Type:               "ValidRules",
+		Type:               accountExportConditionTypeValidRules,
 		Status:             metav1.ConditionTrue,
-		Reason:             "Valid",
+		Reason:             controllerReasonOK,
 		ObservedGeneration: s.accountExport.Generation,
 	}
 	meta.SetStatusCondition(s.accountExport.GetConditions(), *c)
@@ -54,9 +74,9 @@ func (s *accountExportStatus) setStatusValidRules(rules []v1alpha1.AccountExport
 
 func (s *accountExportStatus) setStatusValidRulesFalse(err error) {
 	c := &metav1.Condition{
-		Type:               "ValidRules",
+		Type:               accountExportConditionTypeValidRules,
 		Status:             metav1.ConditionFalse,
-		Reason:             "Invalid",
+		Reason:             controllerReasonInvalid,
 		Message:            err.Error(),
 		ObservedGeneration: s.accountExport.Generation,
 	}
@@ -66,7 +86,7 @@ func (s *accountExportStatus) setStatusValidRulesFalse(err error) {
 
 func (s *accountExportStatus) setAdoptedByAccount() {
 	c := &metav1.Condition{
-		Type:               "AdoptedByAccount",
+		Type:               accountExportConditionTypeAdoptedByAccount,
 		Status:             metav1.ConditionFalse,
 		Reason:             "NotImplemented",
 		Message:            "Not Implemented",
@@ -83,15 +103,19 @@ func (s *accountExportStatus) setFailed(err error) {
 
 func (s *accountExportStatus) evaluateReadyCondition() {
 	readyCondition := metav1.Condition{
-		Type:               "Ready",
+		Type:               controllerTypeReady,
 		ObservedGeneration: s.accountExport.Generation,
 	}
 
 	if s.failed != nil {
-		readyCondition.Reason = "Errored"
+		readyCondition.Reason = controllerReasonErrored
 		readyCondition.Message = s.failed.Error()
 	} else {
-		if s.isReady([]string{"AccountFound", "ValidRules", "AdoptedByAccount"}) {
+		if s.isReady([]string{
+			accountExportConditionTypeBoundToAccount,
+			accountExportConditionTypeValidRules,
+			accountExportConditionTypeAdoptedByAccount,
+		}) {
 			readyCondition.Status = metav1.ConditionTrue
 			readyCondition.Reason = "Ready"
 		} else {

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -105,10 +105,10 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAdopted
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
 
-	t.assertCondition(conditions, accountExportConditionTypeBoundToAccount, metav1.ConditionTrue, controllerReasonOK)
-	t.assertCondition(conditions, accountExportConditionTypeValidRules, metav1.ConditionTrue, controllerReasonOK)
-	t.assertCondition(conditions, accountExportConditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
-	t.assertCondition(conditions, controllerTypeReady, metav1.ConditionFalse, "NotReady")
+	t.assertCondition(conditions, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
+	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
 }
 
 func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAccountIDChangeDetected() {
@@ -166,11 +166,11 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAccount
 
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
-	boundToAccountCondition := t.assertCondition(conditions, accountExportConditionTypeBoundToAccount, metav1.ConditionFalse, metav1.StatusReasonConflict)
+	boundToAccountCondition := t.assertCondition(conditions, conditionTypeBoundToAccount, metav1.ConditionFalse, conditionReasonConflict)
 	t.Equal("Account ID conflict: previously bound to ACCA, now found ACCB", boundToAccountCondition.Message)
-	t.assertCondition(conditions, accountExportConditionTypeValidRules, metav1.ConditionTrue, controllerReasonOK)
-	t.assertCondition(conditions, accountExportConditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
-	t.assertCondition(conditions, controllerTypeReady, metav1.ConditionFalse, "NotReady")
+	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
+	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
 }
 
 func (t *AccountExportControllerTestSuite) assertCondition(conditions []metav1.Condition, conditionType string,

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -1,0 +1,214 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/ports/inbound"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type AccountExportControllerTestSuite struct {
+	suite.Suite
+	ctx context.Context
+
+	accountExportManagerMock *accountExportManagerMock
+	accountReaderMock        *accountReaderMock
+
+	accountExportName      string
+	accountExportNamespace string
+	accountExportRef       ktypes.NamespacedName
+	rules                  []v1alpha1.AccountExportRule
+
+	unitUnderTest *AccountExportReconciler
+}
+
+func TestAccountExportController_TestSuite(t *testing.T) {
+	suite.Run(t, new(AccountExportControllerTestSuite))
+}
+
+func (t *AccountExportControllerTestSuite) SetupTest() {
+	t.ctx = context.Background()
+
+	testName := t.T().Name()
+	t.accountExportName = scopedTestName("test-account-export", testName)
+	t.accountExportNamespace = scopedTestName("ns", testName)
+	t.accountExportRef = ktypes.NamespacedName{
+		Name:      t.accountExportName,
+		Namespace: t.accountExportNamespace,
+	}
+	t.rules = []v1alpha1.AccountExportRule{
+		{Type: v1alpha1.Stream, Name: "foo", Subject: "foo.>"},
+		{Type: v1alpha1.Service, Name: "bar", Subject: "bar.>"},
+	}
+
+	t.Require().NoError(ensureNamespace(t.ctx, t.accountExportNamespace))
+
+	t.accountExportManagerMock = &accountExportManagerMock{}
+	t.accountReaderMock = &accountReaderMock{}
+
+	t.unitUnderTest = NewAccountExportReconciler(
+		k8sClient,
+		k8sClient.Scheme(),
+		t.accountExportManagerMock,
+		t.accountReaderMock,
+	)
+}
+
+func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAdoptedByAccountNotImplemented() {
+	// Given
+	accountID := "ACCA"
+	t.accountReaderMock.mockGet(t.ctx, domain.NewNamespacedName(t.accountExportNamespace, "my-account"), &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): accountID,
+			},
+		},
+	})
+	accountExportResource := &v1alpha1.AccountExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.accountExportName,
+			Namespace: t.accountExportNamespace,
+		},
+		Spec: v1alpha1.AccountExportSpec{
+			AccountName: "my-account",
+			Rules:       t.rules,
+		},
+	}
+	t.accountExportManagerMock.mockCreateClaim(t.ctx, nil, &domain.AccountExportClaim{
+		Rules: t.rules,
+	})
+	t.Require().NoError(k8sClient.Create(t.ctx, accountExportResource))
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountExportRef})
+
+	// Then
+	t.Require().NoError(err)
+
+	accountExport := &v1alpha1.AccountExport{}
+	err = k8sClient.Get(t.ctx, t.accountExportRef, accountExport)
+	t.Require().NoError(err)
+	t.Require().NotNil(accountExport.Status.Claim)
+	t.Require().Equal(&v1alpha1.AccountExportClaim{
+		Rules:              t.rules,
+		ObservedGeneration: int64(1),
+	}, accountExport.Status.Claim)
+
+	conditions := accountExport.Status.Conditions
+	t.Require().NotEmpty(conditions)
+
+	t.assertCondition(conditions, accountExportConditionTypeBoundToAccount, metav1.ConditionTrue, controllerReasonOK)
+	t.assertCondition(conditions, accountExportConditionTypeValidRules, metav1.ConditionTrue, controllerReasonOK)
+	t.assertCondition(conditions, accountExportConditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
+	t.assertCondition(conditions, controllerTypeReady, metav1.ConditionFalse, "NotReady")
+}
+
+func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAccountIDChangeDetected() {
+	// Given
+	t.accountReaderMock.mockGet(t.ctx, domain.NewNamespacedName(t.accountExportNamespace, "account-a"), &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "account-a",
+			Namespace: t.accountExportNamespace,
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): "ACCA",
+			},
+		},
+	}).Once()
+	t.accountReaderMock.mockGet(t.ctx, domain.NewNamespacedName(t.accountExportNamespace, "account-b"), &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "account-b",
+			Namespace: t.accountExportNamespace,
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): "ACCB",
+			},
+		},
+	}).Once()
+	t.accountExportManagerMock.mockCreateClaim(t.ctx, nil, &domain.AccountExportClaim{
+		Rules: t.rules,
+	}).Twice()
+
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.accountExportName,
+			Namespace: t.accountExportNamespace,
+		},
+		Spec: v1alpha1.AccountExportSpec{
+			AccountName: "account-a",
+			Rules:       t.rules,
+		},
+	}))
+	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountExportRef})
+	t.Require().NoError(err)
+
+	accountExport := &v1alpha1.AccountExport{}
+	err = k8sClient.Get(t.ctx, t.accountExportRef, accountExport)
+	t.Require().NoError(err)
+	accountExport.Spec.AccountName = "account-b"
+	t.Require().NoError(k8sClient.Update(t.ctx, accountExport))
+
+	// When
+	_, err = t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountExportRef})
+
+	// Then
+	t.Require().NoError(err)
+
+	accountExport = &v1alpha1.AccountExport{}
+	err = k8sClient.Get(t.ctx, t.accountExportRef, accountExport)
+	t.Require().NoError(err)
+
+	conditions := accountExport.Status.Conditions
+	t.Require().NotEmpty(conditions)
+	boundToAccountCondition := t.assertCondition(conditions, accountExportConditionTypeBoundToAccount, metav1.ConditionFalse, metav1.StatusReasonConflict)
+	t.Equal("Account ID conflict: previously bound to ACCA, now found ACCB", boundToAccountCondition.Message)
+	t.assertCondition(conditions, accountExportConditionTypeValidRules, metav1.ConditionTrue, controllerReasonOK)
+	t.assertCondition(conditions, accountExportConditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
+	t.assertCondition(conditions, controllerTypeReady, metav1.ConditionFalse, "NotReady")
+}
+
+func (t *AccountExportControllerTestSuite) assertCondition(conditions []metav1.Condition, conditionType string,
+	expectStatus metav1.ConditionStatus, expectReason metav1.StatusReason) metav1.Condition {
+	var condition metav1.Condition
+	for _, c := range conditions {
+		if c.Type == conditionType {
+			condition = c
+			break
+		}
+	}
+	t.NotEmpty(condition, fmt.Sprintf("Condition not found: %s", conditionType))
+	t.Equal(
+		fmt.Sprintf("%s|%s|%s", conditionType, expectStatus, expectReason),
+		fmt.Sprintf("%s|%s|%s", condition.Type, condition.Status, condition.Reason))
+	return condition
+}
+
+/* ****************************************************
+* inbound.AccountExportManager Mock
+*****************************************************/
+type accountExportManagerMock struct {
+	mock.Mock
+}
+
+func (m *accountExportManagerMock) CreateClaim(ctx context.Context, state *v1alpha1.AccountExport) (*domain.AccountExportClaim, error) {
+	args := m.Called(ctx, state)
+	return args.Get(0).(*domain.AccountExportClaim), args.Error(1)
+}
+
+func (m *accountExportManagerMock) mockCreateClaim(ctx context.Context, state *v1alpha1.AccountExport, result *domain.AccountExportClaim) *mock.Call {
+	var stateExpect interface{} = state
+	if state == nil {
+		stateExpect = mock.Anything
+	}
+	call := m.On("CreateClaim", ctx, stateExpect)
+	call.Return(result, nil)
+	return call
+}
+
+var _ inbound.AccountExportManager = &accountExportManagerMock{}

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -62,7 +62,7 @@ func TestAccountController_TestSuite(t *testing.T) {
 func (t *AccountControllerTestSuite) SetupTest() {
 	t.ctx = context.Background()
 	t.operatorVersion = testOperatorVersion
-	t.Require().NoError(os.Setenv(EnvOperatorVersion, t.operatorVersion))
+	t.Require().NoError(os.Setenv(envOperatorVersion, t.operatorVersion))
 
 	testName := t.T().Name()
 	t.accountName = scopedTestName(accountBaseName, testName)
@@ -94,7 +94,7 @@ func (t *AccountControllerTestSuite) SetupTest() {
 
 func (t *AccountControllerTestSuite) TearDownTest() {
 	t.accountManagerMock.AssertExpectations(t.T())
-	t.Require().NoError(os.Unsetenv(EnvOperatorVersion))
+	t.Require().NoError(os.Unsetenv(envOperatorVersion))
 }
 
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAccount() {
@@ -117,7 +117,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAc
 
 	for _, c := range account.Status.Conditions {
 		t.Equal(metav1.ConditionTrue, c.Status)
-		t.Equal(controllerReasonReconciled, c.Reason)
+		t.Equal(conditionReasonReconciled, c.Reason)
 	}
 	t.Equal(t.operatorVersion, account.Status.OperatorVersion)
 	t.Empty(t.fakeRecorder.Events)
@@ -141,7 +141,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdat
 	t.Require().NoError(err)
 	for _, c := range account.Status.Conditions {
 		t.Equal(metav1.ConditionFalse, c.Status)
-		t.Equal(controllerReasonErrored, c.Reason)
+		t.Equal(conditionReasonErrored, c.Reason)
 	}
 	t.Len(t.fakeRecorder.Events, 1)
 	t.Contains(<-t.fakeRecorder.Events, "failed to apply account: a test error")
@@ -205,7 +205,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldDeleteAccountMarkedFor
 
 	err = k8sClient.Get(t.ctx, t.accountNamespacedRef, account)
 	t.Require().NoError(err)
-	t.True(controllerutil.ContainsFinalizer(account, controllerAccountFinalizer))
+	t.True(controllerutil.ContainsFinalizer(account, finalizerAccount))
 
 	err = k8sClient.Delete(t.ctx, account)
 	t.Require().NoError(err)
@@ -246,7 +246,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails()
 
 	err = k8sClient.Get(t.ctx, t.accountNamespacedRef, account)
 	t.Require().NoError(err)
-	t.True(controllerutil.ContainsFinalizer(account, controllerAccountFinalizer))
+	t.True(controllerutil.ContainsFinalizer(account, finalizerAccount))
 
 	err = k8sClient.Delete(t.ctx, account)
 	t.Require().NoError(err)
@@ -266,7 +266,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails()
 	t.Require().NoError(err)
 	for _, c := range account.Status.Conditions {
 		t.Equal(metav1.ConditionFalse, c.Status)
-		t.Equal(controllerReasonErrored, c.Reason)
+		t.Equal(conditionReasonErrored, c.Reason)
 	}
 	t.Len(t.fakeRecorder.Events, 1)
 	t.Contains(<-t.fakeRecorder.Events, deletionErr.Error())
@@ -313,7 +313,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVe
 	t.Require().NoError(err)
 
 	newOperatorVersion := "1.1-SNAPSHOT"
-	t.Require().NoError(os.Setenv(EnvOperatorVersion, newOperatorVersion))
+	t.Require().NoError(os.Setenv(envOperatorVersion, newOperatorVersion))
 
 	// Note: assert mock calls during setup and reset for test case
 	t.accountManagerMock.AssertExpectations(t.T())
@@ -329,7 +329,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVe
 	t.Require().NoError(err)
 	for _, c := range account.Status.Conditions {
 		t.Equal(metav1.ConditionTrue, c.Status)
-		t.Equal(controllerReasonReconciled, c.Reason)
+		t.Equal(conditionReasonReconciled, c.Reason)
 	}
 	t.Equal(newOperatorVersion, account.Status.OperatorVersion)
 	t.Empty(t.fakeRecorder.Events)

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -9,7 +9,9 @@ const (
 	controllerReasonReconciling = "Reconciling"
 	controllerReasonReconciled  = "Reconciled"
 	controllerActionReconciled  = "Reconciled"
+	controllerReasonOK          = "OK"
 	controllerReasonErrored     = "Errored"
+	controllerReasonInvalid     = "Invalid"
 )
 
 const (

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -1,19 +1,33 @@
 package controller
 
-const (
-	controllerTypeReady = "Ready"
+const ( // Conditions
+	// Types
+	conditionTypeReady            = "Ready"
+	conditionTypeBoundToAccount   = "BoundToAccount"
+	conditionTypeValidRules       = "ValidRules"
+	conditionTypeAdoptedByAccount = "AdoptedByAccount"
 
-	controllerAccountFinalizer = "account.nauth.io/finalizer"
-	controllerUserFinalizer    = "user.nauth.io/finalizer"
-
-	controllerReasonReconciling = "Reconciling"
-	controllerReasonReconciled  = "Reconciled"
-	controllerActionReconciled  = "Reconciled"
-	controllerReasonOK          = "OK"
-	controllerReasonErrored     = "Errored"
-	controllerReasonInvalid     = "Invalid"
+	// Reasons
+	conditionReasonReady       = "Ready"
+	conditionReasonNotReady    = "NotReady"
+	conditionReasonReconciling = "Reconciling"
+	conditionReasonReconciled  = "Reconciled"
+	conditionReasonOK          = "OK"
+	conditionReasonErrored     = "Errored"
+	conditionReasonInvalid     = "Invalid"
+	conditionReasonConflict    = "Conflict"
 )
 
-const (
-	EnvOperatorVersion = "OPERATOR_VERSION"
+const ( // Events
+	// Actions
+	actionReconciled = "Reconciled"
+)
+
+const ( // Finalizers
+	finalizerAccount = "account.nauth.io/finalizer"
+	finalizerUser    = "user.nauth.io/finalizer"
+)
+
+const ( // Environment Variables
+	envOperatorVersion = "OPERATOR_VERSION"
 )

--- a/internal/adapter/inbound/controller/mocks_test.go
+++ b/internal/adapter/inbound/controller/mocks_test.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
+	"github.com/stretchr/testify/mock"
+)
+
+/* ****************************************************
+* outbound.AccountReader Mock
+*****************************************************/
+type accountReaderMock struct {
+	mock.Mock
+}
+
+func (a *accountReaderMock) Get(ctx context.Context, accountRef domain.NamespacedName) (account *v1alpha1.Account, err error) {
+	args := a.Called(ctx, accountRef)
+	return args.Get(0).(*v1alpha1.Account), args.Error(1)
+}
+
+func (a *accountReaderMock) mockGet(ctx context.Context, accountRef domain.NamespacedName, result *v1alpha1.Account) *mock.Call {
+	call := a.On("Get", ctx, accountRef)
+	call.Return(result, nil)
+	return call
+}
+
+var _ outbound.AccountReader = &accountReaderMock{}

--- a/internal/adapter/inbound/controller/natscluster.go
+++ b/internal/adapter/inbound/controller/natscluster.go
@@ -70,15 +70,15 @@ func (r *NatsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return r.reporter.error(ctx, natsCluster, err)
 	}
 
-	operatorVersion := os.Getenv(EnvOperatorVersion)
+	operatorVersion := os.Getenv(envOperatorVersion)
 	if natsCluster.Status.ObservedGeneration == natsCluster.Generation && natsCluster.Status.OperatorVersion == operatorVersion {
 		return ctrl.Result{}, nil
 	}
 
 	meta.SetStatusCondition(&natsCluster.Status.Conditions, metav1.Condition{
-		Type:    controllerTypeReady,
+		Type:    conditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  controllerReasonReconciling,
+		Reason:  conditionReasonReconciling,
 		Message: "Reconciling NatsCluster",
 	})
 	if err := r.Status().Update(ctx, natsCluster); err != nil {

--- a/internal/adapter/inbound/controller/natscluster_test.go
+++ b/internal/adapter/inbound/controller/natscluster_test.go
@@ -50,7 +50,7 @@ func TestNatsClusterController_TestSuite(t *testing.T) {
 func (t *NatsClusterControllerTestSuite) SetupTest() {
 	t.ctx = context.Background()
 	t.operatorVersion = testOperatorVersion
-	t.Require().NoError(os.Setenv(EnvOperatorVersion, t.operatorVersion))
+	t.Require().NoError(os.Setenv(envOperatorVersion, t.operatorVersion))
 
 	testName := t.T().Name()
 	namespace := scopedTestName("natscluster", testName)
@@ -85,7 +85,7 @@ func (t *NatsClusterControllerTestSuite) SetupTest() {
 
 func (t *NatsClusterControllerTestSuite) TearDownTest() {
 	t.natsClusterManagerMock.AssertExpectations(t.T())
-	t.Require().NoError(os.Unsetenv(EnvOperatorVersion))
+	t.Require().NoError(os.Unsetenv(envOperatorVersion))
 }
 
 func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldSucceed() {
@@ -105,7 +105,7 @@ func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 	t.False(cluster.Status.ReconcileTimestamp.IsZero())
 	for _, c := range cluster.Status.Conditions {
 		t.Equal(metav1.ConditionTrue, c.Status)
-		t.Equal(controllerReasonReconciled, c.Reason)
+		t.Equal(conditionReasonReconciled, c.Reason)
 	}
 	t.Empty(t.fakeRecorder.Events)
 }
@@ -126,7 +126,7 @@ func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldFail() {
 	t.Require().NoError(k8sClient.Get(t.ctx, t.resourceName, cluster))
 	for _, c := range cluster.Status.Conditions {
 		t.Equal(metav1.ConditionFalse, c.Status)
-		t.Equal(controllerReasonErrored, c.Reason)
+		t.Equal(conditionReasonErrored, c.Reason)
 	}
 	t.Len(t.fakeRecorder.Events, 1)
 	t.Contains(<-t.fakeRecorder.Events, "failed to validate NatsCluster: a test error")

--- a/internal/adapter/inbound/controller/status.go
+++ b/internal/adapter/inbound/controller/status.go
@@ -37,9 +37,9 @@ func (s *statusReporter) status(ctx context.Context, object Object) (ctrl.Result
 	log := logf.FromContext(ctx)
 
 	meta.SetStatusCondition(object.GetConditions(), metav1.Condition{
-		Type:    controllerTypeReady,
+		Type:    conditionTypeReady,
 		Status:  metav1.ConditionTrue,
-		Reason:  controllerReasonReconciled,
+		Reason:  conditionReasonReconciled,
 		Message: "Successfully reconciled",
 	})
 
@@ -57,12 +57,12 @@ func (s *statusReporter) status(ctx context.Context, object Object) (ctrl.Result
 func (s *statusReporter) error(ctx context.Context, regarding Object, err error) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	s.Recorder.Eventf(regarding, nil, v1.EventTypeWarning, controllerReasonErrored, controllerActionReconciled, err.Error())
+	s.Recorder.Eventf(regarding, nil, v1.EventTypeWarning, conditionReasonErrored, actionReconciled, err.Error())
 
 	meta.SetStatusCondition(regarding.GetConditions(), metav1.Condition{
-		Type:    controllerTypeReady,
+		Type:    conditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  controllerReasonErrored,
+		Reason:  conditionReasonErrored,
 		Message: err.Error(),
 	})
 

--- a/internal/adapter/inbound/controller/user.go
+++ b/internal/adapter/inbound/controller/user.go
@@ -85,9 +85,9 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if !user.DeletionTimestamp.IsZero() {
 		// The user is being deleted
 		meta.SetStatusCondition(&user.Status.Conditions, metav1.Condition{
-			Type:    controllerTypeReady,
+			Type:    conditionTypeReady,
 			Status:  metav1.ConditionFalse,
-			Reason:  controllerReasonReconciling,
+			Reason:  conditionReasonReconciling,
 			Message: "Deleting user",
 		})
 
@@ -97,13 +97,13 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 
 		// The user is being deleted
-		if controllerutil.ContainsFinalizer(user, controllerUserFinalizer) {
+		if controllerutil.ContainsFinalizer(user, finalizerUser) {
 			if err := r.manager.Delete(ctx, user); err != nil {
 				return r.reporter.error(ctx, user, fmt.Errorf("failed to delete user: %w", err))
 			}
 
 			// remove our finalizer from the list and update it.
-			controllerutil.RemoveFinalizer(user, controllerUserFinalizer)
+			controllerutil.RemoveFinalizer(user, finalizerUser)
 			if err := r.Update(ctx, user); err != nil {
 				log.Info("failed to remove finalizer", "name", user.Name, "error", err)
 				return ctrl.Result{}, err
@@ -113,7 +113,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	operatorVersion := os.Getenv(EnvOperatorVersion)
+	operatorVersion := os.Getenv(envOperatorVersion)
 
 	// Nothing has changed
 	if user.Status.ObservedGeneration == user.Generation && user.Status.OperatorVersion == operatorVersion {
@@ -123,17 +123,17 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// RECONCILE USER - Set status & base properties
 
 	// Add finalizer if not present
-	if !controllerutil.ContainsFinalizer(user, controllerUserFinalizer) {
-		controllerutil.AddFinalizer(user, controllerUserFinalizer)
+	if !controllerutil.ContainsFinalizer(user, finalizerUser) {
+		controllerutil.AddFinalizer(user, finalizerUser)
 		if err := r.Update(ctx, user); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
 	meta.SetStatusCondition(&user.Status.Conditions, metav1.Condition{
-		Type:    controllerTypeReady,
+		Type:    conditionTypeReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  controllerReasonReconciling,
+		Reason:  conditionReasonReconciling,
 		Message: "Reconciling user",
 	})
 	if err := r.Status().Update(ctx, user); err != nil {

--- a/internal/adapter/inbound/controller/user_test.go
+++ b/internal/adapter/inbound/controller/user_test.go
@@ -38,7 +38,7 @@ func TestUserController_TestSuite(t *testing.T) {
 func (t *UserControllerTestSuite) SetupTest() {
 	t.ctx = context.Background()
 	t.operatorVersion = testOperatorVersion
-	t.Require().NoError(os.Setenv(EnvOperatorVersion, t.operatorVersion))
+	t.Require().NoError(os.Setenv(envOperatorVersion, t.operatorVersion))
 
 	testName := t.T().Name()
 	userName := scopedTestName("test-resource", testName)
@@ -68,7 +68,7 @@ func (t *UserControllerTestSuite) SetupTest() {
 
 func (t *UserControllerTestSuite) TearDownTest() {
 	t.userManagerMock.AssertExpectations(t.T())
-	t.Require().NoError(os.Unsetenv(EnvOperatorVersion))
+	t.Require().NoError(os.Unsetenv(envOperatorVersion))
 }
 
 func (t *UserControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingOrUpdatingUser() {
@@ -87,7 +87,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingOrUpd
 
 	for _, c := range user.Status.Conditions {
 		t.Equal(metav1.ConditionTrue, c.Status)
-		t.Equal(controllerReasonReconciled, c.Reason)
+		t.Equal(conditionReasonReconciled, c.Reason)
 	}
 	t.Equal(t.operatorVersion, user.Status.OperatorVersion)
 	t.Empty(t.fakeRecorder.Events)
@@ -110,7 +110,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdateFa
 
 	for _, c := range user.Status.Conditions {
 		t.Equal(metav1.ConditionFalse, c.Status)
-		t.Equal(controllerReasonErrored, c.Reason)
+		t.Equal(conditionReasonErrored, c.Reason)
 	}
 
 	t.Len(t.fakeRecorder.Events, 1)
@@ -128,7 +128,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldDeleteUserMarkedForDeleti
 
 	err = k8sClient.Get(t.ctx, t.userNamespacedName, user)
 	t.Require().NoError(err)
-	t.True(controllerutil.ContainsFinalizer(user, controllerUserFinalizer))
+	t.True(controllerutil.ContainsFinalizer(user, finalizerUser))
 
 	err = k8sClient.Delete(t.ctx, user)
 	t.Require().NoError(err)
@@ -149,7 +149,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldDeleteUserMarkedForDeleti
 
 	for _, c := range user.Status.Conditions {
 		t.Equal(metav1.ConditionTrue, c.Status)
-		t.Equal(controllerReasonReconciled, c.Reason)
+		t.Equal(conditionReasonReconciled, c.Reason)
 	}
 
 	err = k8sClient.Get(t.ctx, t.userNamespacedName, user)
@@ -170,7 +170,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails() {
 
 	err = k8sClient.Get(t.ctx, t.userNamespacedName, user)
 	t.Require().NoError(err)
-	t.True(controllerutil.ContainsFinalizer(user, controllerUserFinalizer))
+	t.True(controllerutil.ContainsFinalizer(user, finalizerUser))
 
 	err = k8sClient.Delete(t.ctx, user)
 	t.Require().NoError(err)
@@ -194,7 +194,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails() {
 	t.Require().NoError(err)
 	for _, c := range user.Status.Conditions {
 		t.Equal(metav1.ConditionFalse, c.Status)
-		t.Equal(controllerReasonErrored, c.Reason)
+		t.Equal(conditionReasonErrored, c.Reason)
 	}
 
 	t.Len(t.fakeRecorder.Events, 1)
@@ -214,7 +214,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVersi
 	t.Require().NoError(err)
 
 	newOperatorVersion := "1.1-SNAPSHOT"
-	t.Require().NoError(os.Setenv(EnvOperatorVersion, newOperatorVersion))
+	t.Require().NoError(os.Setenv(envOperatorVersion, newOperatorVersion))
 
 	// Note: assert mock calls during setup and reset for test case
 	t.userManagerMock.AssertExpectations(t.T())
@@ -230,7 +230,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVersi
 	t.Require().NoError(err)
 	for _, c := range user.Status.Conditions {
 		t.Equal(metav1.ConditionTrue, c.Status)
-		t.Equal(controllerReasonReconciled, c.Reason)
+		t.Equal(conditionReasonReconciled, c.Reason)
 	}
 	t.Equal(newOperatorVersion, user.Status.OperatorVersion)
 	t.Empty(t.fakeRecorder.Events)


### PR DESCRIPTION
To avoid accidental changes to the referenced AccountName in the AccountExport, we should bind the first, valid Account ID to the export resource. This will prevent the Account JWT to be accidentally re-written without exports, hence guard railing against unwanted message flow downtime.

Issue: #11
