### PR TITLE
fix: return get errors directly from reconcilers

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -80,7 +80,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		// Error reading the object - requeue the request.
 		log.Error(err, "Failed to get resource")
-		return r.reporter.error(ctx, natsAccount, err)
+		return ctrl.Result{}, err
 	}
 
 	accountID := natsAccount.GetLabel(v1alpha1.AccountLabelAccountID)

--- a/internal/adapter/inbound/controller/natscluster.go
+++ b/internal/adapter/inbound/controller/natscluster.go
@@ -67,7 +67,7 @@ func (r *NatsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		log.Error(err, "Failed to get resource")
-		return r.reporter.error(ctx, natsCluster, err)
+		return ctrl.Result{}, err
 	}
 
 	operatorVersion := os.Getenv(envOperatorVersion)

--- a/internal/adapter/inbound/controller/user.go
+++ b/internal/adapter/inbound/controller/user.go
@@ -78,7 +78,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 		// Error reading the object - requeue the request.
 		log.Error(err, "Failed to get resource")
-		return r.reporter.error(ctx, user, err)
+		return ctrl.Result{}, err
 	}
 
 	// USER MARKED FOR DELETION


### PR DESCRIPTION
## Summary
Stop routing initial `Get` failures through the status reporter in the Account, User, and NatsCluster reconcilers.

When the reconciler cannot fetch the resource and the error is not a `NotFound`, there is no safe object state to report against. Returning the raw error directly keeps controller-runtime retry behavior intact and avoids trying to write status for resources that were never successfully loaded.

Signed-off-by: Henri Ropponen <henriropponen@gmail.com>

<!-- Write a clear title using https://conventionalcommits.org -->
<!-- Write a summary with intention about the pull request.-->
