### PR TITLE
feat(controller): add account and account export watches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ test/logs/
 
 # Git worktrees in repo root
 .worktrees/
+
+# ignore empty file codex generates
+.codex

--- a/api/v1alpha1/account_export_types.go
+++ b/api/v1alpha1/account_export_types.go
@@ -31,7 +31,9 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
-// +kubebuilder:printcolumn:name="Message",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="Rules",type=string,JSONPath=`.status.conditions[?(@.type=="ValidRules")].reason`
+// +kubebuilder:printcolumn:name="Bound",type=string,JSONPath=`.status.conditions[?(@.type=="BoundToAccount")].reason`
+// +kubebuilder:printcolumn:name="Adopted",type=string,JSONPath=`.status.conditions[?(@.type=="AdoptedByAccount")].reason`
 
 // AccountExport is a component resource for exports in the accounts API.
 type AccountExport struct {

--- a/charts/nauth-crds/crds/nauth.io_accountexports.yaml
+++ b/charts/nauth-crds/crds/nauth.io_accountexports.yaml
@@ -18,8 +18,14 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
-      name: Message
+    - jsonPath: .status.conditions[?(@.type=="ValidRules")].reason
+      name: Rules
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="BoundToAccount")].reason
+      name: Bound
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AdoptedByAccount")].reason
+      name: Adopted
       type: string
     name: v1alpha1
     schema:

--- a/charts/nauth/resources/crds/nauth.io_accountexports.yaml
+++ b/charts/nauth/resources/crds/nauth.io_accountexports.yaml
@@ -18,8 +18,14 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
-      name: Message
+    - jsonPath: .status.conditions[?(@.type=="ValidRules")].reason
+      name: Rules
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="BoundToAccount")].reason
+      name: Bound
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AdoptedByAccount")].reason
+      name: Adopted
       type: string
     name: v1alpha1
     schema:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -274,18 +274,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	features := &controller.ExperimentalFeatures{
+		AccountExportEnabled: experimentalAccountExport,
+	}
+
 	accountReconciler := controller.NewAccountReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		accountManager,
 		mgr.GetEventRecorder("account-controller"),
+		features,
 	)
 	if err = accountReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Account")
 		os.Exit(1)
 	}
 
-	if experimentalAccountExport {
+	if features.AccountExportEnabled {
 		accountExportManager := core.NewAccountExportManager()
 		accountExportReconciler := controller.NewAccountExportReconciler(
 			mgr.GetClient(),

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
@@ -27,16 +28,22 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const accountLabelAccountIDIndexKey = "account.labels.account-id"
 
 // AccountReconciler reconciles an Account object
 type AccountReconciler struct {
@@ -236,13 +243,119 @@ func (r *AccountReconciler) findExportsByAccountID(ctx context.Context, namespac
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Todo: #11 Add watch on AccountExport
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&v1alpha1.Account{},
+		accountLabelAccountIDIndexKey,
+		accountByAccountIDLabelIndexFunc,
+	); err != nil {
+		return fmt.Errorf("failed to index Account by account ID: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.Account{}).
+		For(&v1alpha1.Account{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&v1alpha1.AccountExport{},
+			handler.EnqueueRequestsFromMapFunc(r.mapAccountExportToAccounts),
+			builder.WithPredicates(accountExportWatchPredicateForAccounts()),
+		).
 		Named("account").
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).
 		Complete(r)
+}
+
+func (r *AccountReconciler) mapAccountExportToAccounts(ctx context.Context, obj client.Object) []reconcile.Request {
+	export, ok := obj.(*v1alpha1.AccountExport)
+	if !ok {
+		return nil
+	}
+
+	accountID := export.GetLabel(v1alpha1.AccountExportLabelAccountID)
+	if accountID == "" {
+		return nil
+	}
+
+	accounts := &v1alpha1.AccountList{}
+	if err := r.List(ctx, accounts,
+		client.InNamespace(export.Namespace),
+		client.MatchingFields{accountLabelAccountIDIndexKey: accountID},
+	); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list Accounts for AccountExport watch", "accountID", accountID, "namespace", export.Namespace)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(accounts.Items))
+	for _, account := range accounts.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&account),
+		})
+	}
+
+	return requests
+}
+
+func accountByAccountIDLabelIndexFunc(rawObj client.Object) []string {
+	account := rawObj.(*v1alpha1.Account)
+	accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
+	if accountID == "" {
+		return nil
+	}
+	return []string{accountID}
+}
+
+func accountExportWatchPredicateForAccounts() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			export, ok := e.Object.(*v1alpha1.AccountExport)
+			return ok && export.GetLabel(v1alpha1.AccountExportLabelAccountID) != ""
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			export, ok := e.Object.(*v1alpha1.AccountExport)
+			return ok && export.GetLabel(v1alpha1.AccountExportLabelAccountID) != ""
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldExport, oldOK := e.ObjectOld.(*v1alpha1.AccountExport)
+			newExport, newOK := e.ObjectNew.(*v1alpha1.AccountExport)
+			return oldOK && newOK && accountExportUpdateAffectsAccounts(oldExport, newExport)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func accountExportUpdateAffectsAccounts(oldExport *v1alpha1.AccountExport, newExport *v1alpha1.AccountExport) bool {
+	if oldExport == nil || newExport == nil {
+		return false
+	}
+
+	oldAccountID := oldExport.GetLabel(v1alpha1.AccountExportLabelAccountID)
+	newAccountID := newExport.GetLabel(v1alpha1.AccountExportLabelAccountID)
+	if oldAccountID != newAccountID {
+		return true
+	}
+
+	return !reflect.DeepEqual(accountExportDesiredClaimSnapshot(oldExport), accountExportDesiredClaimSnapshot(newExport))
+}
+
+func accountExportDesiredClaimSnapshot(export *v1alpha1.AccountExport) *accountExportDesiredClaimState {
+	if export == nil || export.Status.DesiredClaim == nil {
+		return nil
+	}
+
+	claim := export.Status.DesiredClaim
+	rules := make([]v1alpha1.AccountExportRule, len(claim.Rules))
+	copy(rules, claim.Rules)
+
+	return &accountExportDesiredClaimState{
+		ObservedGeneration: claim.ObservedGeneration,
+		Rules:              rules,
+	}
+}
+
+type accountExportDesiredClaimState struct {
+	ObservedGeneration int64
+	Rules              []v1alpha1.AccountExportRule
 }

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -43,8 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const accountLabelAccountIDIndexKey = "account.labels.account-id"
-
 // AccountReconciler reconciles an Account object
 type AccountReconciler struct {
 	client.Client
@@ -126,7 +124,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			)
 		}
 
