### PR TITLE
refactor: introduce account resource aggregation input

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -172,7 +172,8 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to import the observed account: %w", err))
 		}
 	} else {
-		result, err = r.manager.CreateOrUpdate(ctx, natsAccount)
+		resources := r.createAccountResources(natsAccount)
+		result, err = r.manager.CreateOrUpdate(ctx, *resources)
 		if err != nil {
 			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to apply account: %w", err))
 		}
@@ -206,6 +207,13 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return r.reporter.status(ctx, natsAccount)
+}
+
+func (r *AccountReconciler) createAccountResources(state *v1alpha1.Account) *domain.AccountResources {
+	return &domain.AccountResources{
+		Account: *state,
+		// TODO: [#11] Lookup and apply AccountExports
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	k8err "k8s.io/apimachinery/pkg/api/errors"
@@ -104,7 +105,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAc
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},
 	}
-	t.accountManagerMock.On("CreateOrUpdate", mock.Anything).Return(mockResult, nil).Once()
+	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
 
 	// When (expect manager.CreateOrUpdate)
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -127,7 +128,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdat
 	// Given
 	accountsManagerErr := fmt.Errorf("a test error")
 
-	t.accountManagerMock.On("CreateOrUpdate", mock.Anything).Return(nil, accountsManagerErr).Once()
+	t.accountManagerMock.mockCreateOrUpdateError(t.ctx, mock.Anything, accountsManagerErr).Once()
 
 	// When (expect manager.CreateOrUpdate)
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -155,7 +156,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldNotDeleteObservedAccou
 		Claims:          &v1alpha1.AccountClaims{},
 	}
 	// Note: Expect manager.Import during setup only
-	t.accountManagerMock.On("Import", mock.Anything).Return(mockResult, nil).Once()
+	t.accountManagerMock.mockImport(t.ctx, mock.Anything, mockResult).Once()
 
 	account := &v1alpha1.Account{}
 	err := k8sClient.Get(t.ctx, t.accountNamespacedRef, account)
@@ -197,7 +198,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldDeleteAccountMarkedFor
 		Claims:          &v1alpha1.AccountClaims{},
 	}
 	// Note: Expect manager.CreateOrUpdate during setup only
-	t.accountManagerMock.On("CreateOrUpdate", mock.Anything).Return(mockResult, nil).Once()
+	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
 	account := &v1alpha1.Account{}
 
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -216,7 +217,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldDeleteAccountMarkedFor
 
 	// Note: assert mock calls during setup and reset for test case
 	t.accountManagerMock.AssertExpectations(t.T())
-	t.accountManagerMock.On("Delete", mock.Anything).Return(nil).Once()
+	t.accountManagerMock.mockDelete(t.ctx, mock.Anything, nil).Once()
 
 	// When (expect manager.Delete)
 	_, err = t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -238,7 +239,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails()
 		Claims:          &v1alpha1.AccountClaims{},
 	}
 	// Note: Expect manager.CreateOrUpdate during setup only
-	t.accountManagerMock.On("CreateOrUpdate", mock.Anything).Return(mockResult, nil).Once()
+	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
 	account := &v1alpha1.Account{}
 
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -253,7 +254,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails()
 
 	// Note: assert mock calls during setup and reset for test case
 	t.accountManagerMock.AssertExpectations(t.T())
-	t.accountManagerMock.On("Delete", mock.Anything).Return(deletionErr).Once()
+	t.accountManagerMock.mockDelete(t.ctx, mock.Anything, deletionErr).Once()
 
 	// When (expect manager.Delete)
 	_, err = t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -289,7 +290,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldImportObservedAccount(
 	err = k8sClient.Update(t.ctx, account)
 	t.Require().NoError(err)
 
-	t.accountManagerMock.On("Import", mock.Anything).Return(mockResult, nil).Once()
+	t.accountManagerMock.mockImport(t.ctx, mock.Anything, mockResult).Once()
 
 	// When (expect manager.Import)
 	_, err = t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -306,7 +307,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVe
 		Claims:          &v1alpha1.AccountClaims{},
 	}
 	// Note: Expect manager.CreateOrUpdate during setup only
