### PR TITLE
feat: avoid re-uploading unchanged Account JWTs to NATS

### DIFF
--- a/api/v1alpha1/account_types.go
+++ b/api/v1alpha1/account_types.go
@@ -84,6 +84,9 @@ type AccountClaims struct {
 type AccountStatus struct {
 	// +optional
 	Claims AccountClaims `json:"claims,omitempty"`
+	// ClaimsHash is a hash of the Account JWT claims, used to determine if the claims have changed and a new JWT needs to be generated.
+	// +optional
+	ClaimsHash string `json:"claimsHash,omitempty"`
 	// +optional
 	Adoptions *AccountAdoptions `json:"adoptions,omitempty"`
 	// +listType=map

--- a/charts/nauth-crds/crds/nauth.io_accounts.yaml
+++ b/charts/nauth-crds/crds/nauth.io_accounts.yaml
@@ -497,6 +497,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              claimsHash:
+                description: ClaimsHash is a hash of the Account JWT claims, used
+                  to determine if the claims have changed and a new JWT needs to be
+                  generated.
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current

--- a/charts/nauth/resources/crds/nauth.io_accounts.yaml
+++ b/charts/nauth/resources/crds/nauth.io_accounts.yaml
@@ -497,6 +497,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              claimsHash:
+                description: ClaimsHash is a hash of the Account JWT claims, used
+                  to determine if the claims have changed and a new JWT needs to be
+                  generated.
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -183,6 +183,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if result.Claims != nil {
 		natsAccount.Status.Claims = *result.Claims
 	}
+	natsAccount.Status.ClaimsHash = result.ClaimsHash
 	natsAccount.Status.ObservedGeneration = natsAccount.Generation
 	natsAccount.Status.ReconcileTimestamp = metav1.Now()
 

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -107,6 +107,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAc
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
 		Claims:          &v1alpha1.AccountClaims{},
+		ClaimsHash:      "CLAIMS_HASH",
 	}
 	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
 
@@ -123,6 +124,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAc
 		t.Equal(metav1.ConditionTrue, c.Status)
 		t.Equal(conditionReasonReconciled, c.Reason)
 	}
+	t.Equal("CLAIMS_HASH", account.Status.ClaimsHash)
 	t.Equal(t.operatorVersion, account.Status.OperatorVersion)
 	t.Empty(t.fakeRecorder.Events)
 }

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -162,18 +162,29 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 		return nil, fmt.Errorf("failed to sign account jwt: %w", err)
 	}
 
-	sysConn, err := a.natsSysClient.Connect(cluster.NatsURL, cluster.SystemAdminCreds)
+	claimsHash, err := hashSignedAccountJWTClaims(signedJwt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to NATS cluster: %w", err)
+		return nil, fmt.Errorf("failed to hash account claims: %w", err)
 	}
-	defer sysConn.Disconnect()
 
-	// TODO: [#11] Don't upload AccountJWT if unchanged (hash)
-	logf.FromContext(ctx).Info("Uploading Account JWT to NATS", "accountID", accountPublicKey)
+	log := logf.FromContext(ctx)
+	prevClaimsHash := account.Status.ClaimsHash
+	if prevClaimsHash == "" || prevClaimsHash != claimsHash {
+		sysConn, err := a.natsSysClient.Connect(cluster.NatsURL, cluster.SystemAdminCreds)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to NATS cluster: %w", err)
+		}
+		defer sysConn.Disconnect()
 
-	err = sysConn.UploadAccountJWT(signedJwt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to upload account jwt: %w", err)
+		err = sysConn.UploadAccountJWT(signedJwt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upload account jwt: %w", err)
+		}
+		log.Info("Uploaded Account JWT to NATS",
+			"accountID", accountPublicKey, "prevClaimsHash", prevClaimsHash, "claimsHash", claimsHash)
+	} else {
+		log.Info("Skipped Account JWT upload to NATS because claims are unchanged",
+			"accountID", accountPublicKey, "prevClaimsHash", prevClaimsHash, "claimsHash", claimsHash)
 	}
 
 	nauthClaims := convertNatsAccountClaims(natsClaims)