-		// Todo: [#11] This will block the deletion and requires manual intervention to continue (removing finalizer)
+		// TODO: [#11] This will block the deletion and requires manual intervention to continue (removing finalizer)
 		// TODO: [#11] Investigate and understand if blocking preemptively with webhooks is a better option (not allowing change)?
 		adoptions := natsAccount.Status.Adoptions
 		if adoptions != nil && len(adoptions.Exports) > 0 {
@@ -260,15 +258,6 @@ func (r *AccountReconciler) findExportsByAccountID(ctx context.Context, namespac
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(
-		context.Background(),
-		&v1alpha1.Account{},
-		accountLabelAccountIDIndexKey,
-		accountByAccountIDLabelIndexFunc,
-	); err != nil {
-		return fmt.Errorf("failed to index Account by account ID: %w", err)
-	}
-
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Account{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).Named("account").
 		WithOptions(controller.Options{
@@ -301,7 +290,7 @@ func (r *AccountReconciler) mapAccountExportToAccounts(ctx context.Context, obj 
 	accounts := &v1alpha1.AccountList{}
 	if err := r.List(ctx, accounts,
 		client.InNamespace(export.Namespace),
-		client.MatchingFields{accountLabelAccountIDIndexKey: accountID},
+		client.MatchingLabels{string(v1alpha1.AccountLabelAccountID): accountID},
 	); err != nil {
 		logf.FromContext(ctx).Error(err, "Failed to list Accounts for AccountExport watch", "accountID", accountID, "namespace", export.Namespace)
 		return nil
@@ -315,15 +304,6 @@ func (r *AccountReconciler) mapAccountExportToAccounts(ctx context.Context, obj 
 	}
 
 	return requests
-}
-
-func accountByAccountIDLabelIndexFunc(rawObj client.Object) []string {
-	account := rawObj.(*v1alpha1.Account)
-	accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
-	if accountID == "" {
-		return nil
-	}
-	return []string{accountID}
 }
 
 func accountExportWatchPredicateForAccounts() predicate.Funcs {

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -51,14 +51,16 @@ type AccountReconciler struct {
 	Scheme   *runtime.Scheme
 	manager  inbound.AccountManager
 	reporter *statusReporter
+	features *ExperimentalFeatures
 }
 
-func NewAccountReconciler(k8sClient client.Client, scheme *runtime.Scheme, manager inbound.AccountManager, recorder events.EventRecorder) *AccountReconciler {
+func NewAccountReconciler(k8sClient client.Client, scheme *runtime.Scheme, manager inbound.AccountManager, recorder events.EventRecorder, features *ExperimentalFeatures) *AccountReconciler {
 	return &AccountReconciler{
 		Client:   k8sClient,
 		Scheme:   scheme,
 		manager:  manager,
 		reporter: newStatusReporter(k8sClient, recorder),
+		features: features,
 	}
 }
 
@@ -216,14 +218,18 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *AccountReconciler) collectAccountResources(ctx context.Context, account *v1alpha1.Account, accountID string) (*domain.AccountResources, error) {
 	result := domain.AccountResources{Account: *account}
-	if accountID != "" {
-		namespace := domain.Namespace(account.Namespace)
-		exports, err := r.findExportsByAccountID(ctx, namespace, accountID)
-		if err != nil {
-			return nil, err
+
+	if r.features.AccountExportEnabled {
+		if accountID != "" {
+			namespace := domain.Namespace(account.Namespace)
+			exports, err := r.findExportsByAccountID(ctx, namespace, accountID)
+			if err != nil {
+				return nil, err
+			}
+			result.Exports = exports.Items
 		}
-		result.Exports = exports.Items
 	}
+
 	return &result, nil
 }
 
@@ -252,17 +258,21 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("failed to index Account by account ID: %w", err)
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.Account{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.Account{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).Named("account").
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		})
+
+	if r.features.AccountExportEnabled {
+		controllerBuilder = controllerBuilder.Watches(
 			&v1alpha1.AccountExport{},
 			handler.EnqueueRequestsFromMapFunc(r.mapAccountExportToAccounts),
 			builder.WithPredicates(accountExportWatchPredicateForAccounts()),
-		).
-		Named("account").
-		WithOptions(controller.Options{
-			MaxConcurrentReconciles: 1,
-		}).
+		)
+	}
+
+	return controllerBuilder.
 		Complete(r)
 }
 

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -126,7 +126,16 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			)
 		}
 
-		// Todo: [#11] We should block deletion if AccountExports are bound to it
+		// Todo: [#11] This will block the deletion and requires manual intervention to continue (removing finalizer)
+		// TODO: [#11] Investigate and understand if blocking preemptively with webhooks is a better option (not allowing change)?
+		adoptions := natsAccount.Status.Adoptions
+		if adoptions != nil && len(adoptions.Exports) > 0 {
+			return r.reporter.error(
+				ctx,
+				natsAccount,
+				fmt.Errorf("cannot delete an account with adopted exports, found %d adoptions", len(adoptions.Exports)),
+			)
+		}
 
 		if controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
 			if managementPolicy != v1alpha1.AccountManagementPolicyObserve {

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -126,6 +126,8 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			)
 		}
 
+		// Todo: [#11] We should block deletion if AccountExports are bound to it
+
 		if controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
 			if managementPolicy != v1alpha1.AccountManagementPolicyObserve {
 				if err := r.manager.Delete(ctx, natsAccount); err != nil {

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
@@ -31,11 +32,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+const exportAccountNameIndexKey string = "export.spec.accountName"
 
 // AccountExportReconciler reconciles an AccountExport object.
 type AccountExportReconciler struct {
@@ -83,10 +90,13 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to patch labels: %w", err)
 		}
-		return ctrl.Result{RequeueAfter: time.Second * 2}, nil
+		// Todo: #11 Can we patch without returning, and update status in same reconcile loop?
+		return ctrl.Result{RequeueAfter: time.Millisecond * 250}, nil
 	}
 
 	if updateStatus {
+		// Todo: #11 Can we safely implement the updateStatus flag, currently always true
+		// Todo: #11 This would make watches simpler (not needing to be so specific)
 		if updateErr := r.Status().Update(ctx, state); updateErr != nil {
 			log.Error(updateErr, "Failed to update status")
 			return ctrl.Result{}, updateErr
@@ -98,15 +108,118 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *AccountExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Todo: #11 Add watch on Account
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&v1alpha1.AccountExport{},
+		exportAccountNameIndexKey,
+		exportBySpecAccountNameIndexFunc,
+	); err != nil {
+		return fmt.Errorf("failed to index AccountExport by account name: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.AccountExport{}).
+		For(&v1alpha1.AccountExport{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named("accountexport").
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).
+		Watches(
+			&v1alpha1.Account{},
+			handler.EnqueueRequestsFromMapFunc(r.mapAccountToAccountExports),
+			builder.WithPredicates(accountExportAccountWatchPredicate()),
+		).
 		Complete(r)
+}
+
+func exportBySpecAccountNameIndexFunc(rawObj client.Object) []string {
+	export := rawObj.(*v1alpha1.AccountExport)
+	if export.Spec.AccountName == "" {
+		return nil
+	}
+	return []string{export.Spec.AccountName}
+}
+
+func (r *AccountExportReconciler) mapAccountToAccountExports(ctx context.Context, obj client.Object) []reconcile.Request {
+	account, ok := obj.(*v1alpha1.Account)
+	if !ok {
+		return nil
+	}
+
+	exports := &v1alpha1.AccountExportList{}
+	if err := r.List(ctx, exports,
+		client.InNamespace(account.Namespace),
+		client.MatchingFields{exportAccountNameIndexKey: account.Name},
+	); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list AccountExports for Account watch", "account", account.Name, "namespace", account.Namespace)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(exports.Items))
+	for _, export := range exports.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: export.Namespace,
+				Name:      export.Name,
+			},
+		})
+	}
+
+	return requests
+}
+
+func accountExportAccountWatchPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool { return true },
+		DeleteFunc: func(event.DeleteEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldAccount, oldOK := e.ObjectOld.(*v1alpha1.Account)
+			newAccount, newOK := e.ObjectNew.(*v1alpha1.Account)
+			return oldOK && newOK && accountUpdateAffectsAccountExports(oldAccount, newAccount)
+		},
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+func accountUpdateAffectsAccountExports(oldAccount *v1alpha1.Account, newAccount *v1alpha1.Account) bool {
+	if oldAccount == nil || newAccount == nil {
+		return false
+	}
+
+	oldAccountID := oldAccount.GetLabel(v1alpha1.AccountLabelAccountID)
+	newAccountID := newAccount.GetLabel(v1alpha1.AccountLabelAccountID)
+	// this is only possible if account is deleted and recreated with new name
+	if oldAccountID != newAccountID {
+		return true
+	}
+
+	return !reflect.DeepEqual(accountExportAdoptionSnapshot(oldAccount), accountExportAdoptionSnapshot(newAccount))
+}
+
+// Builds a comparable snapshot of export adoption state so Account changes relevant to AccountExports can be detected efficiently.
+func accountExportAdoptionSnapshot(account *v1alpha1.Account) map[string]accountExportAdoptionState {
+	if account == nil || account.Status.Adoptions == nil {
+		return nil
+	}
+
+	adoptions := make(map[string]accountExportAdoptionState, len(account.Status.Adoptions.Exports))
+	for _, adoption := range account.Status.Adoptions.Exports {
+		adoptions[string(adoption.UID)] = accountExportAdoptionState{
+			ObservedGeneration:             adoption.ObservedGeneration,
+			Status:                         adoption.Status.Status,
+			Reason:                         adoption.Status.Reason,
+			Message:                        adoption.Status.Message,
+			DesiredClaimObservedGeneration: adoption.Status.DesiredClaimObservedGeneration,
+		}
+	}
+	return adoptions
+}
+
+type accountExportAdoptionState struct {
+	ObservedGeneration             int64
+	Status                         metav1.ConditionStatus
+	Reason                         string
+	Message                        string
+	DesiredClaimObservedGeneration *int64
 }
 
 func (r *AccountExportReconciler) patchLabels(ctx context.Context, resource *v1alpha1.AccountExport) error {
@@ -207,12 +320,12 @@ func mapResolutionToStatus(resolution *domain.AccountExportResolution, state *v1
 }
 
 func isAccountExportReady(state *v1alpha1.AccountExport) bool {
-	conditionsReady := conditionsReady(state.Status.Conditions, []string{
+	allConditionsReady := conditionsReady(state.Status.Conditions, []string{
 		conditionTypeBoundToAccount,
 		conditionTypeValidRules,
 		conditionTypeAdoptedByAccount,
 	})
 	claimsReady := state.Status.DesiredClaim != nil && state.Status.DesiredClaim.ObservedGeneration == state.Generation
 
-	return conditionsReady && claimsReady
+	return allConditionsReady && claimsReady
 }

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -67,7 +67,6 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log := logf.FromContext(ctx)
 
 	// Todo: #11 Consider adding events
-	// Todo: #11 Go through all reasons and consolidate
 
 	state := &v1alpha1.AccountExport{}
 	if err := r.Get(ctx, req.NamespacedName, state); err != nil {
@@ -275,10 +274,10 @@ func mapResolutionToStatus(resolution *domain.AccountExportResolution, state *v1
 			state.SetLabel(v1alpha1.AccountExportLabelAccountID, resolution.AccountID)
 			patchLabels = true
 			msg := fmt.Sprintf("Binding to Account ID: %s", resolution.AccountID)
-			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonReconciling, msg)
+			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonBinding, msg)
 		} else {
 			msg := "Account not found or could not be read"
-			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonErrored, msg)
+			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonNotFound, msg)
 		}
 
 	case domain.AccountBindingStateConflict:
@@ -297,26 +296,26 @@ func mapResolutionToStatus(resolution *domain.AccountExportResolution, state *v1
 	case domain.AccountAdoptionStateMissing:
 		if resolution.AccountID == "" {
 			msg := "Account not found or could not be read"
-			updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonErrored, msg)
+			updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonNotFound, msg)
 		} else {
-			updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonErrored, resolution.AdoptionError.Error())
+			updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonFailed, resolution.AdoptionError.Error())
 		}
 
 	case domain.AccountAdoptionStateNotAdopted:
-		updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonReconciling, resolution.AdoptionError.Error())
+		updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonAdopting, resolution.AdoptionError.Error())
 
 	case domain.AccountAdoptionStateAdopted:
 		updateConditionTrue(conditionTypeAdoptedByAccount)
 
 	default:
-		updateConditionFalse(conditionTypeBoundToAccount, conditionReasonErrored, "Unknown adopted state")
+		updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonErrored, "Unknown adopted state")
 	}
 
 	// ready condition
 	if isAccountExportReady(state) {
 		updateConditionTrue(conditionTypeReady)
 	} else {
-		updateConditionFalse(conditionTypeReady, conditionReasonReconciling, "Reconciling")
+		updateConditionFalse(conditionTypeReady, conditionReasonReconciling, "All conditions not met")
 	}
 
 	return patchLabels, updateStatus

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -81,7 +81,9 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	account := &v1alpha1.Account{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: state.Namespace, Name: state.Spec.AccountName}, account); err != nil {
-		log.Error(err, "Failed to get account", "accountName", state.Spec.AccountName)
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to read account", "accountName", state.Spec.AccountName)
+		}
 	}
 
 	resolution := r.manager.Resolve(ctx, state, account)
@@ -105,7 +107,9 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	log.Info("Reconciliation complete")
+	if meta.IsStatusConditionTrue(state.Status.Conditions, conditionTypeReady) {
+		log.Info("AccountExport reconciliation Ready")
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
@@ -66,7 +65,7 @@ func NewAccountExportReconciler(k8sClient client.Client, scheme *runtime.Scheme,
 func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	// Todo: #11 Consider adding events
+	// TODO: #11 Consider adding events
 
 	state := &v1alpha1.AccountExport{}
 	if err := r.Get(ctx, req.NamespacedName, state); err != nil {
@@ -83,6 +82,7 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.Get(ctx, types.NamespacedName{Namespace: state.Namespace, Name: state.Spec.AccountName}, account); err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to read account", "accountName", state.Spec.AccountName)
+			// TODO: #11 return quick in case account fetch failed.
 		}
 	}
 
@@ -94,19 +94,20 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to patch labels: %w", err)
 		}