-	t.accountManagerMock.On("CreateOrUpdate", mock.Anything).Return(mockResult, nil).Once()
+	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
 	account := &v1alpha1.Account{}
 
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -317,7 +318,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVe
 
 	// Note: assert mock calls during setup and reset for test case
 	t.accountManagerMock.AssertExpectations(t.T())
-	t.accountManagerMock.On("CreateOrUpdate", mock.Anything).Return(mockResult, nil).Once()
+	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
 
 	// When (expect manager.CreateOrUpdate)
 	_, err = t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
@@ -335,12 +336,15 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVe
 	t.Empty(t.fakeRecorder.Events)
 }
 
+/* ****************************************************
+* inbound.AccountManager Mock
+*****************************************************/
 type AccountManagerMock struct {
 	mock.Mock
 }
 
-func (o *AccountManagerMock) CreateOrUpdate(ctx context.Context, state *v1alpha1.Account) (*domain.AccountResult, error) {
-	args := o.Called(state)
+func (o *AccountManagerMock) CreateOrUpdate(ctx context.Context, resources domain.AccountResources) (*domain.AccountResult, error) {
+	args := o.Called(ctx, resources)
 	if args.Error(1) != nil {
 		return nil, args.Error(1)
 	}
@@ -348,10 +352,22 @@ func (o *AccountManagerMock) CreateOrUpdate(ctx context.Context, state *v1alpha1
 		return nil, nil
 	}
 	return args.Get(0).(*domain.AccountResult), nil
+}
+
+func (o *AccountManagerMock) mockCreateOrUpdate(ctx interface{}, resources interface{}, result *domain.AccountResult) *mock.Call {
+	call := o.On("CreateOrUpdate", ctx, resources)
+	call.Return(result, nil)
+	return call
+}
+
+func (o *AccountManagerMock) mockCreateOrUpdateError(ctx interface{}, resources interface{}, err error) *mock.Call {
+	call := o.On("CreateOrUpdate", ctx, resources)
+	call.Return(nil, err)
+	return call
 }
 
 func (o *AccountManagerMock) Import(ctx context.Context, state *v1alpha1.Account) (*domain.AccountResult, error) {
-	args := o.Called(state)
+	args := o.Called(ctx, state)
 	if args.Error(1) != nil {
 		return nil, args.Error(1)
 	}
@@ -361,7 +377,21 @@ func (o *AccountManagerMock) Import(ctx context.Context, state *v1alpha1.Account
 	return args.Get(0).(*domain.AccountResult), nil
 }
 
-func (o *AccountManagerMock) Delete(ctx context.Context, desired *v1alpha1.Account) error {
-	args := o.Called(desired)
+func (o *AccountManagerMock) Delete(ctx context.Context, state *v1alpha1.Account) error {
+	args := o.Called(ctx, state)
 	return args.Error(0)
 }
+
+func (o *AccountManagerMock) mockDelete(ctx interface{}, state interface{}, err error) *mock.Call {
+	call := o.On("Delete", ctx, state)
+	call.Return(err)
+	return call
+}
+
+func (o *AccountManagerMock) mockImport(ctx interface{}, state interface{}, result *domain.AccountResult) *mock.Call {
+	call := o.On("Import", ctx, state)
+	call.Return(result, nil)
+	return call
+}
+
+var _ inbound.AccountManager = (*AccountManagerMock)(nil)

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -76,18 +76,19 @@ func (a *AccountManager) validate() error {
 	return nil
 }
 
-func (a *AccountManager) CreateOrUpdate(ctx context.Context, state *v1alpha1.Account) (*domain.AccountResult, error) {
-	accountRef := domain.NewNamespacedName(state.GetNamespace(), state.GetName())
+func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.AccountResources) (*domain.AccountResult, error) {
+	account := &resources.Account
+	accountRef := domain.NewNamespacedName(account.GetNamespace(), account.GetName())
 	if err := accountRef.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid account reference %q: %w", accountRef, err)
 	}
 
-	cluster, err := a.resolveClusterTarget(ctx, state)
+	cluster, err := a.resolveClusterTarget(ctx, account)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve cluster target: %w", err)
 	}
 
-	fixedAccountID := state.GetLabel(v1alpha1.AccountLabelAccountID)
+	fixedAccountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
 	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, accountRef, fixedAccountID)
 	if fixedAccountID != "" {
 		// Update
@@ -148,7 +149,7 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, state *v1alpha1.Acc
 		return nil, fmt.Errorf("failed to get operator signing public key: %w", err)
 	}
 
-	natsClaims, err := newAccountClaimsBuilder(ctx, getDisplayName(state), state.Spec, accountPublicKey, a.accountReader).
+	natsClaims, err := newAccountClaimsBuilder(ctx, getDisplayName(account), account.Spec, accountPublicKey, a.accountReader).
 		signingKey(accountSigningPublicKey).
 		build()
 	if err != nil {
@@ -176,6 +177,7 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, state *v1alpha1.Acc
 		AccountID:       accountPublicKey,
 		AccountSignedBy: operatorSigningPublicKey,
 		Claims:          &nauthClaims,
+		// TODO: [#11] Set Adoptions
 	}, nil
 }
 

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -109,14 +109,16 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldSucceed() {
 	t.natsSysConnMock.mockDisconnect()
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-		},
-		Spec: v1alpha1.AccountSpec{
-			NatsLimits: &v1alpha1.NatsLimits{
-				Subs: &natsLimitsSubs,
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+			},
+			Spec: v1alpha1.AccountSpec{
+				NatsLimits: &v1alpha1.NatsLimits{
+					Subs: &natsLimitsSubs,
+				},
 			},
 		},
 	})
