### PR TITLE
build: fix broken make deploy/install targets

### DIFF
--- a/.mise-tasks/nauth/build-installer.sh
+++ b/.mise-tasks/nauth/build-installer.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# MISE description="Render a consolidated install manifest to dist/install.yaml"
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-default}"
+RELEASE_NAME="${RELEASE_NAME:-nauth}"
+CHART_DIR="$MISE_PROJECT_ROOT/charts/nauth"
+OUTPUT_PATH="$MISE_PROJECT_ROOT/dist/install.yaml"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+helm dependency update "$CHART_DIR"
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  > "$OUTPUT_PATH"
+
+echo "Wrote $OUTPUT_PATH"

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,8 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	rm Dockerfile.cross
 
 .PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
-	mkdir -p dist
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+build-installer: manifests generate ## Render a consolidated install manifest from the Helm chart to dist/install.yaml.
+	mise run nauth:build-installer
 
 ##@ Deployment
 
@@ -145,21 +143,21 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+install: manifests generate ## Install CRDs into the current Kubernetes context from kubeconfig.
+	$(KUBECTL) apply -f charts/nauth-crds/crds
 
 .PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+uninstall: manifests generate ## Uninstall CRDs from the current Kubernetes context. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f charts/nauth-crds/crds
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+deploy: manifests generate ## Deploy nauth to the current Kubernetes context using the Helm chart.
+	helm dependency update charts/nauth
+	helm upgrade --install nauth charts/nauth --create-namespace
 
 .PHONY: undeploy
-undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+undeploy: ## Remove the nauth Helm release from the current Kubernetes context.
+	helm uninstall nauth
 
 ##@ Dependencies
 


### PR DESCRIPTION
Replace stale Kubebuilder `config/`-based Make targets with working commands that match the repository's current Helm- and chart-based setup.

What changed:
- proxy `make build-installer` through a canonical Mise task
- make `install` and `uninstall` operate on chart CRDs directly
- make `deploy` and `undeploy` use Helm instead of removed `config/` kustomize paths
- update Makefile help text to reflect current kubeconfig/context behavior
- remove redundant Mise wrapper tasks that did not add project-specific value

Why:
- the old targets referenced a non-existent `config/` tree and were broken
- contributors still expect these Make targets to work
- Mise remains the canonical tool where it adds value, while Make stays usable as a compatibility layer
