### PR TITLE
feat: bind account exports by account-id label

### DIFF
--- a/api/v1alpha1/account_export_types.go
+++ b/api/v1alpha1/account_export_types.go
@@ -22,6 +22,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type AccountExportLabel string
+
+const (
+	AccountExportLabelAccountID AccountExportLabel = "accountexport.nauth.io/account-id"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
@@ -38,6 +44,17 @@ type AccountExport struct {
 
 func (a *AccountExport) GetConditions() *[]metav1.Condition {
 	return &a.Status.Conditions
+}
+
+func (a *AccountExport) GetLabel(label AccountExportLabel) string {
+	return a.GetLabels()[string(label)]
+}
+
+func (a *AccountExport) SetLabel(label AccountExportLabel, value string) {
+	if a.Labels == nil {
+		a.Labels = make(map[string]string)
+	}
+	a.Labels[string(label)] = value
 }
 
 // AccountExportSpec defines the desired state of AccountExport.

--- a/charts/nauth/templates/rbac_manager_role.yaml
+++ b/charts/nauth/templates/rbac_manager_role.yaml
@@ -29,6 +29,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - nauth.io

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -49,7 +49,7 @@ func NewAccountExportReconciler(k8sClient client.Client, scheme *runtime.Scheme,
 	}
 }
 
-// +kubebuilder:rbac:groups=nauth.io,resources=accountexports,verbs=get;list;watch
+// +kubebuilder:rbac:groups=nauth.io,resources=accountexports,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=nauth.io,resources=accountexports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
@@ -75,10 +75,18 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		statusWrapper.setBoundToAccountNotFound(err)
 	} else {
 		accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
-		boundAccountID := state.Status.AccountID
+		boundAccountID := state.GetLabel(v1alpha1.AccountExportLabelAccountID)
 		if boundAccountID != "" && boundAccountID != accountID {
 			statusWrapper.setBoundToAccountConflict(boundAccountID, accountID)
 		} else {
+			if boundAccountID != accountID {
+				patchBase := state.DeepCopy()
+				state.SetLabel(v1alpha1.AccountExportLabelAccountID, accountID)
+				if patchErr := r.Patch(ctx, state, client.MergeFrom(patchBase)); patchErr != nil {
+					log.Error(patchErr, "Failed to patch labels")
+					return ctrl.Result{}, patchErr
+				}
+			}
 			statusWrapper.setBoundToAccountOK(accountID)
 		}
 	}

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -105,6 +105,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAdopted
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
 
+	t.assertBoundAccountID(accountExport, t.accountID)
 	t.assertCondition(conditions, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
 	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionTrue, conditionReasonOK)
 	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
@@ -148,6 +149,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenExportR
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
 
+	t.assertBoundAccountID(accountExport, t.accountID)
 	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionFalse, conditionReasonInvalid)
 	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
 }
@@ -203,6 +205,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenExportR
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
 
+	t.assertBoundAccountID(accountExport, t.accountID)
 	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionFalse, conditionReasonInvalid)
 	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
 }
@@ -264,6 +267,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAccount
 	t.Require().NotEmpty(conditions)
 	boundToAccountCondition := t.assertCondition(conditions, conditionTypeBoundToAccount, metav1.ConditionFalse, conditionReasonConflict)
 	t.Equal("Account ID conflict: previously bound to ACCA, now found ACCB", boundToAccountCondition.Message)
+	t.assertBoundAccountID(accountExport, "ACCA")
 	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionTrue, conditionReasonOK)
 	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
 	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
@@ -283,6 +287,11 @@ func (t *AccountExportControllerTestSuite) assertCondition(conditions []metav1.C
 		fmt.Sprintf("%s|%s|%s", conditionType, expectStatus, expectReason),
 		fmt.Sprintf("%s|%s|%s", condition.Type, condition.Status, condition.Reason))
 	return condition
+}
+
+func (t *AccountExportControllerTestSuite) assertBoundAccountID(export *v1alpha1.AccountExport, expectAccountID string) {
+	t.Equalf(expectAccountID, export.GetLabel(v1alpha1.AccountExportLabelAccountID), "Expected label %q", v1alpha1.AccountExportLabelAccountID)
+	t.Equalf(expectAccountID, export.Status.AccountID, "Expectedd Status.AccountID")
 }
 
 /* ****************************************************


### PR DESCRIPTION
Store the resolved account ID for `AccountExport` resources in metadata labels and patch the resource during reconciliation when the binding is established.

Update the manager RBAC to allow patching `accountexports` so the controller can persist the lookup label before writing status.

Issue: #11