@@ -160,17 +162,19 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldSucceed_WhenAccountExplicitC
 	t.natsSysConnMock.mockDisconnect()
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-		},
-		Spec: v1alpha1.AccountSpec{
-			NatsClusterRef: &v1alpha1.NatsClusterRef{
-				Name: "account-namespace-cluster",
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
 			},
-			NatsLimits: &v1alpha1.NatsLimits{
-				Subs: &natsLimitsSubs,
+			Spec: v1alpha1.AccountSpec{
+				NatsClusterRef: &v1alpha1.NatsClusterRef{
+					Name: "account-namespace-cluster",
+				},
+				NatsLimits: &v1alpha1.NatsLimits{
+					Subs: &natsLimitsSubs,
+				},
 			},
 		},
 	})
@@ -205,14 +209,16 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldSucceed_WhenSecretsAlreadyEx
 	t.natsSysConnMock.mockDisconnect()
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-		},
-		Spec: v1alpha1.AccountSpec{
-			NatsLimits: &v1alpha1.NatsLimits{
-				Subs: &natsLimitsSubs,
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+			},
+			Spec: v1alpha1.AccountSpec{
+				NatsLimits: &v1alpha1.NatsLimits{
+					Subs: &natsLimitsSubs,
+				},
 			},
 		},
 	})
@@ -231,12 +237,14 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldFail_WhenClusterNotFound() {
 	t.clusterTargetResolverMock.mockGetClusterTargetError(t.ctx, nil, fmt.Errorf("test cluster not found"))
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+			},
+			Spec: v1alpha1.AccountSpec{},
 		},
-		Spec: v1alpha1.AccountSpec{},
 	})
 
 	// Then