@@ -181,6 +192,7 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 		AccountID:       accountPublicKey,
 		AccountSignedBy: operatorSigningPublicKey,
 		Claims:          &nauthClaims,
+		ClaimsHash:      claimsHash,
 		// TODO: [#11] Set Adoptions
 	}, nil
 }
@@ -208,11 +220,6 @@ func (a *AccountManager) Import(ctx context.Context, state *v1alpha1.Account) (*
 	cluster, err := a.resolveClusterTarget(ctx, state)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve cluster target: %w", err)
-	}
-
-	operatorSigningPublicKey, err := cluster.OperatorSigningKey.PublicKey()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get operator signing public key during import: %w", err)
 	}
 
 	accountID := state.GetLabel(v1alpha1.AccountLabelAccountID)
@@ -255,10 +262,15 @@ func (a *AccountManager) Import(ctx context.Context, state *v1alpha1.Account) (*
 	}
 
 	nauthClaims := convertNatsAccountClaims(natsClaims)
+	claimsHash, err := hashSignedAccountJWTClaims(accountJWT)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash account claims during import: %w", err)
+	}
 	return &domain.AccountResult{
 		AccountID:       accountID,
-		AccountSignedBy: operatorSigningPublicKey,
+		AccountSignedBy: natsClaims.Issuer,
 		Claims:          &nauthClaims,
+		ClaimsHash:      claimsHash,
 	}, nil
 }
 

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
@@ -10,6 +12,7 @@ import (
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
+	"k8s.io/apimachinery/pkg/util/json"
 )
 
 type accountClaimsBuilder struct {
@@ -205,6 +208,24 @@ func (b *accountClaimsBuilder) build() (*jwt.AccountClaims, error) {
 	}
 
 	return b.claim, nil
+}
+
+func hashSignedAccountJWTClaims(accountJWT string) (string, error) {
+	claims, err := jwt.DecodeAccountClaims(accountJWT)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode account JWT claims for hashing: %w", err)
+	}
+	// Exclude unstable JWT metadata so equivalent account content hashes the same across reconciles.
+	claims.IssuedAt = 0
+	claims.ID = ""
+
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func convertNatsAccountClaims(claims *jwt.AccountClaims) v1alpha1.AccountClaims {

--- a/internal/core/account_claims_test.go
+++ b/internal/core/account_claims_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
@@ -147,6 +148,52 @@ func Test_AccountClaims_convertNatsAccountClaims_ShouldSucceed_WhenMinimal(t *te
 			Payload: &ptrNoLimit,
 		},
 	}, result)
