### PR TITLE
feat(controller): add AccountImport reconciliation scaffolding

### DIFF
--- a/charts/nauth/templates/deployment.yaml
+++ b/charts/nauth/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
             - --metrics-secure=false
             # TODO: [#11] Remove experimental flag for AccountExport CRD
             - --experimental-account-export={{ .Values.experimental.accountExport.enabled }}
+            # TODO: [#11] Remove experimental flag for AccountImport CRD
+            - --experimental-account-import={{ .Values.experimental.accountImport.enabled }}
             {{- if .Values.namespaced }}
             - --namespace={{ include "nauth.namespaceName" . }}
             {{- end }}

--- a/charts/nauth/templates/rbac_manager_role.yaml
+++ b/charts/nauth/templates/rbac_manager_role.yaml
@@ -32,6 +32,15 @@ rules:
   - patch
   - watch
 - apiGroups:
+    - nauth.io
+  resources:
+    - accountimports
+  verbs:
+    - get
+    - list
+    - patch
+    - watch
+- apiGroups:
   - nauth.io
   resources:
   - natsclusters
@@ -51,6 +60,7 @@ rules:
   resources:
   - accounts/status
   - accountexports/status
+  - accountimports/status
   - natsclusters/status
   - users/status
   verbs:

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -111,6 +111,10 @@ experimental:
   accountExport:
     # -- Enables experimental AccountExport reconciliation. Temporary opt-in until the resource is fully implemented.
     enabled: false
+  # TODO: [#11] Remove experimental flag for AccountImport CRD
+  accountImport:
+    # -- Enables experimental AccountImport reconciliation. Temporary opt-in until the resource is fully implemented.
+    enabled: false
 
 # -- Setting resources is up to the user. Follows PodSpec.
 resources: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var experimentalAccountExport bool // TODO: [#11] Remove experimental flag for AccountExport CRD
+	var experimentalAccountImport bool // TODO: [#11] Remove experimental flag for AccountImport CRD
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -92,6 +93,12 @@ func main() {
 		"experimental-account-export",
 		false,
 		"Enable experimental AccountExport reconciliation (temporary flag).",
+	)
+	flag.BoolVar(
+		&experimentalAccountImport,
+		"experimental-account-import",
+		false,
+		"Enable experimental AccountImport reconciliation (temporary flag).",
 	)
 	opts := zap.Options{
 		Development: true,
@@ -290,6 +297,18 @@ func main() {
 			os.Exit(1)
 		}
 		setupLog.Info("experimental controller enabled", "controller", "AccountExport")
+	}
+
+	if experimentalAccountImport {
+		accountImportReconciler := controller.NewAccountImportReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+		)
+		if err = accountImportReconciler.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "AccountImport")
+			os.Exit(1)
+		}
+		setupLog.Info("experimental controller enabled", "controller", "AccountImport")
 	}
 
 	userManager := core.NewUserManager(accountManager, secretClient)

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
@@ -86,9 +87,11 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	meta.SetStatusCondition(state.GetConditions(), exportAccountCondition)
 
-	if err := r.upsertLabels(ctx, state, importAccountID, exportAccountID); err != nil {
+	if labelsUpdated, err := r.upsertLabels(ctx, state, importAccountID, exportAccountID); err != nil {
 		log.Error(err, "Failed to upsert labels")
 		return ctrl.Result{}, err
+	} else if labelsUpdated {
+		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
 	}
 
 	// TODO: [#11] Validate rules
@@ -176,7 +179,7 @@ func (r *AccountImportReconciler) getConditionedAccount(ctx context.Context, acc
 	}
 }
 
