### PR TITLE
feat: adopt account export resources into account claims

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -12,6 +12,7 @@ import (
 	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -150,9 +151,12 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 		return nil, fmt.Errorf("failed to get operator signing public key: %w", err)
 	}
 
-	natsClaims, err := newAccountClaimsBuilder(ctx, getDisplayName(account), account.Spec, accountPublicKey, a.accountReader).
-		signingKey(accountSigningPublicKey).
-		build()
+	claimsBuilder := newAccountClaimsBuilder(ctx, getDisplayName(account), account.Spec, accountPublicKey, a.accountReader)
+	claimsBuilder.addSigningKey(accountSigningPublicKey)
+	adoptions := &v1alpha1.AccountAdoptions{
+		Exports: adoptExports(claimsBuilder, resources.Exports),
+	}
+	natsClaims, err := claimsBuilder.build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build NATS account claims: %w", err)
 	}
@@ -193,8 +197,43 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 		AccountSignedBy: operatorSigningPublicKey,
 		Claims:          &nauthClaims,
 		ClaimsHash:      claimsHash,
-		// TODO: [#11] Set Adoptions
+		Adoptions:       adoptions,
 	}, nil
+}
+
+func adoptExports(builder *accountClaimsBuilder, exports []v1alpha1.AccountExport) []v1alpha1.AccountAdoption {
+	adoptions := make([]v1alpha1.AccountAdoption, len(exports))
+	for i, export := range exports {
+		var adoptionStatus v1alpha1.AccountAdoptionStatus
+		desiredClaim := export.Status.DesiredClaim
+		if desiredClaim == nil {
+			adoptionStatus = v1alpha1.AccountAdoptionStatus{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(metav1.StatusReasonInvalid),
+				Message: "missing desired claim in export status",
+			}
+		} else if err := builder.addExportRuleGroup(desiredClaim.Rules); err != nil {
+			adoptionStatus = v1alpha1.AccountAdoptionStatus{
+				Status:                         metav1.ConditionFalse,
+				Reason:                         string(metav1.StatusReasonInvalid),
+				DesiredClaimObservedGeneration: &desiredClaim.ObservedGeneration,
+				Message:                        err.Error(),
+			}
+		} else {
+			adoptionStatus = v1alpha1.AccountAdoptionStatus{
+				Status:                         metav1.ConditionTrue,
+				Reason:                         "Adopted",
+				DesiredClaimObservedGeneration: &desiredClaim.ObservedGeneration,
+			}
+		}
+		adoptions[i] = v1alpha1.AccountAdoption{
+			Name:               export.Name,
+			UID:                export.UID,
+			ObservedGeneration: export.Generation,
+			Status:             adoptionStatus,
+		}
+	}
+	return adoptions
 }
 
 func signAccountJWT(claims *jwt.AccountClaims, operatorSigningKey nkeys.KeyPair) (string, error) {
@@ -204,11 +243,6 @@ func signAccountJWT(claims *jwt.AccountClaims, operatorSigningKey nkeys.KeyPair)
 		return "", fmt.Errorf("account claims validation failed: %v", errs)
 	}
 	return claims.Encode(operatorSigningKey)