+}
+
+func Test_AccountClaims_hashSignedAccountJWTClaims_ShouldGenerateDeterministicHash(t *testing.T) {
+	// Given
+	opSignKey, _ := nkeys.CreateOperator()
+	accKey, _ := nkeys.CreateAccount()
+	accID, _ := accKey.PublicKey()
+	accSignKey, _ := nkeys.CreateAccount()
+	accSignPubKey, _ := accSignKey.PublicKey()
+	toJWT := func(claims *jwt.AccountClaims, opSignKey nkeys.KeyPair) string {
+		signedJWT, err := claims.Encode(opSignKey)
+		require.NoError(t, err)
+		return signedJWT
+	}
+
+	claims0 := jwt.NewAccountClaims(accID)
+	claims0.Name = "Test Account"
+	claims0.SigningKeys.Add(accSignPubKey)
+	jwt0 := toJWT(claims0, opSignKey)
+
+	time.Sleep(1010 * time.Millisecond) // Ensure that time-based fields would differ if not fixed
+
+	claims1 := jwt.NewAccountClaims(accID)
+	claims1.Name = "Test Account"
+	claims1.SigningKeys.Add(accSignPubKey)
+	jwt1 := toJWT(claims1, opSignKey)
+
+	unitUnderTest := func(jwt string) string {
+		hash, err := hashSignedAccountJWTClaims(jwt)
+		require.NoError(t, err)
+		return hash
+	}
+
+	// When
+	claims0Hash := unitUnderTest(jwt0)
+
+	// Then
+	require.Equal(t, claims0Hash, unitUnderTest(jwt0), "expected hash to be deterministic for same JWT")
+	require.Equal(t, claims0Hash, unitUnderTest(jwt1), "expected hash to be deterministic for same claims and signing key")
+
+	opSignKeyOther, _ := nkeys.CreateOperator()
+	require.NotEqual(t, claims0Hash, unitUnderTest(toJWT(claims0, opSignKeyOther)), "expected hash to change when signing key changes")
+
+	claimsOther := *claims0
+	claimsOther.Description = "Claims V2"
+	require.NotEqual(t, claims0Hash, unitUnderTest(toJWT(&claimsOther, opSignKey)), "expected hash to change when claims content changes")
 }
 
 func fakeAccountId(accountRef domain.NamespacedName) string {

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -71,6 +71,10 @@ func (t *AccountManagerTestSuite) SetupTest() {
 }
 
 func (t *AccountManagerTestSuite) TearDownTest() {
+	t.assertAndResetAllMock()
+}
+
+func (t *AccountManagerTestSuite) assertAndResetAllMock() {
 	t.clusterTargetResolverMock.AssertExpectations(t.T())
 	t.secretManagerMock.AssertExpectations(t.T())
 	t.accountReaderMock.AssertExpectations(t.T())
@@ -78,6 +82,14 @@ func (t *AccountManagerTestSuite) TearDownTest() {
 	t.natsSysConnMock.AssertExpectations(t.T())
 	t.natsAccClientMock.AssertExpectations(t.T())
 	t.natsAccConnMock.AssertExpectations(t.T())
+
+	t.clusterTargetResolverMock.Mock = mock.Mock{}
+	t.secretManagerMock.Mock = mock.Mock{}
+	t.accountReaderMock.Mock = mock.Mock{}
+	t.natsSysClientMock.Mock = mock.Mock{}
+	t.natsSysConnMock.Mock = mock.Mock{}
+	t.natsAccClientMock.Mock = mock.Mock{}
+	t.natsAccConnMock.Mock = mock.Mock{}
 }
 
 func TestAccountManager_TestSuite(t *testing.T) {
@@ -316,6 +328,147 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldSucceed() {
 	t.verifyAccountResult(result, caughtAccountJWT, accountRootKey, accountSignKey)
 }
 
+func (t *AccountManagerTestSuite) Test_Update_ShouldSkipUpload_WhenClaimsHashUnchanged() {
+	// Given
+	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
+	accountRootKey, _ := nkeys.CreateAccount()
+	accountID, _ := accountRootKey.PublicKey()
+	accountSignKey, _ := nkeys.CreateAccount()
+
+	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
+	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
+		Root: accountRootKey,
+		Sign: accountSignKey,
+	})
+	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
+	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) {})
+	t.natsSysConnMock.mockDisconnect()
+
+	initialResult, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
+				},
+			},
+			Spec: v1alpha1.AccountSpec{},
+		},
+	})
+	t.Require().NoError(err)
+	t.Require().NotNil(initialResult)
+	t.Require().NotEmpty(initialResult.ClaimsHash)
+	t.assertAndResetAllMock()
+
+	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
+	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
+		Root: accountRootKey,
+		Sign: accountSignKey,
+	})
+
+	// When
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
+				},
+			},
+			Spec: v1alpha1.AccountSpec{},
+			Status: v1alpha1.AccountStatus{
+				ClaimsHash: initialResult.ClaimsHash,
+			},
+		},
+	})
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.Equal(initialResult.ClaimsHash, result.ClaimsHash)
+}
+
+func (t *AccountManagerTestSuite) Test_Update_ShouldUploadNewAccountJWT_WhenOperatorSigningKeyHashChanged() {
+	// Given
+	var caughtAccountJWT string
+	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
+	accountRootKey, _ := nkeys.CreateAccount()
+	accountID, _ := accountRootKey.PublicKey()
+	accountSignKey, _ := nkeys.CreateAccount()
+
+	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
+	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
+		Root: accountRootKey,
+		Sign: accountSignKey,
+	})
+	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
+	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) {})
+	t.natsSysConnMock.mockDisconnect()
+
+	initialResult, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
+				},
+			},
+			Spec: v1alpha1.AccountSpec{},
+		},
+	})
+	t.Require().NoError(err)
+	t.Require().NotNil(initialResult)
+	t.Require().NotEmpty(initialResult.ClaimsHash)
+	t.assertAndResetAllMock()
+
+	newOpSignKey, err := nkeys.CreateOperator()
+	t.Require().NoError(err)
+	newOpSignKeyPublic, err := newOpSignKey.PublicKey()
+	t.Require().NoError(err)
+	t.clusterTarget.OperatorSigningKey = newOpSignKey
+
+	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
+	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
+		Root: accountRootKey,
+		Sign: accountSignKey,
+	})
+	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
+	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) { caughtAccountJWT = jwt })
+	t.natsSysConnMock.mockDisconnect()
+
+	// When
+	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
+		Account: v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "account-namespace",
+				Name:      "account-name",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountID,
+				},
+			},
+			Spec: v1alpha1.AccountSpec{},
+			Status: v1alpha1.AccountStatus{
+				ClaimsHash: initialResult.ClaimsHash,
+			},
+		},
+	})
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.NotEqual(initialResult.ClaimsHash, result.ClaimsHash)
+	t.Equal(newOpSignKeyPublic, result.AccountSignedBy)
+	t.NotEmpty(caughtAccountJWT)
+
+	parsedClaims, err := jwt.DecodeAccountClaims(caughtAccountJWT)
+	t.NoError(err)
+	t.Equal(result.AccountID, parsedClaims.Subject)
+	t.Equal(newOpSignKeyPublic, parsedClaims.Issuer)
+}
+
 func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountSecretsAreMissing() {
 	// Given
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
@@ -486,6 +639,7 @@ func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {
 	t.NoError(err)
 	t.NotNil(result)
 	t.Equal(accountID, result.AccountID)
+	t.Equal(accountSignKeyPublic, result.AccountSignedBy)
 	t.Equal(existingNatsLimitsSubs, *result.Claims.NatsLimits.Subs)
 }
 
@@ -756,6 +910,7 @@ func (t *AccountManagerTestSuite) verifyAccountResult(result *domain.AccountResu
 	t.NotEmpty(result.AccountID)
 	t.Equal(result.AccountID, rootKeyPublic)
 	t.Equal(t.opSignKeyPublic, result.AccountSignedBy)
+	t.NotEmpty(result.ClaimsHash)
 
 	t.NotEmpty(caughtAccountJWT)
 	accountClaims, err := jwt.DecodeAccountClaims(caughtAccountJWT)

--- a/internal/domain/nauth.go
+++ b/internal/domain/nauth.go
@@ -13,6 +13,7 @@ type AccountResult struct {
 	AccountID       string
 	AccountSignedBy string
 	Claims          *v1alpha1.AccountClaims
+	ClaimsHash      string
 	Adoptions       *v1alpha1.AccountAdoptions
 }
 


### PR DESCRIPTION
Add deterministic hashing of normalized NATS Account claims and persist the hash in Account status so reconciliation can detect when the effective Account JWT content is unchanged.

This is needed because the previous short-circuit based on Account generation, observedGeneration, and operator version is no longer valid once Account reconciliation depends on external child resources such as AccountExport. As reconciliation becomes more frequent, we must avoid uploading the same Account JWT to NATS over and over and unnecessarily hammering the cluster.

Issue: #11