-func (r *AccountImportReconciler) upsertLabels(ctx context.Context, resource *v1alpha1.AccountImport, importAccountID string, exportAccountID string) error {
+func (r *AccountImportReconciler) upsertLabels(ctx context.Context, resource *v1alpha1.AccountImport, importAccountID string, exportAccountID string) (updated bool, err error) {
 	patch := false
 	if importAccountID != "" && importAccountID != resource.GetLabel(v1alpha1.AccountImportLabelAccountID) {
 		resource.SetLabel(v1alpha1.AccountImportLabelAccountID, importAccountID)
@@ -194,13 +197,14 @@ func (r *AccountImportReconciler) upsertLabels(ctx context.Context, resource *v1
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("failed to generate patch for labels: %w", err)
+			return false, fmt.Errorf("failed to generate patch for labels: %w", err)
 		}
 		if err = r.Patch(ctx, resource, client.RawPatch(types.MergePatchType, patchData)); err != nil {
-			return fmt.Errorf("failed to patch labels: %w", err)
+			return false, fmt.Errorf("failed to patch labels: %w", err)
 		}
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func (r *AccountImportReconciler) setConditions(state *v1alpha1.AccountImport, subConditions ...metav1.Condition) {

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// AccountImportReconciler reconciles an AccountImport object.
+type AccountImportReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func NewAccountImportReconciler(k8sClient client.Client, scheme *runtime.Scheme) *AccountImportReconciler {
+	return &AccountImportReconciler{
+		Client: k8sClient,
+		Scheme: scheme,
+	}
+}
+
+// +kubebuilder:rbac:groups=nauth.io,resources=accountimports,verbs=get;list;watch
+
+func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	state := &v1alpha1.AccountImport{}
+	if err := r.Get(ctx, req.NamespacedName, state); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("resource not found. Ignoring since object must be deleted")
+			return ctrl.Result{}, nil
+		}
+
+		log.Error(err, "Failed to get resource")
+		return ctrl.Result{}, err
+	}
+
+	// TODO: [#11] Reconcile AccountImport
+	log.Info("TODO: [#11] Reconcile AccountImport", "resource", req.NamespacedName)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *AccountImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.AccountImport{}).
+		Named("accountimport").
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		Complete(r)
+}

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -18,10 +18,16 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -58,9 +64,55 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	// TODO: [#11] Reconcile AccountImport
-	log.Info("TODO: [#11] Reconcile AccountImport", "resource", req.NamespacedName)
+	importAccountRef := domain.NewNamespacedName(state.Namespace, state.Spec.AccountName)
+	importAccountID := state.GetLabel(v1alpha1.AccountImportLabelAccountID)
+	importAccount, importAccountCondition := r.getConditionedAccount(ctx, importAccountRef, importAccountID)
+	importAccountCondition.Type = conditionTypeBoundToAccount
+	if importAccount != nil {
+		importAccountID = importAccount.GetLabel(v1alpha1.AccountLabelAccountID)
+	}
+	meta.SetStatusCondition(state.GetConditions(), importAccountCondition)
 
+	exportAccountNamespace := state.Spec.ExportAccountRef.Namespace
+	if exportAccountNamespace == "" {
+		exportAccountNamespace = state.Namespace
+	}
+	exportAccountRef := domain.NewNamespacedName(exportAccountNamespace, state.Spec.ExportAccountRef.Name)
+	exportAccountID := state.GetLabel(v1alpha1.AccountImportLabelExportAccountID)
+	exportAccount, exportAccountCondition := r.getConditionedAccount(ctx, exportAccountRef, exportAccountID)
+	exportAccountCondition.Type = conditionTypeBoundToExportAccount
+	if exportAccount != nil {
+		exportAccountID = exportAccount.GetLabel(v1alpha1.AccountLabelAccountID)
+	}
+	meta.SetStatusCondition(state.GetConditions(), exportAccountCondition)
+
+	if err := r.upsertLabels(ctx, state, importAccountID, exportAccountID); err != nil {
+		log.Error(err, "Failed to upsert labels")
+		return ctrl.Result{}, err
+	}
+
+	// TODO: [#11] Validate rules
+	validRulesCondition := metav1.Condition{
+		Type:    conditionTypeValidRules,
+		Status:  metav1.ConditionFalse,
+		Reason:  "NotImplemented",
+		Message: "Rules validation not implemented",
+	}
+
+	// TODO: [#11] Check account adoption
+	adoptedByAccountCondition := metav1.Condition{
+		Type:    conditionTypeAdoptedByAccount,
+		Status:  metav1.ConditionFalse,
+		Reason:  "NotImplemented",
+		Message: "Rules validation not implemented",
+	}
+
+	r.setConditions(state, importAccountCondition, exportAccountCondition, validRulesCondition, adoptedByAccountCondition)
+
+	if err := r.Status().Update(ctx, state); err != nil {
+		log.Error(err, "Failed to update status", "namespace", state.Namespace, "name", state.GetName())
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -73,4 +125,98 @@ func (r *AccountImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: 1,
 		}).
 		Complete(r)