-}
-
-func (a *AccountManager) ValidateExports(ctx context.Context, state *v1alpha1.AccountExport) (*domain.AccountExportClaim, error) {
-	// TODO: [#22] Implement ValidateExports
-	return nil, fmt.Errorf("not implemented, [#22] ValidateExports")
 }
 
 func (a *AccountManager) Import(ctx context.Context, state *v1alpha1.Account) (*domain.AccountResult, error) {

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
@@ -127,36 +128,20 @@ func newAccountClaimsBuilder(
 		exports := make(jwt.Exports, 0, len(spec.Exports))
 
 		for _, export := range spec.Exports {
-			var targetType jwt.ExportType
-			switch export.Type {
-			case v1alpha1.Stream:
-				targetType = jwt.Stream
-			case v1alpha1.Service:
-				targetType = jwt.Service
-			default:
-				targetType = jwt.Stream
-			}
-
-			var latency *jwt.ServiceLatency
-			if export.Latency != nil {
-				latency = &jwt.ServiceLatency{
-					Sampling: jwt.SamplingRate(export.Latency.Sampling),
-					Results:  jwt.Subject(export.Latency.Results),
-				}
-			}
-
 			exportClaim := &jwt.Export{
 				Name:                 export.Name,
 				Subject:              jwt.Subject(export.Subject),
-				Type:                 targetType,
+				Type:                 toJWTExportType(export.Type),
 				TokenReq:             export.TokenReq,
 				Revocations:          jwt.RevocationList(export.Revocations),
 				ResponseType:         jwt.ResponseType(export.ResponseType),
 				ResponseThreshold:    export.ResponseThreshold,
-				Latency:              latency,
 				AccountTokenPosition: export.AccountTokenPosition,
 				Advertise:            export.Advertise,
 				AllowTrace:           export.AllowTrace,
+			}
+			if export.Latency != nil {
+				exportClaim.Latency = toJWTServiceLatency(*export.Latency)
 			}
 			exports = append(exports, exportClaim)
 		}
@@ -197,7 +182,43 @@ func newAccountClaimsBuilder(
 	}
 }
 
-func (b *accountClaimsBuilder) signingKey(signingKey string) *accountClaimsBuilder {
+func (b *accountClaimsBuilder) addExportRuleGroup(rules []v1alpha1.AccountExportRule) error {
+	tmpClaim := *b.claim
+	for _, rule := range rules {
+		export := jwt.Export{
+			Name:         rule.Name,
+			Subject:      jwt.Subject(rule.Subject),
+			Type:         toJWTExportType(rule.Type),
+			ResponseType: jwt.ResponseType(rule.ResponseType),
+		}
+		if rule.ResponseThreshold != nil {
+			export.ResponseThreshold = *rule.ResponseThreshold
+		}
+		if rule.Latency != nil {
+			export.Latency = toJWTServiceLatency(*rule.Latency)
+		}
+		if rule.AccountTokenPosition != nil {
+			export.AccountTokenPosition = *rule.AccountTokenPosition
+		}
+		if rule.Advertise != nil {
+			export.Advertise = *rule.Advertise
+		}
+		if rule.AllowTrace != nil {
+			export.AllowTrace = *rule.AllowTrace
+		}
+		tmpClaim.Exports = appendExportIfMissing(tmpClaim.Exports, export)
+	}
+	validationResults := &jwt.ValidationResults{}
+	tmpClaim.Exports.Validate(validationResults)
+	validationErrors := validationResults.Errors()
+	if len(validationErrors) != 0 {
+		return fmt.Errorf("rules adoption failed: %w", errors.Join(validationErrors...))
+	}
+	b.claim.Exports = tmpClaim.Exports
+	return nil
+}
+
+func (b *accountClaimsBuilder) addSigningKey(signingKey string) *accountClaimsBuilder {
 	b.claim.SigningKeys.Add(signingKey)
 	return b
 }
@@ -376,4 +397,35 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) v1alpha1.AccountClaims 
 	}
 
 	return out
+}
+
+// Helpers
+
+func appendExportIfMissing(exports jwt.Exports, export jwt.Export) jwt.Exports {
+	for _, existing := range exports {
+		if existing != nil && reflect.DeepEqual(export, *existing) {
+			return exports
+		}
+	}
+	return append(exports, &export)
+}
+
+func toJWTExportType(source v1alpha1.ExportType) jwt.ExportType {
+	var result jwt.ExportType
+	switch source {
+	case v1alpha1.Stream:
+		result = jwt.Stream
+	case v1alpha1.Service:
+		result = jwt.Service
+	default:
+		result = jwt.Stream
+	}
+	return result
+}
+
+func toJWTServiceLatency(source v1alpha1.ServiceLatency) *jwt.ServiceLatency {
+	return &jwt.ServiceLatency{
+		Sampling: jwt.SamplingRate(source.Sampling),
+		Results:  jwt.Subject(source.Results),
+	}
 }