-		// Todo: #11 Can we patch without returning, and update status in same reconcile loop?
-		return ctrl.Result{RequeueAfter: time.Millisecond * 250}, nil
+		// TODO: #11 Can we patch without returning, and update status in same reconcile loop?
+		return ctrl.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
 	if updateStatus {
-		// Todo: #11 Can we safely implement the updateStatus flag, currently always true
-		// Todo: #11 This would make watches simpler (not needing to be so specific)
+		// TODO: #11 Can we safely implement the updateStatus flag, currently always true
+		// TODO: #11 This would make watches simpler (not needing to be so specific)
 		if updateErr := r.Status().Update(ctx, state); updateErr != nil {
 			log.Error(updateErr, "Failed to update status")
 			return ctrl.Result{}, updateErr
 		}
 	}
 
+	// TODO: #11 Remove logging when i/e feature is complete
 	if meta.IsStatusConditionTrue(state.Status.Conditions, conditionTypeReady) {
 		log.Info("AccountExport reconciliation Ready")
 	}
@@ -193,7 +194,6 @@ func accountUpdateAffectsAccountExports(oldAccount *v1alpha1.Account, newAccount
 
 	oldAccountID := oldAccount.GetLabel(v1alpha1.AccountLabelAccountID)
 	newAccountID := newAccount.GetLabel(v1alpha1.AccountLabelAccountID)
-	// this is only possible if account is deleted and recreated with new name
 	if oldAccountID != newAccountID {
 		return true
 	}

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -66,6 +66,9 @@ func NewAccountExportReconciler(k8sClient client.Client, scheme *runtime.Scheme,
 func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
+	// Todo: #11 Consider adding events
+	// Todo: #11 Go through all reasons and consolidate
+
 	state := &v1alpha1.AccountExport{}
 	if err := r.Get(ctx, req.NamespacedName, state); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -211,7 +211,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAccount
 	t.Equalf(t.accountIDA, accountExport.GetLabel(v1alpha1.AccountExportLabelAccountID), "Expected label %q", v1alpha1.AccountExportLabelAccountID)
 
 	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "Errored")
+	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, conditionReasonFailed)
 	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonReconciling)
 }
 
