### PR TITLE
chore: clean up stale kubebuilder project metadata and scaffold residue

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -14,15 +14,6 @@ resources:
   controller: true
   domain: nauth.io
   group: nauth.io
-  kind: Operator
-  path: github.com/WirelessCar/nauth/api/v1alpha1
-  version: v1alpha1
-- api:
-    crdVersion: v1
-    namespaced: true
-  controller: true
-  domain: nauth.io
-  group: nauth.io
   kind: Account
   path: github.com/WirelessCar/nauth/api/v1alpha1
   version: v1alpha1
@@ -33,6 +24,24 @@ resources:
   domain: nauth.io
   group: nauth.io
   kind: User
+  path: github.com/WirelessCar/nauth/api/v1alpha1
+  version: v1alpha1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: nauth.io
+  group: nauth.io
+  kind: NatsCluster
+  path: github.com/WirelessCar/nauth/api/v1alpha1
+  version: v1alpha1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: nauth.io
+  group: nauth.io
+  kind: AccountExport
   path: github.com/WirelessCar/nauth/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,6 @@ import (
 	"github.com/WirelessCar/nauth/internal/adapter/outbound/nats"
 	"github.com/WirelessCar/nauth/internal/core"
 	"github.com/WirelessCar/nauth/internal/domain"
-	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -60,7 +59,6 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
 }
 
 // nolint:gocyclo
@@ -352,8 +350,6 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "NatsCluster")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
-
 	if metricsCertWatcher != nil {
 		setupLog.Info("Adding metrics certificate watcher to manager")
 		if err := mgr.Add(metricsCertWatcher); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,7 +150,8 @@ func main() {
 		TLSOpts: webhookTLSOpts,
 	})
 
-	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
+	// Metrics endpoint settings are wired through the Helm chart deployment template.
+	// See charts/nauth/templates/deployment.yaml and charts/nauth/templates/metrics_service.yaml.
 	// More info:
 	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/metrics/server
 	// - https://book.kubebuilder.io/reference/metrics.html
@@ -163,7 +164,8 @@ func main() {
 	if secureMetrics {
 		// FilterProvider is used to protect the metrics endpoint with authn/authz.
 		// These configurations ensure that only authorized users and service accounts
-		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
+		// can access the metrics endpoint. The RBAC for this is defined in
+		// charts/nauth/templates/rbac_metrics.yaml. More info:
 		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/metrics/filters#WithAuthenticationAndAuthorization
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
@@ -171,11 +173,6 @@ func main() {
 	// If the certificate is not specified, controller-runtime will automatically
 	// generate self-signed certificates for the metrics server. While convenient for development and testing,
 	// this setup is not recommended for production.
-	//
-	// TODO(user): If you enable certManager, uncomment the following lines:
-	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
-	// managed by cert-manager for the metrics server.
-	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
 	if len(metricsCertPath) > 0 {
 		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)

--- a/internal/adapter/outbound/k8s/suite_test.go
+++ b/internal/adapter/outbound/k8s/suite_test.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
-	// +kubebuilder:scaffold:imports
 )
 
 const testNamespace = "k8s-adapter-test"


### PR DESCRIPTION
## Commits

- **chore(kubebuilder): update PROJECT resource metadata**
- **chore(kubebuilder): remove stale scaffold markers**
- **chore(comments): update stale kubebuilder config references**

## Summary

Clean up stale Kubebuilder metadata and scaffold residue without changing runtime behavior.

## What changed

- update `PROJECT` to match the actual managed resources in the repository
- remove the stale `Operator` entry from `PROJECT`
- add missing `NatsCluster` and `AccountExport` entries to `PROJECT`
- remove inert `+kubebuilder:scaffold:*` markers
- update `cmd/main.go` comments to point to the current Helm chart files instead of removed `config/*` paths
- remove the leftover cert-manager scaffold note that referenced non-existent Kubebuilder paths

## Why

The repository still carries some Kubebuilder-generated metadata and comments, but parts of it had drifted out of sync with the actual repo structure:

- `PROJECT` no longer described the real resources
- scaffold markers were no longer serving any purpose
- some comments in `cmd/main.go` still referenced removed `config/*` files

This PR keeps the Kubebuilder heritage explicit while removing misleading residue.

## Scope

This PR is intentionally limited to metadata and comments:
- no controller behavior changes
- no CRD schema changes
- no chart behavior changes