--- a/internal/core/account_claims_test.go
+++ b/internal/core/account_claims_test.go
@@ -52,8 +52,8 @@ func Test_AccountClaims(t *testing.T) {
 
 			// Build NATS JWT AccountClaims from AccountSpec
 			builder := newAccountClaimsBuilder(ctx, testClaimsDisplayName, *spec, testClaimsAccountPubKey, accountReaderMock)
-			builder.signingKey(testClaimsSigningKey01)
-			builder.signingKey(testClaimsSigningKey02)
+			builder.addSigningKey(testClaimsSigningKey01)
+			builder.addSigningKey(testClaimsSigningKey02)
 
 			natsClaims, err := builder.build()
 			require.NoError(t, err)
@@ -95,8 +95,8 @@ func Test_AccountClaims(t *testing.T) {
 				Imports:         nauthClaims.Imports,
 			}
 			rebuilder := newAccountClaimsBuilder(ctx, testClaimsDisplayName, *rebuiltNatsClaims, testClaimsAccountPubKey, accountReaderMock)
-			rebuilder.signingKey(testClaimsSigningKey01)
-			rebuilder.signingKey(testClaimsSigningKey02)
+			rebuilder.addSigningKey(testClaimsSigningKey01)
+			rebuilder.addSigningKey(testClaimsSigningKey02)
 
 			natsClaimsRebuilt, err := rebuilder.build()
 			require.NoError(t, err)

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -3,26 +3,28 @@ package core
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	approvals "github.com/approvals/go-approval-tests"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type AccountManagerTestSuite struct {
 	suite.Suite
 	ctx context.Context
 
-	opSignKey       nkeys.KeyPair
-	opSignKeyPublic string
-	sauCreds        domain.NatsUserCreds
-	natsURL         string
-	clusterTarget   clusterTarget
+	keys          testKeys
+	sauCreds      domain.NatsUserCreds
+	natsURL       string
+	clusterTarget clusterTarget
 
 	accountReaderMock         *AccountReaderMock
 	natsSysClientMock         *NatsSysClientMock
@@ -38,8 +40,7 @@ type AccountManagerTestSuite struct {
 func (t *AccountManagerTestSuite) SetupTest() {
 	t.ctx = context.Background()
 
-	t.opSignKey, _ = nkeys.CreateOperator()
-	t.opSignKeyPublic, _ = t.opSignKey.PublicKey()
+	t.keys = testKeys1()
 	t.sauCreds = domain.NatsUserCreds{
 		Creds:     []byte("FAKE_CREDENTIALS"),
 		AccountID: "FAKE_SYS_ACCOUNT_ID",
@@ -47,7 +48,7 @@ func (t *AccountManagerTestSuite) SetupTest() {
 	t.natsURL = "nats://nats:4222"
 	t.clusterTarget = clusterTarget{
 		NatsURL:            t.natsURL,
-		OperatorSigningKey: t.opSignKey,
+		OperatorSigningKey: t.keys.OpSign.KeyPair,
 		SystemAdminCreds:   t.sauCreds,
 	}
 
@@ -75,6 +76,11 @@ func (t *AccountManagerTestSuite) TearDownTest() {
 }
 
 func (t *AccountManagerTestSuite) assertAndResetAllMock() {
+	t.assertAllMocks()
+	t.resetAllMocks()
+}
+
+func (t *AccountManagerTestSuite) assertAllMocks() {
 	t.clusterTargetResolverMock.AssertExpectations(t.T())
 	t.secretManagerMock.AssertExpectations(t.T())
 	t.accountReaderMock.AssertExpectations(t.T())
@@ -82,7 +88,9 @@ func (t *AccountManagerTestSuite) assertAndResetAllMock() {
 	t.natsSysConnMock.AssertExpectations(t.T())
 	t.natsAccClientMock.AssertExpectations(t.T())
 	t.natsAccConnMock.AssertExpectations(t.T())
+}
 
+func (t *AccountManagerTestSuite) resetAllMocks() {
 	t.clusterTargetResolverMock.Mock = mock.Mock{}
 	t.secretManagerMock.Mock = mock.Mock{}
 	t.accountReaderMock.Mock = mock.Mock{}
@@ -207,14 +215,13 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldSucceed_WhenSecretsAlreadyEx
 		caughtAccountJWT string
 	)
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
-	accountRootKey, _ := nkeys.CreateAccount()
-	accountSignKey, _ := nkeys.CreateAccount()
+	keys := testKeys1()
 	var natsLimitsSubs int64 = 100
 
 	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
 	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, "", &Secrets{
-		Root: accountRootKey,
-		Sign: accountSignKey,
+		Root: keys.AcRoot.KeyPair,
+		Sign: keys.AcSign.KeyPair,
 	})
 	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
 	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) { caughtAccountJWT = jwt })
@@ -239,9 +246,59 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldSucceed_WhenSecretsAlreadyEx
 	t.NoError(err)
 	t.NotNil(result)
 
-	jwtClaims := t.verifyAccountResult(result, caughtAccountJWT, accountRootKey, accountSignKey)
+	jwtClaims := t.verifyAccountResult(result, caughtAccountJWT, keys.AcRoot.KeyPair, keys.AcSign.KeyPair)
 
 	t.Equal(natsLimitsSubs, jwtClaims.Limits.Subs)
+}
+
+func (t *AccountManagerTestSuite) Test_CreateOrUpdate_ShouldSucceed_Adoptions() {
+	testCases := discoverTestCases("approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.{TestCase}.input.yaml")
+	t.Require().NotEmpty(testCases, "no test cases discovered")
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func() {
+			// Given
+			t.resetAllMocks()
+			inputData, err := os.ReadFile(testCase.InputFile)
+			t.Require().NoError(err)
+			var input domain.AccountResources
+			t.Require().NoError(yaml.UnmarshalStrict(inputData, &input))
+			t.Require().NotEmpty(input.Account.Name, "account.name must be present in input file")
+			t.Require().NotEmpty(input.Account.Namespace, "account.namespace must be present in input file")
+			t.Require().Nil(input.Account.Spec.NatsClusterRef, "account.natsClusterRef must be absent in input file")
+
+			accountRef := domain.NewNamespacedName(input.Account.Namespace, input.Account.Name)
+			keys := testKeys1()
+
+			t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
+			t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, "", &Secrets{
+				Root: keys.AcRoot.KeyPair,
+				Sign: keys.AcSign.KeyPair,
+			})
+			t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
+			var caughtAccountJWT string
+			t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) { caughtAccountJWT = jwt })
+			t.natsSysConnMock.mockDisconnect()
+
+			// When
+			result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, input)
+
+			// Then
+			t.assertAndResetAllMock()
+			t.Require().NoError(err)
+			t.Require().NotNil(result)
+			t.Require().NotEmpty(caughtAccountJWT)
+
+			t.NotNil(result.Claims)
+			t.NotEmpty(result.ClaimsHash)
+			t.verifyAccountResult(result, caughtAccountJWT, t.keys.AcRoot.KeyPair, t.keys.AcSign.KeyPair)
+
+			resultYaml, err := yaml.Marshal(result)
+			t.Require().NoError(err)
+			approvals.VerifyString(t.T(), string(resultYaml), approvalOptionsForTestSuite(&t.Suite).
+				ForFile().WithExtension(".yaml"))
+		})
+	}
 }
 
 func (t *AccountManagerTestSuite) Test_Create_ShouldFail_WhenClusterNotFound() {
@@ -294,14 +351,12 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldSucceed() {
 		caughtAccountJWT string
 	)
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
-	accountRootKey, _ := nkeys.CreateAccount()
-	accountID, _ := accountRootKey.PublicKey()
-	accountSignKey, _ := nkeys.CreateAccount()
+	accountID := t.keys.AcRoot.PublicKey
 
 	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
 	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
-		Root: accountRootKey,
-		Sign: accountSignKey,
+		Root: t.keys.AcRoot.KeyPair,
+		Sign: t.keys.AcSign.KeyPair,
 	})
 	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
 	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) { caughtAccountJWT = jwt })