@@ -347,7 +347,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldNotBeAdoptedByAc
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
 
-	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, conditionReasonReconciling)
+	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, conditionReasonAdopting)
 	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonReconciling)
 }
 

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -235,7 +235,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldBindAccount() {
 	// Then
 	t.Require().NoError(err)
 	t.NotEmpty(res)
-	t.Equal(time.Second*2, res.RequeueAfter, "Should be requeued")
+	t.Equal(time.Millisecond*250, res.RequeueAfter, "Should be requeued")
 
 	accountExport := &v1alpha1.AccountExport{}
 	err = k8sClient.Get(t.ctx, t.accountExportRef, accountExport)

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -49,9 +49,9 @@ func (t *AccountExportControllerTestSuite) SetupTest() {
 		{Type: v1alpha1.Service, Name: "bar", Subject: "bar.>"},
 	}
 	t.accountNameA = "account-a"
-	t.accountIDA = "ACCA"
+	t.accountIDA = accountIDAccA
 	t.accountNameB = "account-b"
-	t.accountIDB = "ACCB"
+	t.accountIDB = accountIDAccB
 
 	t.Require().NoError(ensureNamespace(t.ctx, t.accountExportNamespace))
 

--- a/internal/adapter/inbound/controller/account_export_watch_test.go
+++ b/internal/adapter/inbound/controller/account_export_watch_test.go
@@ -58,7 +58,6 @@ func TestAccountExportReconciler_ShouldReconcileForAccountUpdate(t *testing.T) {
 		expectRequeue bool
 	}{
 		{
-			// this is only possible if account is deleted and recreated with new name
 			name: "account_id_label_changed",
 			mutate: func(account *v1alpha1.Account) {
 				account.Labels[string(v1alpha1.AccountLabelAccountID)] = accountIDAccB

--- a/internal/adapter/inbound/controller/account_export_watch_test.go
+++ b/internal/adapter/inbound/controller/account_export_watch_test.go
@@ -25,7 +25,7 @@ func TestAccountExportReconciler_ShouldReconcileForAccountUpdate(t *testing.T) {
 				Name:      "account-a",
 				Namespace: "ns-a",
 				Labels: map[string]string{
-					string(v1alpha1.AccountLabelAccountID): "ACCA",
+					string(v1alpha1.AccountLabelAccountID): accountIDAccA,
 				},
 			},
 			Status: v1alpha1.AccountStatus{
@@ -61,7 +61,7 @@ func TestAccountExportReconciler_ShouldReconcileForAccountUpdate(t *testing.T) {
 			// this is only possible if account is deleted and recreated with new name
 			name: "account_id_label_changed",
 			mutate: func(account *v1alpha1.Account) {
-				account.Labels[string(v1alpha1.AccountLabelAccountID)] = "ACCB"
+				account.Labels[string(v1alpha1.AccountLabelAccountID)] = accountIDAccB
 			},
 			expectRequeue: true,
 		},

--- a/internal/adapter/inbound/controller/account_export_watch_test.go
+++ b/internal/adapter/inbound/controller/account_export_watch_test.go
@@ -1,0 +1,179 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestAccountExportReconciler_ShouldReconcileForAccountUpdate(t *testing.T) {
+	exportUID := types.UID("export-uid")
+	desiredGen1 := int64(1)
+	desiredGen2 := int64(2)
+
+	createAccount := func() *v1alpha1.Account {
+		return &v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "account-a",
+				Namespace: "ns-a",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): "ACCA",
+				},
+			},
+			Status: v1alpha1.AccountStatus{
+				ClaimsHash:         "hash-a",
+				ObservedGeneration: 3,
+				OperatorVersion:    "v1.0.0",
+				ReconcileTimestamp: metav1.Now(),
+				Adoptions: &v1alpha1.AccountAdoptions{
+					Exports: []v1alpha1.AccountAdoption{
+						{
+							Name:               "export-a",
+							UID:                exportUID,
+							ObservedGeneration: 1,
+							Status: v1alpha1.AccountAdoptionStatus{
+								Status:                         metav1.ConditionFalse,
+								Reason:                         conditionReasonReconciling,
+								Message:                        "waiting",
+								DesiredClaimObservedGeneration: &desiredGen1,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		mutate        func(account *v1alpha1.Account)
+		expectRequeue bool
+	}{
+		{
+			// this is only possible if account is deleted and recreated with new name
+			name: "account_id_label_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Labels[string(v1alpha1.AccountLabelAccountID)] = "ACCB"
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "adoption_status_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.Adoptions.Exports[0].Status.Status = metav1.ConditionTrue
+				account.Status.Adoptions.Exports[0].Status.Reason = conditionReasonOK
+				account.Status.Adoptions.Exports[0].Status.Message = ""
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "desired_claim_generation_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.Adoptions.Exports[0].Status.DesiredClaimObservedGeneration = &desiredGen2
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "adoption_removed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.Adoptions.Exports = nil
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "observed_generation_only_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.ObservedGeneration = 4
+			},
+			expectRequeue: false,
+		},
+		{
+			name: "claims_hash_only_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.ClaimsHash = "hash-b"
+			},
+			expectRequeue: false,
+		},
+		{
+			name: "operator_version_only_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.OperatorVersion = "v1.1.0"
+			},
+			expectRequeue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldAccount := createAccount()
+			newAccount := oldAccount.DeepCopy()
+			tt.mutate(newAccount)
+
+			assert.Equal(t, tt.expectRequeue, accountUpdateAffectsAccountExports(oldAccount, newAccount))
+		})
+	}
+}
+
+func TestAccountExportReconciler_MapAccountToExports(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(testScheme))
+
+	account := &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "account-a",
+			Namespace: "ns-a",
+		},
+	}
+	exportA := &v1alpha1.AccountExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "export-a",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.AccountExportSpec{
+			AccountName: "account-a",
+		},
+	}
+	exportB := &v1alpha1.AccountExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "export-b",
+			Namespace: "ns-a",
+		},
+		Spec: v1alpha1.AccountExportSpec{
+			AccountName: "account-b",
+		},
+	}
+	exportOtherNamespace := &v1alpha1.AccountExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "export-c",
+			Namespace: "ns-b",
+		},
+		Spec: v1alpha1.AccountExportSpec{
+			AccountName: "account-a",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithIndex(&v1alpha1.AccountExport{}, exportAccountNameIndexKey, exportBySpecAccountNameIndexFunc).
+		WithObjects(account, exportA, exportB, exportOtherNamespace).
+		Build()
+
+	reconciler := &AccountExportReconciler{Client: fakeClient}
+
+	requests := reconciler.mapAccountToAccountExports(context.Background(), account)
+	require.Len(t, requests, 1)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "ns-a",
+			Name:      "export-a",
+		},
+	}, requests[0])
+}

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -56,7 +56,8 @@ type AccountControllerTestSuite struct {
 	operatorNamespace    string
 	operatorVersion      string
 
-	unitUnderTest *AccountReconciler
+	unitUnderTest            *AccountReconciler
+	withExperimentalFeatures func(features *ExperimentalFeatures)
 }
 
 func TestAccountController_TestSuite(t *testing.T) {
@@ -84,7 +85,11 @@ func (t *AccountControllerTestSuite) SetupTest() {
 		k8sClient.Scheme(),
 		t.accountManagerMock,
 		t.fakeRecorder,
+		&ExperimentalFeatures{},
 	)
+	t.withExperimentalFeatures = func(features *ExperimentalFeatures) {
+		t.unitUnderTest.features = features
+	}
 
 	t.Require().NoError(ensureNamespace(t.ctx, t.operatorNamespace))
 	t.Require().NoError(ensureNamespace(t.ctx, t.accountNamespace))
@@ -342,6 +347,10 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVe
 }
 
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenAccountExportsExist() {
+	t.withExperimentalFeatures(&ExperimentalFeatures{
+		AccountExportEnabled: true,
+	})
+
 	// Given
 	accountKey, _ := nkeys.CreateAccount()
 	accountID, _ := accountKey.PublicKey()

--- a/internal/adapter/inbound/controller/account_watch_test.go
+++ b/internal/adapter/inbound/controller/account_watch_test.go
@@ -1,0 +1,175 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestAccountReconciler_ShouldReconcileForAccountExportUpdate(t *testing.T) {
+	createExport := func() *v1alpha1.AccountExport {
+		return &v1alpha1.AccountExport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "export-a",
+				Namespace: "ns-a",
+				Labels: map[string]string{
+					string(v1alpha1.AccountExportLabelAccountID): "ACCA",
+				},
+			},
+			Status: v1alpha1.AccountExportStatus{
+				AccountID: "ACCA",
+				DesiredClaim: &v1alpha1.AccountExportClaim{
+					ObservedGeneration: 1,
+					Rules: []v1alpha1.AccountExportRule{
+						{Name: "rule-a", Subject: "foo.*", Type: v1alpha1.Stream},
+					},
+				},
+				Conditions: []metav1.Condition{
+					{Type: conditionTypeReady, Status: metav1.ConditionFalse, Reason: conditionReasonReconciling},
+				},
+				ObservedGeneration: 1,
+				OperatorVersion:    "v1.0.0",
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		mutate        func(export *v1alpha1.AccountExport)
+		expectRequeue bool
+	}{
+		{
+			name: "bound_account_id_label_changed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Labels[string(v1alpha1.AccountExportLabelAccountID)] = "ACCB"
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "desired_claim_observed_generation_changed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Status.DesiredClaim.ObservedGeneration = 2
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "desired_claim_rules_changed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Status.DesiredClaim.Rules = append(export.Status.DesiredClaim.Rules, v1alpha1.AccountExportRule{
+					Name: "rule-b", Subject: "bar.*", Type: v1alpha1.Stream,
+				})
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "desired_claim_removed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Status.DesiredClaim = nil
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "conditions_only_changed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Status.Conditions[0].Status = metav1.ConditionTrue
+				export.Status.Conditions[0].Reason = conditionReasonOK
+			},
+			expectRequeue: false,
+		},
+		{
+			name: "status_account_id_only_changed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Status.AccountID = "ACCB"
+			},
+			expectRequeue: false,
+		},
+		{
+			name: "observed_generation_only_changed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Status.ObservedGeneration = 2
+			},
+			expectRequeue: false,
+		},
+		{
+			name: "operator_version_only_changed",
+			mutate: func(export *v1alpha1.AccountExport) {
+				export.Status.OperatorVersion = "v1.1.0"
+			},
+			expectRequeue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldExport := createExport()
+			newExport := oldExport.DeepCopy()
+			tt.mutate(newExport)
+
+			assert.Equal(t, tt.expectRequeue, accountExportUpdateAffectsAccounts(oldExport, newExport))
+		})
+	}
+}
+
+func TestAccountReconciler_MapAccountExportToAccounts(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(testScheme))
+
+	accountA := &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "account-a",
+			Namespace: "ns-a",
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): "ACCA",
+			},
+		},
+	}
+	accountB := &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "account-b",
+			Namespace: "ns-a",
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): "ACCB",
+			},
+		},
+	}
+	accountOtherNamespace := &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "account-c",
+			Namespace: "ns-b",
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): "ACCA",
+			},
+		},
+	}
+	export := &v1alpha1.AccountExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "export-a",
+			Namespace: "ns-a",
+			Labels: map[string]string{
+				string(v1alpha1.AccountExportLabelAccountID): "ACCA",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithIndex(&v1alpha1.Account{}, accountLabelAccountIDIndexKey, accountByAccountIDLabelIndexFunc).
+		WithObjects(accountA, accountB, accountOtherNamespace, export).
+		Build()
+
+	reconciler := &AccountReconciler{Client: fakeClient}
+
+	requests := reconciler.mapAccountExportToAccounts(context.Background(), export)
+	require.Len(t, requests, 1)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(accountA),
+	}, requests[0])
+}