+}
+
+func (r *AccountImportReconciler) getConditionedAccount(ctx context.Context, accountRef domain.NamespacedName, boundAccountID string) (*v1alpha1.Account, metav1.Condition) {
+	if err := accountRef.Validate(); err != nil {
+		return nil, metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  string(metav1.StatusReasonInvalid),
+			Message: fmt.Sprintf("Invalid Account reference %s: %q", accountRef, err),
+		}
+	}
+
+	result := &v1alpha1.Account{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}, result); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, metav1.Condition{
+				Status:  metav1.ConditionFalse,
+				Reason:  string(metav1.StatusReasonNotFound),
+				Message: fmt.Sprintf("Account %s not found", accountRef),
+			}
+		}
+		return nil, metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  string(metav1.StatusReasonInternalError),
+			Message: fmt.Sprintf("Failed to get Account %s: %q", accountRef, err),
+		}
+	}
+
+	accountID := result.GetLabel(v1alpha1.AccountLabelAccountID)
+	if accountID == "" {
+		return nil, metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  string(metav1.StatusReasonInvalid),
+			Message: fmt.Sprintf("Account %s not bound to an Account ID yet", accountRef),
+		}
+	}
+
+	if boundAccountID != "" && boundAccountID != accountID {
+		return nil, metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  string(metav1.StatusReasonConflict),
+			Message: fmt.Sprintf("Account ID conflict: previously bound to %s, now found %s", boundAccountID, accountID),
+		}
+	}
+
+	return result, metav1.Condition{
+		Status:  metav1.ConditionTrue,
+		Reason:  conditionReasonOK,
+		Message: fmt.Sprintf("Account ID: %s", accountID),
+	}
+}
+
+func (r *AccountImportReconciler) upsertLabels(ctx context.Context, resource *v1alpha1.AccountImport, importAccountID string, exportAccountID string) error {
+	patch := false
+	if importAccountID != "" && importAccountID != resource.GetLabel(v1alpha1.AccountImportLabelAccountID) {
+		resource.SetLabel(v1alpha1.AccountImportLabelAccountID, importAccountID)
+		patch = true
+	}
+	if exportAccountID != "" && exportAccountID != resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID) {
+		resource.SetLabel(v1alpha1.AccountImportLabelExportAccountID, exportAccountID)
+		patch = true
+	}
+
+	if patch {
+		patchData, err := json.Marshal(map[string]map[string]map[string]string{
+			"metadata": {
+				"labels": resource.GetLabels(),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to generate patch for labels: %w", err)
+		}
+		if err = r.Patch(ctx, resource, client.RawPatch(types.MergePatchType, patchData)); err != nil {
+			return fmt.Errorf("failed to patch labels: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *AccountImportReconciler) setConditions(state *v1alpha1.AccountImport, subConditions ...metav1.Condition) {
+	ready := metav1.Condition{
+		Type:               conditionTypeReady,
+		ObservedGeneration: state.Generation,
+		Status:             metav1.ConditionTrue,
+		Reason:             conditionReasonReady,
+	}
+	for _, subCondition := range subConditions {
+		subCondition.ObservedGeneration = state.Generation
+		meta.SetStatusCondition(state.GetConditions(), subCondition)
+		if subCondition.Status != metav1.ConditionTrue {
+			ready.Status = metav1.ConditionFalse
+			ready.Reason = conditionReasonNotReady
+		}
+	}
+	meta.SetStatusCondition(state.GetConditions(), ready)
 }

--- a/internal/adapter/inbound/controller/account_import_test.go
+++ b/internal/adapter/inbound/controller/account_import_test.go
@@ -79,22 +79,25 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 	}))
 
 	// When
-	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
 
 	// Then
 	t.Require().NoError(err)
+	t.Require().NotNil(result)
+	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful reconciliation")
 
-	result := &v1alpha1.AccountImport{}
-	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
-	t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(result, conditionTypeValidRules, metav1.ConditionFalse, "NotImplemented")
+	resource := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, resource))
+	t.assertCondition(resource, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(resource, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(resource, conditionTypeValidRules, metav1.ConditionFalse, "NotImplemented")
 	// TODO: [#11] Verify rules validation condition
-	t.assertCondition(result, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
+	t.assertCondition(resource, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
 	// TODO: [#11] Verify account adoption condition
-	t.assertCondition(result, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
-	t.Equal(importAccountID, result.GetLabel(v1alpha1.AccountImportLabelAccountID))
-	t.Equal(exportAccountID, result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+	t.assertCondition(resource, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+	t.Equal(importAccountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
+	t.Equal(exportAccountID, resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful status update")
 }
 
 func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExportAccountInImplicitSameNamespace() {
@@ -124,17 +127,19 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 	}))
 
 	// When
-	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
 
 	// Then
 	t.Require().NoError(err)
+	t.Require().NotNil(result)
+	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful reconciliation")
 
-	result := &v1alpha1.AccountImport{}
-	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
-	t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
-	t.Equal(importAccountID, result.GetLabel(v1alpha1.AccountImportLabelAccountID))
-	t.Equal(exportAccountID, result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+	resource := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, resource))
+	t.assertCondition(resource, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(resource, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.Equal(importAccountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
+	t.Equal(exportAccountID, resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
 }
 
 func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenImportAccountIsNotReady() {
@@ -163,21 +168,26 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenImpo
 	}))
 
 	// When
-	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+	result, err := t.runReconcileLoopForNewResource("", exportAccountID)
+
+	// Then
+	t.Require().NoError(err)
+	t.Require().NotNil(result)
+	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful reconciliation")
 
 	// Then
 	t.Require().NoError(err)
 
-	result := &v1alpha1.AccountImport{}
-	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
+	resource := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, resource))
 
-	condition := t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionFalse, conditionReasonInvalid)
+	condition := t.assertCondition(resource, conditionTypeBoundToAccount, metav1.ConditionFalse, conditionReasonInvalid)
 	t.Contains(condition.Message, "not bound to an Account ID yet")
-	t.Equal("", result.GetLabel(v1alpha1.AccountImportLabelAccountID))
+	t.Equal("", resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
 
-	t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(result, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
-	t.Equal(exportAccountID, result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+	t.assertCondition(resource, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(resource, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+	t.Equal(exportAccountID, resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
 }
 
 func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExportAccountIsNotReady() {
@@ -206,21 +216,23 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 	}))
 
 	// When
-	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+	result, err := t.runReconcileLoopForNewResource(accountID, "")
 
 	// Then
 	t.Require().NoError(err)
+	t.Require().NotNil(result)
+	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful reconciliation")
 
-	result := &v1alpha1.AccountImport{}
-	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
+	resource := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, resource))
 
-	condition := t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionFalse, conditionReasonInvalid)
+	condition := t.assertCondition(resource, conditionTypeBoundToExportAccount, metav1.ConditionFalse, conditionReasonInvalid)
 	t.Contains(condition.Message, "not bound to an Account ID yet")
-	t.Equal("", result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+	t.Equal("", resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
 
-	t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(result, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
-	t.Equal(accountID, result.GetLabel(v1alpha1.AccountImportLabelAccountID))
+	t.assertCondition(resource, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(resource, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+	t.Equal(accountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
 }
 
 func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenResourceNotFound() {
@@ -290,6 +302,22 @@ func (t *AccountImportControllerTestSuite) Test_getConditionedAccount_ShouldRetu
 }
 
 // Helpers
+
+func (t *AccountImportControllerTestSuite) runReconcileLoopForNewResource(expectAccountID string, expectExportAccountID string) (ctrl.Result, error) {
+	// 1) expect labels to be upserted
+	resource := &v1alpha1.AccountImport{}
+	result, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+	t.Require().NoError(err)
+	t.Require().NotNil(result)
+	t.Require().NotEmpty(result.RequeueAfter, "reconcile requeue expected after labels upsert")
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, resource))
+	t.Require().Equalf(expectAccountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID), "Account ID label mismatch")
+	t.Require().Equalf(expectExportAccountID, resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID), "Export Account ID label mismatch")
+	t.Require().Nil(resource.Status.Conditions, "no Status Conditions expected after first reconcile run")
+
+	// 2) expect conditions to be updated
+	return t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+}
 
 func (t *AccountImportControllerTestSuite) assertCondition(result *v1alpha1.AccountImport, conditionType string,
 	expectStatus metav1.ConditionStatus, expectReason string) metav1.Condition {

--- a/internal/adapter/inbound/controller/account_import_test.go
+++ b/internal/adapter/inbound/controller/account_import_test.go
@@ -1,0 +1,328 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type AccountImportControllerTestSuite struct {
+	suite.Suite
+	ctx context.Context
+
+	namespace            string
+	importName           string
+	importNamespacedName ktypes.NamespacedName
+	importAccountName    string
+	exportAccountName    string
+	foreignNamespace     string
+
+	unitUnderTest *AccountImportReconciler
+}
+
+func TestAccountImportController_TestSuite(t *testing.T) {
+	suite.Run(t, new(AccountImportControllerTestSuite))
+}
+
+func (t *AccountImportControllerTestSuite) SetupTest() {
+	t.ctx = context.Background()
+
+	testName := t.T().Name()
+	t.importName = scopedTestName("account-import", testName)
+	t.namespace = scopedTestName("namespace", testName)
+	t.importNamespacedName = ktypes.NamespacedName{Name: t.importName, Namespace: t.namespace}
+	t.importAccountName = scopedTestName("import-account", testName)
+	t.exportAccountName = scopedTestName("export-account", testName)
+	t.foreignNamespace = scopedTestName("export-namespace", testName)
+
+	t.Require().NoError(ensureNamespace(t.ctx, t.namespace))
+
+	t.unitUnderTest = NewAccountImportReconciler(
+		k8sClient,
+		k8sClient.Scheme(),
+	)
+}
+
+func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
+	// Given
+	importAccountID := t.anyAccountID()
+	t.ensureAccount(t.namespace, t.importAccountName, importAccountID)
+	exportAccountID := t.anyAccountID()
+	t.ensureAccount(t.foreignNamespace, t.exportAccountName, exportAccountID)
+
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.importName,
+			Namespace: t.namespace,
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			AccountName: t.importAccountName,
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name:      t.exportAccountName,
+				Namespace: t.foreignNamespace,
+			},
+			Rules: []v1alpha1.AccountImportRule{
+				{
+					Subject: "foo.*",
+					Type:    v1alpha1.Stream,
+				},
+			},
+		},
+	}))
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+
+	// Then
+	t.Require().NoError(err)
+
+	result := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
+	t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(result, conditionTypeValidRules, metav1.ConditionFalse, "NotImplemented")
+	// TODO: [#11] Verify rules validation condition
+	t.assertCondition(result, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
+	// TODO: [#11] Verify account adoption condition
+	t.assertCondition(result, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+	t.Equal(importAccountID, result.GetLabel(v1alpha1.AccountImportLabelAccountID))
+	t.Equal(exportAccountID, result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+}
+
+func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExportAccountInImplicitSameNamespace() {
+	// Given
+	importAccountID := t.anyAccountID()
+	t.ensureAccount(t.namespace, t.importAccountName, importAccountID)
+	exportAccountID := t.anyAccountID()
+	t.ensureAccount(t.namespace, t.exportAccountName, exportAccountID)
+
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.importName,
+			Namespace: t.namespace,
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			AccountName: t.importAccountName,
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name: t.exportAccountName,
+			},
+			Rules: []v1alpha1.AccountImportRule{
+				{
+					Subject: "foo.*",
+					Type:    v1alpha1.Stream,
+				},
+			},
+		},
+	}))
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+
+	// Then
+	t.Require().NoError(err)
+
+	result := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
+	t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.Equal(importAccountID, result.GetLabel(v1alpha1.AccountImportLabelAccountID))
+	t.Equal(exportAccountID, result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+}
+
+func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenImportAccountIsNotReady() {
+	// Given
+	t.ensureAccount(t.namespace, t.importAccountName, "")
+	exportAccountID := t.anyAccountID()
+	t.ensureAccount(t.namespace, t.exportAccountName, exportAccountID)
+
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.importName,
+			Namespace: t.namespace,
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			AccountName: t.importAccountName,
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name: t.exportAccountName,
+			},
+			Rules: []v1alpha1.AccountImportRule{
+				{
+					Subject: "foo.*",
+					Type:    v1alpha1.Stream,
+				},
+			},
+		},
+	}))
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+
+	// Then
+	t.Require().NoError(err)
+
+	result := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
+
+	condition := t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionFalse, conditionReasonInvalid)
+	t.Contains(condition.Message, "not bound to an Account ID yet")
+	t.Equal("", result.GetLabel(v1alpha1.AccountImportLabelAccountID))
+
+	t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(result, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+	t.Equal(exportAccountID, result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+}
+
+func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExportAccountIsNotReady() {
+	// Given
+	accountID := t.anyAccountID()
+	t.ensureAccount(t.namespace, t.importAccountName, accountID)
+	t.ensureAccount(t.namespace, t.exportAccountName, "")
+
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.importName,
+			Namespace: t.namespace,
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			AccountName: t.importAccountName,
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name: t.exportAccountName,
+			},
+			Rules: []v1alpha1.AccountImportRule{
+				{
+					Subject: "foo.*",
+					Type:    v1alpha1.Stream,
+				},
+			},
+		},
+	}))
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+
+	// Then
+	t.Require().NoError(err)
+
+	result := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, result))
+
+	condition := t.assertCondition(result, conditionTypeBoundToExportAccount, metav1.ConditionFalse, conditionReasonInvalid)
+	t.Contains(condition.Message, "not bound to an Account ID yet")
+	t.Equal("", result.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+
+	t.assertCondition(result, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(result, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+	t.Equal(accountID, result.GetLabel(v1alpha1.AccountImportLabelAccountID))
+}
+
+func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenResourceNotFound() {
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, ctrl.Request{NamespacedName: t.importNamespacedName})
+
+	// Then
+	t.Require().NoError(err)
+}
+
+func (t *AccountImportControllerTestSuite) Test_getConditionedAccount_ShouldReturnFalse_WhenAccountRefInvalid() {
+	// Given
+	accountRef := domain.NewNamespacedName("invalid namespace", "account")
+
+	// When
+	account, condition := t.unitUnderTest.getConditionedAccount(t.ctx, accountRef, "")
+
+	// Then
+	t.Equal(metav1.ConditionFalse, condition.Status)
+	t.Equal(string(metav1.StatusReasonInvalid), condition.Reason)
+	t.Contains(condition.Message, "Invalid Account reference")
+	t.Nil(account)
+}
+
+func (t *AccountImportControllerTestSuite) Test_getConditionedAccount_ShouldReturnFalse_WhenAccountNotFound() {
+	// Given
+	accountRef := domain.NewNamespacedName(t.namespace, "my-account")
+
+	// When
+	account, condition := t.unitUnderTest.getConditionedAccount(t.ctx, accountRef, "")
+
+	// Then
+	t.Equal(metav1.ConditionFalse, condition.Status)
+	t.Equal(string(metav1.StatusReasonNotFound), condition.Reason)
+	t.Contains(condition.Message, "/my-account not found")
+	t.Nil(account)
+}
+
+func (t *AccountImportControllerTestSuite) Test_getConditionedAccount_ShouldReturnFalse_WhenAccountIDNotSet() {
+	// Given
+	accountRef := domain.NewNamespacedName(t.namespace, "my-account")
+	t.ensureAccount(t.namespace, "my-account", "")
+
+	// When
+	account, condition := t.unitUnderTest.getConditionedAccount(t.ctx, accountRef, "")
+
+	// Then
+	t.Equal(metav1.ConditionFalse, condition.Status)
+	t.Equal(string(metav1.StatusReasonInvalid), condition.Reason)
+	t.Contains(condition.Message, "/my-account not bound to an Account ID yet")
+	t.Nil(account)
+}
+
+func (t *AccountImportControllerTestSuite) Test_getConditionedAccount_ShouldReturnFalse_WhenAccountIDMismatchBound() {
+	// Given
+	accountRef := domain.NewNamespacedName(t.namespace, "my-account")
+	t.ensureAccount(t.namespace, "my-account", t.anyAccountID())
+
+	// When
+	account, condition := t.unitUnderTest.getConditionedAccount(t.ctx, accountRef, t.anyAccountID())
+
+	// Then
+	t.Equal(metav1.ConditionFalse, condition.Status)
+	t.Equal(string(metav1.StatusReasonConflict), condition.Reason)
+	t.Contains(condition.Message, "Account ID conflict")
+	t.Nil(account)
+}
+
+// Helpers
+
+func (t *AccountImportControllerTestSuite) assertCondition(result *v1alpha1.AccountImport, conditionType string,
+	expectStatus metav1.ConditionStatus, expectReason string) metav1.Condition {
+	var condition metav1.Condition
+	for _, c := range *result.GetConditions() {
+		if c.Type == conditionType {
+			condition = c
+			break
+		}
+	}
+	t.NotEmpty(condition, fmt.Sprintf("Condition not found: %s", conditionType))
+	t.Equalf(
+		fmt.Sprintf("%s|%s|%s", conditionType, expectStatus, expectReason),
+		fmt.Sprintf("%s|%s|%s", condition.Type, condition.Status, condition.Reason),
+		condition.Message)
+	return condition
+}
+
+func (t *AccountImportControllerTestSuite) ensureAccount(namespace, name, accountID string) {
+	t.Require().NoError(ensureNamespace(t.ctx, namespace))
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): accountID,
+			},
+		},
+	}))
+}
+
+func (t *AccountImportControllerTestSuite) anyAccountID() (accountID string) {
+	accountKey, _ := nkeys.CreateAccount()
+	accountID, _ = accountKey.PublicKey()
+	return
+}

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -2,10 +2,11 @@ package controller
 
 const ( // Conditions
 	// Types
-	conditionTypeReady            = "Ready"
-	conditionTypeBoundToAccount   = "BoundToAccount"
-	conditionTypeValidRules       = "ValidRules"
-	conditionTypeAdoptedByAccount = "AdoptedByAccount"
+	conditionTypeReady                = "Ready"
+	conditionTypeBoundToAccount       = "BoundToAccount"
+	conditionTypeBoundToExportAccount = "BoundToExportAccount"
+	conditionTypeValidRules           = "ValidRules"
+	conditionTypeAdoptedByAccount     = "AdoptedByAccount"
 
 	// Reasons
 	conditionReasonReady       = "Ready"


### PR DESCRIPTION
Add the first end-to-end controller path for AccountImport so the resource is wired into the operator and can start participating in reconciliation. This lays the groundwork for the remaining import-specific behavior by establishing the controller flow, connecting the runtime bindings, and covering the initial reconciliation path with tests.

Issue: #11