@@ -325,20 +380,18 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldSucceed() {
 	t.NoError(err)
 	t.NotNil(result)
 
-	t.verifyAccountResult(result, caughtAccountJWT, accountRootKey, accountSignKey)
+	t.verifyAccountResult(result, caughtAccountJWT, t.keys.AcRoot.KeyPair, t.keys.AcSign.KeyPair)
 }
 
 func (t *AccountManagerTestSuite) Test_Update_ShouldSkipUpload_WhenClaimsHashUnchanged() {
 	// Given
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
-	accountRootKey, _ := nkeys.CreateAccount()
-	accountID, _ := accountRootKey.PublicKey()
-	accountSignKey, _ := nkeys.CreateAccount()
+	accountID := t.keys.AcRoot.PublicKey
 
 	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
 	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
-		Root: accountRootKey,
-		Sign: accountSignKey,
+		Root: t.keys.AcRoot.KeyPair,
+		Sign: t.keys.AcSign.KeyPair,
 	})
 	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
 	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) {})
@@ -363,8 +416,8 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldSkipUpload_WhenClaimsHashUnc
 
 	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
 	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
-		Root: accountRootKey,
-		Sign: accountSignKey,
+		Root: t.keys.AcRoot.KeyPair,
+		Sign: t.keys.AcSign.KeyPair,
 	})
 
 	// When
@@ -394,14 +447,12 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldUploadNewAccountJWT_WhenOper
 	// Given
 	var caughtAccountJWT string
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
-	accountRootKey, _ := nkeys.CreateAccount()
-	accountID, _ := accountRootKey.PublicKey()
-	accountSignKey, _ := nkeys.CreateAccount()
+	accountID := t.keys.AcRoot.PublicKey
 
 	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
 	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
-		Root: accountRootKey,
-		Sign: accountSignKey,
+		Root: t.keys.AcRoot.KeyPair,
+		Sign: t.keys.AcSign.KeyPair,
 	})
 	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
 	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) {})
@@ -432,8 +483,8 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldUploadNewAccountJWT_WhenOper
 
 	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, nil, &t.clusterTarget)
 	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
-		Root: accountRootKey,
-		Sign: accountSignKey,
+		Root: t.keys.AcRoot.KeyPair,
+		Sign: t.keys.AcSign.KeyPair,
 	})
 	t.natsSysClientMock.mockConnect(t.natsURL, t.sauCreds, t.natsSysConnMock)
 	t.natsSysConnMock.mockUploadAccountJWTCatch(func(jwt string) { caughtAccountJWT = jwt })
@@ -609,7 +660,7 @@ func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {
 		},
 	}
 	existingClaims, err := newAccountClaimsBuilder(t.ctx, "Existing Account", existingSpec, accountID, t.accountReaderMock).
-		signingKey(accountSignKeyPublic).
+		addSigningKey(accountSignKeyPublic).
 		build()
 	t.NoError(err, "failed to build existing account claims")
 	existingJWT, err := existingClaims.Encode(accountSignKey)