--- a/internal/adapter/inbound/controller/account_watch_test.go
+++ b/internal/adapter/inbound/controller/account_watch_test.go
@@ -21,11 +21,11 @@ func TestAccountReconciler_ShouldReconcileForAccountExportUpdate(t *testing.T) {
 				Name:      "export-a",
 				Namespace: "ns-a",
 				Labels: map[string]string{
-					string(v1alpha1.AccountExportLabelAccountID): "ACCA",
+					string(v1alpha1.AccountExportLabelAccountID): accountIDAccA,
 				},
 			},
 			Status: v1alpha1.AccountExportStatus{
-				AccountID: "ACCA",
+				AccountID: accountIDAccA,
 				DesiredClaim: &v1alpha1.AccountExportClaim{
 					ObservedGeneration: 1,
 					Rules: []v1alpha1.AccountExportRule{
@@ -49,7 +49,7 @@ func TestAccountReconciler_ShouldReconcileForAccountExportUpdate(t *testing.T) {
 		{
 			name: "bound_account_id_label_changed",
 			mutate: func(export *v1alpha1.AccountExport) {
-				export.Labels[string(v1alpha1.AccountExportLabelAccountID)] = "ACCB"
+				export.Labels[string(v1alpha1.AccountExportLabelAccountID)] = accountIDAccB
 			},
 			expectRequeue: true,
 		},
@@ -87,7 +87,7 @@ func TestAccountReconciler_ShouldReconcileForAccountExportUpdate(t *testing.T) {
 		{
 			name: "status_account_id_only_changed",
 			mutate: func(export *v1alpha1.AccountExport) {
-				export.Status.AccountID = "ACCB"
+				export.Status.AccountID = accountIDAccB
 			},
 			expectRequeue: false,
 		},
@@ -127,7 +127,7 @@ func TestAccountReconciler_MapAccountExportToAccounts(t *testing.T) {
 			Name:      "account-a",
 			Namespace: "ns-a",
 			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): "ACCA",
+				string(v1alpha1.AccountLabelAccountID): accountIDAccA,
 			},
 		},
 	}
@@ -136,7 +136,7 @@ func TestAccountReconciler_MapAccountExportToAccounts(t *testing.T) {
 			Name:      "account-b",
 			Namespace: "ns-a",
 			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): "ACCB",
+				string(v1alpha1.AccountLabelAccountID): accountIDAccB,
 			},
 		},
 	}