@@ -252,12 +260,14 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldFail_WhenExistingSecretsAreI
 	t.secretManagerMock.mockGetSecretsFoundError(t.ctx, accountRef, "", fmt.Errorf("root secret is malformed"))
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+			},
+			Spec: v1alpha1.AccountSpec{},
 		},
-		Spec: v1alpha1.AccountSpec{},
 	})
 
 	// Then
@@ -286,15 +296,17 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldSucceed() {
 	t.natsSysConnMock.mockDisconnect()
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
+				},
 			},
+			Spec: v1alpha1.AccountSpec{},
 		},
-		Spec: v1alpha1.AccountSpec{},
 	})
 
 	// Then
@@ -313,15 +325,17 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountSecretsAreMi
 	t.secretManagerMock.mockGetSecretsMissing(t.ctx, accountRef, accountID)
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
+				},
 			},
+			Spec: v1alpha1.AccountSpec{},
 		},
-		Spec: v1alpha1.AccountSpec{},
 	})
 
 	// Then
@@ -343,15 +357,17 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenUpdatingSystemAccou
 	})
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
+				},
 			},
+			Spec: v1alpha1.AccountSpec{},
 		},
-		Spec: v1alpha1.AccountSpec{},
 	})
 
 	// Then
@@ -385,33 +401,35 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountClaimsAreInv
 	})
 
 	// When
-	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
-			},
-		},
-		Spec: v1alpha1.AccountSpec{
-			Imports: v1alpha1.Imports{
-				{
-					Name: "import-once",
-					AccountRef: v1alpha1.AccountRef{
-						Namespace: "import-namespace",
-						Name:      "import-account",
-					},
-					Subject: "foo",
-					Type:    v1alpha1.Service,
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
 				},
-				{
-					Name: "import-twice",
-					AccountRef: v1alpha1.AccountRef{
-						Namespace: "import-namespace",
-						Name:      "import-account",
+			},
+			Spec: v1alpha1.AccountSpec{
+				Imports: v1alpha1.Imports{
+					{
+						Name: "import-once",
+						AccountRef: v1alpha1.AccountRef{
+							Namespace: "import-namespace",
+							Name:      "import-account",
+						},
+						Subject: "foo",
+						Type:    v1alpha1.Service,
 					},
-					Subject: "foo",
-					Type:    v1alpha1.Service,
+					{
+						Name: "import-twice",
+						AccountRef: v1alpha1.AccountRef{
+							Namespace: "import-namespace",
+							Name:      "import-account",
+						},
+						Subject: "foo",
+						Type:    v1alpha1.Service,
+					},
 				},
 			},
 		},

--- a/internal/domain/nauth.go
+++ b/internal/domain/nauth.go
@@ -4,11 +4,18 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 )
 
+type AccountResources struct {
+	Account v1alpha1.Account
+	Exports []v1alpha1.AccountExport
+}
+
 type AccountResult struct {
 	AccountID       string
 	AccountSignedBy string
 	Claims          *v1alpha1.AccountClaims
+	Adoptions       *v1alpha1.AccountAdoptions
 }
+
 type AccountExportClaim struct {
 	Rules []v1alpha1.AccountExportRule
 }

--- a/internal/ports/inbound/nauth.go
+++ b/internal/ports/inbound/nauth.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AccountManager interface {
-	CreateOrUpdate(ctx context.Context, state *v1alpha1.Account) (*domain.AccountResult, error)
+	CreateOrUpdate(ctx context.Context, accountResources domain.AccountResources) (*domain.AccountResult, error)
 	Import(ctx context.Context, state *v1alpha1.Account) (*domain.AccountResult, error)
 	Delete(ctx context.Context, desired *v1alpha1.Account) error
 }


### PR DESCRIPTION
Change account reconciliation to build an `AccountResources` input object before calling the account manager, instead of passing only the `Account` resource.

This prepares the account flow for aggregating child resources such as `AccountExport` into account processing, and updates controller/core tests and interfaces to use the new input shape.

Issue: #11