@@ -901,6 +952,8 @@ func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldFailWhenClaimsValidatio
 *****************************************************/
 
 func (t *AccountManagerTestSuite) verifyAccountResult(result *domain.AccountResult, caughtAccountJWT string, expectRootKey, expectSignKey nkeys.KeyPair) *jwt.AccountClaims {
+	t.Require().NotEmpty(caughtAccountJWT, "caught Account JWT must not be empty")
+
 	rootKeyPublic, err := expectRootKey.PublicKey()
 	t.NoError(err, "failed to get public key from expect root key pair")
 	signKeyPublic, err := expectSignKey.PublicKey()
@@ -909,14 +962,13 @@ func (t *AccountManagerTestSuite) verifyAccountResult(result *domain.AccountResu
 	t.NotNil(result)
 	t.NotEmpty(result.AccountID)
 	t.Equal(result.AccountID, rootKeyPublic)
-	t.Equal(t.opSignKeyPublic, result.AccountSignedBy)
+	t.Equal(t.keys.OpSign.PublicKey, result.AccountSignedBy)
 	t.NotEmpty(result.ClaimsHash)
 
-	t.NotEmpty(caughtAccountJWT)
 	accountClaims, err := jwt.DecodeAccountClaims(caughtAccountJWT)
 	t.NoError(err, "failed to decode caught account JWT")
 
-	t.Equal(t.opSignKeyPublic, accountClaims.Issuer)
+	t.Equal(t.keys.OpSign.PublicKey, accountClaims.Issuer)
 	t.Equal(result.AccountID, accountClaims.Subject)
 
 	t.Equal([]string{signKeyPublic}, accountClaims.SigningKeys.Keys(), "account claims should contain the expected signing key")

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.approved.yaml
@@ -1,0 +1,53 @@
+AccountID: ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4
+AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
+Adoptions:
+  exports:
+  - name: export group A
+    observedGeneration: 1
+    status:
+      desiredClaimObservedGeneration: 1
+      reason: Adopted
+      status: "True"
+    uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+  - name: export group B
+    observedGeneration: 1
+    status:
+      desiredClaimObservedGeneration: 1
+      message: 'rules adoption failed: stream export subject "foo.*" already exports
+        "foo.*"'
+      reason: Invalid
+      status: "False"
+    uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+Claims:
+  accountLimits:
+    conn: -1
+    exports: -1
+    imports: -1
+    leaf: -1
+    wildcards: true
+  displayName: account-namespace/account-name
+  exports:
+  - name: my service
+    subject: bar.*
+    type: service
+  - name: my stream
+    subject: foo.*
+    type: stream
+  - name: inline export
+    subject: inline.foor.*
+    type: stream
+  jetStreamLimits:
+    consumer: -1
+    diskMaxStreamBytes: -1
+    diskStorage: -1
+    maxAckPending: -1
+    memMaxStreamBytes: -1
+    memStorage: -1
+    streams: -1
+  natsLimits:
+    data: -1
+    payload: -1
+    subs: -1
+  signingKeys:
+  - key: ADZUBQ2ZAWRNON6VNSZHGLOJ5SOYE6GY2YDBQV3I2ZBQIWWP5YBR3KWT
+ClaimsHash: 706d92c42b4b9882bcd693ca4e63de3dee7095f9c340d3bfceb2c8a512529438

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.input.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.input.yaml
@@ -1,0 +1,49 @@
+account:
+  apiVersion: nauth.io/v1alpha1
+  kind: Account
+  metadata:
+    name: account-name
+    namespace: account-namespace
+  spec:
+    exports:
+      - name: inline export
+        subject: inline.foor.*
+        type: stream
+exports:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: export group A
+      namespace: account-namespace
+      uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+      generation: 1
+    status:
+      desiredClaim:
+        observedGeneration: 1
+        rules:
+          - name: my stream
+            subject: foo.*
+            type: stream
+          - name: my service
+            subject: bar.*
+            type: service
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: export group B
+      namespace: account-namespace
+      uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+      generation: 1
+    status:
+      desiredClaim:
+        observedGeneration: 1
+        rules:
+          - name: valid subject A
+            subject: subject.a
+            type: service
+          - name: expect conflict subject
+            subject: foo.*
+            type: stream
+          - name: valid subject B
+            subject: subject.b
+            type: service

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.approved.yaml
@@ -1,0 +1,52 @@
+AccountID: ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4
+AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
+Adoptions:
+  exports:
+  - name: valid API
+    observedGeneration: 1
+    status:
+      desiredClaimObservedGeneration: 1
+      reason: Adopted
+      status: "True"
+    uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+  - name: invalid API
+    observedGeneration: 1
+    status:
+      desiredClaimObservedGeneration: 1
+      message: 'rules adoption failed: subject "invalid subject" cannot have spaces'
+      reason: Invalid
+      status: "False"
+    uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+Claims:
+  accountLimits:
+    conn: -1
+    exports: -1
+    imports: -1
+    leaf: -1
+    wildcards: true
+  displayName: account-namespace/account-name
+  exports:
+  - name: valid service
+    subject: bar.*
+    type: service
+  - name: valid stream
+    subject: foo.*
+    type: stream
+  - name: inline export
+    subject: inline.foor.*
+    type: stream
+  jetStreamLimits:
+    consumer: -1
+    diskMaxStreamBytes: -1
+    diskStorage: -1
+    maxAckPending: -1
+    memMaxStreamBytes: -1
+    memStorage: -1
+    streams: -1
+  natsLimits:
+    data: -1
+    payload: -1
+    subs: -1
+  signingKeys:
+  - key: ADZUBQ2ZAWRNON6VNSZHGLOJ5SOYE6GY2YDBQV3I2ZBQIWWP5YBR3KWT
+ClaimsHash: 347126abacdec05e5ec2105e7ec426bb365e54cf0ac2e6d4246a07acca8eb0a5

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.input.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.input.yaml
@@ -1,0 +1,48 @@
+account:
+  apiVersion: nauth.io/v1alpha1
+  kind: Account
+  metadata:
+    name: account-name
+    namespace: account-namespace
+  spec:
+    exports:
+      - name: inline export
+        subject: inline.foor.*
+        type: stream
+exports:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: valid API
+      namespace: account-namespace
+      uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+      generation: 1
+    status:
+      desiredClaim:
+        observedGeneration: 1
+        rules:
+          - name: valid stream
+            subject: foo.*
+            type: stream
+          - name: valid service
+            subject: bar.*
+            type: service
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: invalid API
+      namespace: account-namespace
+      uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+      generation: 1
+    status:
+      desiredClaim:
+        observedGeneration: 1
+        rules:
+          - name: valid subject A
+            subject: subject.a
+            type: service
+          - subject: invalid subject
+            type: stream
+          - name: valid subject B
+            subject: subject.b
+            type: service

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMerge.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMerge.approved.yaml
@@ -1,0 +1,47 @@
+AccountID: ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4
+AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
+Adoptions:
+  exports:
+  - name: extracted export
+    observedGeneration: 1
+    status:
+      desiredClaimObservedGeneration: 1
+      reason: Adopted
+      status: "True"
+    uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+Claims:
+  accountLimits:
+    conn: -1
+    exports: -1
+    imports: -1
+    leaf: -1
+    wildcards: true
+  displayName: account-namespace/account-name
+  exports:
+  - name: my service
+    subject: bar.*
+    type: service
+  - name: my extra inline stream
+    subject: baz.*
+    type: stream
+  - name: my extra extracted stream
+    subject: boz.*
+    type: stream
+  - name: my stream
+    subject: foo.*
+    type: stream
+  jetStreamLimits:
+    consumer: -1
+    diskMaxStreamBytes: -1
+    diskStorage: -1
+    maxAckPending: -1
+    memMaxStreamBytes: -1
+    memStorage: -1
+    streams: -1
+  natsLimits:
+    data: -1
+    payload: -1
+    subs: -1
+  signingKeys:
+  - key: ADZUBQ2ZAWRNON6VNSZHGLOJ5SOYE6GY2YDBQV3I2ZBQIWWP5YBR3KWT
+ClaimsHash: d82b726ef4199619dac946bec5ceb981e9fdb371673fb344505b10332514617f

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMerge.input.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMerge.input.yaml
@@ -1,0 +1,38 @@
+account:
+  apiVersion: nauth.io/v1alpha1
+  kind: Account
+  metadata:
+    name: account-name
+    namespace: account-namespace
+  spec:
+    exports:
+      - name: my stream
+        subject: foo.*
+        type: stream
+      - name: my service
+        subject: bar.*
+        type: service
+      - name: my extra inline stream
+        subject: baz.*
+        type: stream
+exports:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: extracted export
+      namespace: account-namespace
+      uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+      generation: 1
+    status:
+      desiredClaim:
+        observedGeneration: 1
+        rules:
+          - name: my extra extracted stream
+            subject: boz.*
+            type: stream
+          - name: my stream
+            subject: foo.*
+            type: stream
+          - name: my service
+            subject: bar.*
+            type: service

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMixed.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMixed.approved.yaml
@@ -1,0 +1,40 @@
+AccountID: ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4
+AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
+Adoptions:
+  exports:
+  - name: sourced export
+    observedGeneration: 1
+    status:
+      desiredClaimObservedGeneration: 1
+      reason: Adopted
+      status: "True"
+    uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+Claims:
+  accountLimits:
+    conn: -1
+    exports: -1
+    imports: -1
+    leaf: -1
+    wildcards: true
+  displayName: account-namespace/account-name
+  exports:
+  - name: inline export
+    subject: inline.foor.*
+    type: stream
+  - subject: sourced.bar.report
+    type: service
+  jetStreamLimits:
+    consumer: -1
+    diskMaxStreamBytes: -1
+    diskStorage: -1
+    maxAckPending: -1
+    memMaxStreamBytes: -1
+    memStorage: -1
+    streams: -1
+  natsLimits:
+    data: -1
+    payload: -1
+    subs: -1
+  signingKeys:
+  - key: ADZUBQ2ZAWRNON6VNSZHGLOJ5SOYE6GY2YDBQV3I2ZBQIWWP5YBR3KWT
+ClaimsHash: 1cdf04050830e5ac042af88fe4fd810aa6adbacd1624f1b8d0ca76121bcc6a11

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMixed.input.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMixed.input.yaml
@@ -1,0 +1,25 @@
+account:
+  apiVersion: nauth.io/v1alpha1
+  kind: Account
+  metadata:
+    name: account-name
+    namespace: account-namespace
+  spec:
+    exports:
+      - name: inline export
+        subject: inline.foor.*
+        type: stream
+exports:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: sourced export
+      namespace: account-namespace
+      uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+      generation: 1
+    status:
+      desiredClaim:
+        observedGeneration: 1
+        rules:
+          - subject: sourced.bar.report
+            type: service

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsOnly.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsOnly.approved.yaml
@@ -1,0 +1,53 @@
+AccountID: ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4
+AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
+Adoptions:
+  exports:
+  - name: foo API
+    observedGeneration: 3
+    status:
+      desiredClaimObservedGeneration: 2
+      reason: Adopted
+      status: "True"
+    uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+  - name: bar API
+    observedGeneration: 1
+    status:
+      desiredClaimObservedGeneration: 1
+      reason: Adopted
+      status: "True"
+    uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+Claims:
+  accountLimits:
+    conn: -1
+    exports: -1
+    imports: -1
+    leaf: -1
+    wildcards: true
+  displayName: account-namespace/account-name
+  exports:
+  - subject: bar.report
+    type: service
+  - name: foo created events
+    subject: evt.foo.created
+    type: stream
+  - name: foo deleted events
+    subject: evt.foo.deleted
+    type: stream
+  - name: foo find service
+    subject: svc.foo.find
+    type: service
+  jetStreamLimits:
+    consumer: -1
+    diskMaxStreamBytes: -1
+    diskStorage: -1
+    maxAckPending: -1
+    memMaxStreamBytes: -1
+    memStorage: -1
+    streams: -1
+  natsLimits:
+    data: -1
+    payload: -1
+    subs: -1
+  signingKeys:
+  - key: ADZUBQ2ZAWRNON6VNSZHGLOJ5SOYE6GY2YDBQV3I2ZBQIWWP5YBR3KWT
+ClaimsHash: ed8f01ee92446515959ed6d09515b34d54f290eccc52eeb49360b34c37a08aa1

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsOnly.input.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsOnly.input.yaml
@@ -1,0 +1,40 @@
+account:
+  apiVersion: nauth.io/v1alpha1
+  kind: Account
+  metadata:
+    name: account-name
+    namespace: account-namespace
+exports:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: foo API
+      namespace: account-namespace
+      uid: aac5f3ce-7ed4-4981-b346-5dfcf778e585
+      generation: 3
+    status:
+      desiredClaim:
+        observedGeneration: 2
+        rules:
+          - name: foo created events
+            subject: evt.foo.created
+            type: stream
+          - name: foo deleted events
+            subject: evt.foo.deleted
+            type: stream
+          - name: foo find service
+            subject: svc.foo.find
+            type: service
+  - apiVersion: nauth.io/v1alpha1
+    kind: Export
+    metadata:
+      name: bar API
+      namespace: account-namespace
+      uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707
+      generation: 1
+    status:
+      desiredClaim:
+        observedGeneration: 1
+        rules:
+          - subject: bar.report
+            type: service

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.InlineOnly.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.InlineOnly.approved.yaml
@@ -1,0 +1,42 @@
+AccountID: ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4
+AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
+Adoptions: {}
+Claims:
+  accountLimits:
+    conn: 100
+    exports: 100
+    imports: 100
+    leaf: -1
+    wildcards: true
+  displayName: account-namespace/account-name
+  exports:
+  - name: JS orders consumer create
+    responseType: Stream
+    subject: $JS.API.CONSUMER.CREATE.orders
+    type: service
+  - name: JS orders consumer create wildcard
+    responseType: Stream
+    subject: $JS.API.CONSUMER.CREATE.orders.>
+    type: service
+  - name: JS orders FC
+    subject: $JS.FC.orders.>
+    type: service
+  - name: JS orders stream
+    subject: orders.S.>
+    type: stream
+  jetStreamLimits:
+    consumer: 50
+    diskMaxStreamBytes: 209715200
+    diskStorage: 209715200
+    maxAckPending: -1
+    maxBytesRequired: true
+    memMaxStreamBytes: 209715200
+    memStorage: 209715200
+    streams: 50
+  natsLimits:
+    data: 1024000
+    payload: 50000
+    subs: 100
+  signingKeys:
+  - key: ADZUBQ2ZAWRNON6VNSZHGLOJ5SOYE6GY2YDBQV3I2ZBQIWWP5YBR3KWT
+ClaimsHash: cecf4119e847f0cc70a68793d92478e0abadc0ca7ba52b98e8adbe78d59025d9

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.InlineOnly.input.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.InlineOnly.input.yaml
@@ -1,0 +1,41 @@
+account:
+  apiVersion: nauth.io/v1alpha1
+  kind: Account
+  metadata:
+    name: account-name
+    namespace: account-namespace
+  spec:
+    accountLimits:
+      conn: 100
+      exports: 100
+      imports: 100
+      leaf: -1
+      wildcards: true
+    exports:
+      - name: JS orders stream
+        subject: orders.S.>
+        type: stream
+      - name: JS orders FC
+        subject: $JS.FC.orders.>
+        type: service
+      - name: JS orders consumer create
+        responseType: Stream
+        subject: $JS.API.CONSUMER.CREATE.orders
+        type: service
+      - name: JS orders consumer create wildcard
+        responseType: Stream
+        subject: $JS.API.CONSUMER.CREATE.orders.>
+        type: service
+    jetStreamLimits:
+      consumer: 50
+      diskMaxStreamBytes: 209715200
+      diskStorage: 209715200
+      maxAckPending: -1
+      maxBytesRequired: true
+      memMaxStreamBytes: 209715200
+      memStorage: 209715200
+      streams: 50
+    natsLimits:
+      data: 1024000
+      payload: 50000
+      subs: 100

--- a/internal/core/main_test.go
+++ b/internal/core/main_test.go
@@ -5,10 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
 	approvals "github.com/approvals/go-approval-tests"
+	approvalscore "github.com/approvals/go-approval-tests/core"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestMain(m *testing.M) {
@@ -49,3 +52,44 @@ func discoverTestCases(pattern string) []TestCaseInputFile {
 	}
 	return testCases
 }
+
+func approvalOptionsForTestSuite(ts *suite.Suite) approvals.VerifyOptions {
+	t := ts.T()
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		t.Fatal("failed to resolve approval caller file")
+	}
+
+	return approvals.Options().ForFile().WithNamer(func(f approvalscore.Failable) approvalscore.ApprovalNamer {
+		return &fixedSourceApprovalNamer{
+			name:       strings.ReplaceAll(f.Name(), "/", "."),
+			sourceFile: file,
+		}
+	})
+}
+
+type fixedSourceApprovalNamer struct {
+	name       string
+	sourceFile string
+}
+
+func (n *fixedSourceApprovalNamer) GetName() string {
+	return n.name
+}
+
+func (n *fixedSourceApprovalNamer) GetReceivedFile(extWithDot string) string {
+	return n.fileName("received", extWithDot)
+}
+
+func (n *fixedSourceApprovalNamer) GetApprovalFile(extWithDot string) string {
+	return n.fileName("approved", extWithDot)
+}
+
+func (n *fixedSourceApprovalNamer) fileName(kind string, extWithDot string) string {
+	testFileName := strings.TrimSuffix(filepath.Base(n.sourceFile), filepath.Ext(n.sourceFile))
+	return filepath.Join(filepath.Dir(n.sourceFile), "approvals", testFileName+"."+n.name+"."+kind+extWithDot)
+}
+
+var _ approvalscore.ApprovalNamer = (*fixedSourceApprovalNamer)(nil)

--- a/internal/core/test_key_test.go
+++ b/internal/core/test_key_test.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nkeys"
+)
+
+type testKeys struct {
+	OpRoot testKey
+	OpSign testKey
+	AcRoot testKey
+	AcSign testKey
+}
+
+func (k testKeys) String() string {
+	return fmt.Sprintf("OpRoot: %s, OpSign: %s, AcRoot: %s, AcSign: %s", k.OpRoot, k.OpSign, k.AcRoot, k.AcSign)
+}
+
+type testKey struct {
+	KeyPair   nkeys.KeyPair
+	Seed      string
+	PublicKey string
+}
+
+func (k testKey) String() string {
+	return fmt.Sprintf("[S:%s, P:%s]", k.Seed, k.PublicKey)
+}
+
+func testKeys1() testKeys {
+	return testKeys{
+		OpRoot: testKeyFixed("SOACDATEBXKVKM32VHLGU4574XUZNUOZ6GVD45J7HVC4D74KJWCR52PZYY", "OAZQ4BE3XWWQZXMZNAJUXUL33QR3JEMGNYUOVRTOSIHZS24GR5OB7GCQ"),
+		OpSign: testKeyFixed("SOAHBKSH6IERVYYRYFF3XD7L6N3FJKQGDK3VVNO5HYVS3HEZIJZTKG32ZI", "ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5"),
+		AcRoot: testKeyFixed("SAAKZTYWR5QQQJOQ3HQMYPPDH2LIDGFS6USLW3P4K47HZEHR6AKVTJYPGQ", "ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4"),
+		AcSign: testKeyFixed("SAABWTQAYJ7BEI65HLX5F4GSWHZL6DH6UQOGWYCEV5OQ63XQT2BNQERQKY", "ADZUBQ2ZAWRNON6VNSZHGLOJ5SOYE6GY2YDBQV3I2ZBQIWWP5YBR3KWT"),
+	}
+}
+
+func testKeyFixed(seed, optExpPub string) testKey {
+	key, err := nkeys.FromSeed([]byte(seed))
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate nkey.KeyPair from seed %q: %s", seed, err.Error()))
+	}
+	pub, err := key.PublicKey()
+	if err != nil {
+		panic(fmt.Sprintf("failed to extract public key from seed %q: %s", seed, err.Error()))
+	}
+	if optExpPub != "" && optExpPub != pub {
+		panic(fmt.Sprintf("unexpected public key generated from seed %q: got %q, want %q", seed, pub, optExpPub))
+	}
+	return testKey{
+		KeyPair:   key,
+		Seed:      seed,
+		PublicKey: pub,
+	}
+}

--- a/internal/domain/nauth.go
+++ b/internal/domain/nauth.go
@@ -5,8 +5,8 @@ import (
 )
 
 type AccountResources struct {
-	Account v1alpha1.Account
-	Exports []v1alpha1.AccountExport
+	Account v1alpha1.Account         `json:"account,omitempty"`
+	Exports []v1alpha1.AccountExport `json:"exports,omitempty"`
 }
 
 type AccountResult struct {


### PR DESCRIPTION
Adopt `AccountExport` child resources during account `CreateOrUpdate` and include the resulting adoption status in `AccountResult.Adoptions`.

This change adds export-rule-group adoption to the account claims builder, tracks adopted/invalid export resources in the account result, and covers the behavior with parameterized suite tests using approval-based assertions for the resulting YAML output.

Issue: #11