@@ -145,7 +145,7 @@ func TestAccountReconciler_MapAccountExportToAccounts(t *testing.T) {
 			Name:      "account-c",
 			Namespace: "ns-b",
 			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): "ACCA",
+				string(v1alpha1.AccountLabelAccountID): accountIDAccA,
 			},
 		},
 	}
@@ -154,7 +154,7 @@ func TestAccountReconciler_MapAccountExportToAccounts(t *testing.T) {
 			Name:      "export-a",
 			Namespace: "ns-a",
 			Labels: map[string]string{
-				string(v1alpha1.AccountExportLabelAccountID): "ACCA",
+				string(v1alpha1.AccountExportLabelAccountID): accountIDAccA,
 			},
 		},
 	}

--- a/internal/adapter/inbound/controller/account_watch_test.go
+++ b/internal/adapter/inbound/controller/account_watch_test.go
@@ -161,7 +161,6 @@ func TestAccountReconciler_MapAccountExportToAccounts(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
-		WithIndex(&v1alpha1.Account{}, accountLabelAccountIDIndexKey, accountByAccountIDLabelIndexFunc).
 		WithObjects(accountA, accountB, accountOtherNamespace, export).
 		Build()
 

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -9,14 +9,16 @@ const ( // Conditions
 	conditionTypeAdoptedByAccount     = "AdoptedByAccount"
 
 	// Reasons
-	conditionReasonReady       = "Ready"
-	conditionReasonNotReady    = "NotReady"
 	conditionReasonReconciling = "Reconciling"
 	conditionReasonReconciled  = "Reconciled"
 	conditionReasonOK          = "OK"
 	conditionReasonErrored     = "Errored"
 	conditionReasonInvalid     = "Invalid"
 	conditionReasonConflict    = "Conflict"
+	conditionReasonBinding     = "Binding"
+	conditionReasonNotFound    = "NotFound"
+	conditionReasonAdopting    = "Adopting"
+	conditionReasonFailed      = "Failed"
 )
 
 const ( // Events

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -1,5 +1,7 @@
 package controller
 
+import "time"
+
 const ( // Conditions
 	// Types
 	conditionTypeReady                = "Ready"
@@ -9,6 +11,8 @@ const ( // Conditions
 	conditionTypeAdoptedByAccount     = "AdoptedByAccount"
 
 	// Reasons
+	conditionReasonReady       = "Ready"
+	conditionReasonNotReady    = "NotReady"
 	conditionReasonReconciling = "Reconciling"
 	conditionReasonReconciled  = "Reconciled"
 	conditionReasonOK          = "OK"
@@ -33,4 +37,9 @@ const ( // Finalizers
 
 const ( // Environment Variables
 	envOperatorVersion = "OPERATOR_VERSION"
+)
+
+const ( // "requeue after" durations
+	// Allow some time to avoid reading stale data
+	requeueImmediately = time.Millisecond * 250
 )

--- a/internal/adapter/inbound/controller/constants_test.go
+++ b/internal/adapter/inbound/controller/constants_test.go
@@ -2,4 +2,6 @@ package controller
 
 const (
 	testOperatorVersion = "0.0-SNAPSHOT"
+	accountIDAccA       = "ACCA"
+	accountIDAccB       = "ACCB"
 )

--- a/internal/adapter/inbound/controller/experimental.go
+++ b/internal/adapter/inbound/controller/experimental.go
@@ -1,0 +1,5 @@
+package controller
+
+type ExperimentalFeatures struct {
+	AccountExportEnabled bool
+}

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -190,9 +190,6 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 		}
 		log.Info("Uploaded Account JWT to NATS",
 			"accountID", accountPublicKey, "prevClaimsHash", prevClaimsHash, "claimsHash", claimsHash)
-	} else {
-		log.Info("Skipped Account JWT upload to NATS because claims are unchanged",
-			"accountID", accountPublicKey, "prevClaimsHash", prevClaimsHash, "claimsHash", claimsHash)
 	}
 
 	nauthClaims := convertNatsAccountClaims(natsClaims)


### PR DESCRIPTION
## Summary

  Improve Account and AccountExport reconciliation with dependency watches, clearer status
  reporting, and deletion safeguards for accounts with exports.

  ## What changed

  - Added cross-resource watches and indexes between Account and AccountExport
  - Improved AccountExport condition reasons and status columns
  - Blocked account deletion while exports still exist
  - Updated controller and core tests, plus related cleanup

  ### Commits in this PR

  - 5f31d67 chore: cleanup logs
  - 2bccbb1 feat: block delete account if exports exist
  - 0a07c9e feat: improving condition reasons for account export
  - fc526ab feat: add TODO comments for leftover work related to AccountExport
  - a0c0fb0 feat: update AccountExport status columns to include ValidRules, Bound, and
    Adopted
  - 0e9a963 feat: use feature flag for AccountExport tests in Account reconciler
  - aff9ee8 chore: use constants for account IDs in tests
  - e7ac517 chore: update .gitignore to ignore empty codex generated files
  - 1e0117a feat: add watch for Account
  - b21515a feat: add watch for AccountExport