### PR TITLE
feat(core): validate AccountImport rules

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -308,6 +308,7 @@ func main() {
 		accountImportReconciler := controller.NewAccountImportReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
+			accountManager,
 		)
 		if err = accountImportReconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AccountImport")

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,13 +40,15 @@ import (
 // AccountImportReconciler reconciles an AccountImport object.
 type AccountImportReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme  *runtime.Scheme
+	manager inbound.AccountImportManager
 }
 
-func NewAccountImportReconciler(k8sClient client.Client, scheme *runtime.Scheme) *AccountImportReconciler {
+func NewAccountImportReconciler(k8sClient client.Client, scheme *runtime.Scheme, manager inbound.AccountImportManager) *AccountImportReconciler {
 	return &AccountImportReconciler{
-		Client: k8sClient,
-		Scheme: scheme,
+		Client:  k8sClient,
+		Scheme:  scheme,
+		manager: manager,
 	}
 }
 
@@ -94,12 +97,26 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
 	}
 
-	// TODO: [#11] Validate rules
-	validRulesCondition := metav1.Condition{
-		Type:    conditionTypeValidRules,
-		Status:  metav1.ConditionFalse,
-		Reason:  "NotImplemented",
-		Message: "Rules validation not implemented",
+	validRules, validRulesErr := r.validateRules(importAccountID, exportAccountID, state.Spec.Rules)
+	var validRulesCondition metav1.Condition
+	if validRulesErr != nil {
+		validRulesCondition = metav1.Condition{
+			Type:    conditionTypeValidRules,
+			Status:  metav1.ConditionFalse,
+			Reason:  conditionReasonNOK,
+			Message: validRulesErr.Error(),
+		}
+	} else {
+		validRulesCondition = metav1.Condition{
+			Type:    conditionTypeValidRules,
+			Status:  metav1.ConditionTrue,
+			Reason:  conditionReasonOK,
+			Message: "Rules validation successful",
+		}
+		state.Status.DesiredClaim = &v1alpha1.AccountImportClaim{
+			ObservedGeneration: state.Generation,
+			Rules:              validRules,
+		}
 	}
 
 	// TODO: [#11] Check account adoption
@@ -117,6 +134,24 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *AccountImportReconciler) validateRules(importAccountID string, exportAccountID string, rules []v1alpha1.AccountImportRule) ([]v1alpha1.AccountImportRuleDerived, error) {
+	var err error
+	var derivedRules []v1alpha1.AccountImportRuleDerived
+	if importAccountID == "" {
+		err = fmt.Errorf("import account ID is required")
+	} else if exportAccountID == "" {
+		err = fmt.Errorf("export account ID is required")
+	} else if len(rules) == 0 {
+		err = fmt.Errorf("at least one rule is required")
+	} else {
+		derivedRules = deriveImportRules(rules, exportAccountID)
+		if err = r.manager.ValidateImportRules(importAccountID, derivedRules); err != nil {
+			err = fmt.Errorf("rules validation failed: %w", err)
+		}
+	}
+	return derivedRules, err
 }
 
 func (r *AccountImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -223,4 +258,15 @@ func (r *AccountImportReconciler) setConditions(state *v1alpha1.AccountImport, s
 		}
 	}
 	meta.SetStatusCondition(state.GetConditions(), ready)
+}
+
+func deriveImportRules(rules []v1alpha1.AccountImportRule, exportAccountID string) []v1alpha1.AccountImportRuleDerived {
+	result := make([]v1alpha1.AccountImportRuleDerived, len(rules))
+	for i, r := range rules {
+		result[i] = v1alpha1.AccountImportRuleDerived{
+			Account:           exportAccountID,
+			AccountImportRule: r,
+		}
+	}
+	return result
 }

--- a/internal/adapter/inbound/controller/account_import_test.go
+++ b/internal/adapter/inbound/controller/account_import_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -24,6 +26,8 @@ type AccountImportControllerTestSuite struct {
 	importAccountName    string
 	exportAccountName    string
 	foreignNamespace     string
+
+	accountImportManagerMock *accountImportManagerMock
 
 	unitUnderTest *AccountImportReconciler
 }
@@ -43,12 +47,19 @@ func (t *AccountImportControllerTestSuite) SetupTest() {
 	t.exportAccountName = scopedTestName("export-account", testName)
 	t.foreignNamespace = scopedTestName("export-namespace", testName)
 
+	t.accountImportManagerMock = &accountImportManagerMock{}
+
 	t.Require().NoError(ensureNamespace(t.ctx, t.namespace))
 
 	t.unitUnderTest = NewAccountImportReconciler(
 		k8sClient,
 		k8sClient.Scheme(),
+		t.accountImportManagerMock,
 	)
+}
+
+func (t *AccountImportControllerTestSuite) TearDownTest() {
+	t.accountImportManagerMock.AssertExpectations(t.T())
 }
 
 func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
@@ -58,7 +69,7 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 	exportAccountID := t.anyAccountID()
 	t.ensureAccount(t.foreignNamespace, t.exportAccountName, exportAccountID)
 
-	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+	resourceInput := v1alpha1.AccountImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.importName,
 			Namespace: t.namespace,
@@ -76,7 +87,10 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 				},
 			},
 		},
-	}))
+	}
+	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
+	derivedRules := deriveImportRules(resourceInput.Spec.Rules, exportAccountID)
+	t.accountImportManagerMock.mockValidateImportRules(importAccountID, derivedRules).Once()
 
 	// When
 	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
@@ -90,11 +104,16 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, resource))
 	t.assertCondition(resource, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
 	t.assertCondition(resource, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(resource, conditionTypeValidRules, metav1.ConditionFalse, "NotImplemented")
-	// TODO: [#11] Verify rules validation condition
+	t.assertCondition(resource, conditionTypeValidRules, metav1.ConditionTrue, conditionReasonOK)
 	t.assertCondition(resource, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
 	// TODO: [#11] Verify account adoption condition
 	t.assertCondition(resource, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+
+	expectClaim := &v1alpha1.AccountImportClaim{
+		ObservedGeneration: 1,
+		Rules:              derivedRules,
+	}
+	t.Equalf(expectClaim, resource.Status.DesiredClaim, "expected claim")
 	t.Equal(importAccountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
 	t.Equal(exportAccountID, resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
 	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful status update")
@@ -107,7 +126,7 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 	exportAccountID := t.anyAccountID()
 	t.ensureAccount(t.namespace, t.exportAccountName, exportAccountID)
 
-	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+	resourceInput := v1alpha1.AccountImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.importName,
 			Namespace: t.namespace,
@@ -124,7 +143,9 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 				},
 			},
 		},
-	}))
+	}
+	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
+	t.accountImportManagerMock.mockValidateImportRules(importAccountID, deriveImportRules(resourceInput.Spec.Rules, exportAccountID)).Once()
 
 	// When
 	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
@@ -148,7 +169,7 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenImpo
 	exportAccountID := t.anyAccountID()
 	t.ensureAccount(t.namespace, t.exportAccountName, exportAccountID)
 
-	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+	resourceInput := v1alpha1.AccountImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.importName,
 			Namespace: t.namespace,
@@ -165,7 +186,8 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenImpo
 				},
 			},
 		},
-	}))
+	}
+	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
 
 	// When
 	result, err := t.runReconcileLoopForNewResource("", exportAccountID)
@@ -196,7 +218,7 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 	t.ensureAccount(t.namespace, t.importAccountName, accountID)
 	t.ensureAccount(t.namespace, t.exportAccountName, "")
 
-	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.AccountImport{
+	resourceInput := v1alpha1.AccountImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      t.importName,
 			Namespace: t.namespace,
@@ -213,7 +235,8 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 				},
 			},
 		},
-	}))
+	}
+	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
 
 	// When
 	result, err := t.runReconcileLoopForNewResource(accountID, "")
@@ -233,6 +256,59 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 	t.assertCondition(resource, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
 	t.assertCondition(resource, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
 	t.Equal(accountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
+}
+
+func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenRulesValidationFail() {
+	// Given
+	importAccountID := t.anyAccountID()
+	t.ensureAccount(t.namespace, t.importAccountName, importAccountID)
+	exportAccountID := t.anyAccountID()
+	t.ensureAccount(t.foreignNamespace, t.exportAccountName, exportAccountID)
+
+	resourceInput := v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.importName,
+			Namespace: t.namespace,
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			AccountName: t.importAccountName,
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name:      t.exportAccountName,
+				Namespace: t.foreignNamespace,
+			},
+			Rules: []v1alpha1.AccountImportRule{
+				{
+					Subject: "foo.*",
+					Type:    v1alpha1.Stream,
+				},
+			},
+		},
+	}
+	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
+	t.accountImportManagerMock.mockValidateImportRulesError(importAccountID, deriveImportRules(resourceInput.Spec.Rules, exportAccountID), fmt.Errorf("invalid test rules")).Once()
+
+	// When
+	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
+
+	// Then
+	t.Require().NoError(err)
+	t.Require().NotNil(result)
+	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful reconciliation")
+
+	resource := &v1alpha1.AccountImport{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.importNamespacedName, resource))
+	t.assertCondition(resource, conditionTypeBoundToAccount, metav1.ConditionTrue, conditionReasonOK)
+	t.assertCondition(resource, conditionTypeBoundToExportAccount, metav1.ConditionTrue, conditionReasonOK)
+	rulesCondition := t.assertCondition(resource, conditionTypeValidRules, metav1.ConditionFalse, conditionReasonNOK)
+	t.Contains(rulesCondition.Message, "invalid test rules")
+	t.assertCondition(resource, conditionTypeAdoptedByAccount, metav1.ConditionFalse, "NotImplemented")
+	// TODO: [#11] Verify account adoption condition
+	t.assertCondition(resource, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
+
+	t.Nil(resource.Status.DesiredClaim, "expected no claim")
+	t.Equal(importAccountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
+	t.Equal(exportAccountID, resource.GetLabel(v1alpha1.AccountImportLabelExportAccountID))
+	t.Require().Empty(result.RequeueAfter, "no reconcile requeue expected after successful status update")
 }
 
 func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenResourceNotFound() {
@@ -354,3 +430,22 @@ func (t *AccountImportControllerTestSuite) anyAccountID() (accountID string) {
 	accountID, _ = accountKey.PublicKey()
 	return
 }
+
+type accountImportManagerMock struct {
+	mock.Mock
+}
+
+func (m *accountImportManagerMock) ValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error {
+	args := m.Called(importAccountID, rules)
+	return args.Error(0)
+}
+
+func (m *accountImportManagerMock) mockValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) *mock.Call {
+	return m.On("ValidateImportRules", importAccountID, rules).Return(nil)
+}
+
+func (m *accountImportManagerMock) mockValidateImportRulesError(importAccountID string, rules []v1alpha1.AccountImportRuleDerived, err error) *mock.Call {
+	return m.On("ValidateImportRules", importAccountID, rules).Return(err)
+}
+
+var _ inbound.AccountImportManager = (*accountImportManagerMock)(nil)

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -16,6 +16,7 @@ const ( // Conditions
 	conditionReasonReconciling = "Reconciling"
 	conditionReasonReconciled  = "Reconciled"
 	conditionReasonOK          = "OK"
+	conditionReasonNOK         = "NOK"
 	conditionReasonErrored     = "Errored"
 	conditionReasonInvalid     = "Invalid"
 	conditionReasonConflict    = "Conflict"

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -472,6 +472,10 @@ func (a *AccountManager) SignUserJWT(ctx context.Context, accountRef domain.Name
 	}, nil
 }
 
+func (a *AccountManager) ValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error {
+	return validateImportRules(importAccountID, rules)
+}
+
 func (a *AccountManager) resolveClusterTarget(ctx context.Context, account *v1alpha1.Account) (*clusterTarget, error) {
 	natsClusterRef := account.Spec.NatsClusterRef
 	if natsClusterRef != nil && natsClusterRef.Namespace == "" {
@@ -499,11 +503,16 @@ func cachedAccountIDReader(ctx context.Context, accountReader outbound.AccountRe
 			if err != nil {
 				return "", fmt.Errorf("failed to resolve account ID: %w", err)
 			}
-			cache[accountRef] = account.GetLabel(v1alpha1.AccountLabelAccountID)
+			accountID = account.GetLabel(v1alpha1.AccountLabelAccountID)
+			cache[accountRef] = accountID
+		}
+		if accountID == "" {
+			return "", fmt.Errorf("account ID label %s is missing for account %q", v1alpha1.AccountLabelAccountID, accountRef)
 		}
 		return accountID, nil
 	}
 }
 
 var _ inbound.AccountManager = (*AccountManager)(nil)
+var _ inbound.AccountImportManager = (*AccountManager)(nil)
 var _ UserJWTSigner = (*AccountManager)(nil)

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -143,51 +143,56 @@ func (b *accountClaimsBuilder) imports(imports v1alpha1.Imports, resolveAccountI
 				accountRef,
 				err))
 		} else {
-			b.claim.Imports.Add(&jwt.Import{
+			jwtImport := &jwt.Import{
 				Name:         imp.Name,
 				Subject:      jwt.Subject(imp.Subject),
 				Type:         jwt.ExportType(imp.Type.ToInt()),
 				Account:      exportAccountID,
 				LocalSubject: jwt.RenamingSubject(imp.LocalSubject),
-			})
+				Share:        imp.Share,
+				AllowTrace:   imp.AllowTrace,
+			}
+			result, mergeErr := mergeImports(b.claim.Subject, b.claim.Imports, jwt.Imports{jwtImport})
+			if mergeErr != nil {
+				b.errs = append(b.errs, fmt.Errorf("failed to add import %q: %w", imp.Name, mergeErr))
+			}
+			b.claim.Imports = result
 		}
 	}
 	return b
 }
 
 func (b *accountClaimsBuilder) addExportRuleGroup(rules []v1alpha1.AccountExportRule) error {
-	tmpClaim := *b.claim
-	for _, rule := range rules {
-		export := jwt.Export{
+	jwtExports := make(jwt.Exports, len(rules))
+	for i, rule := range rules {
+		jwtExport := jwt.Export{
 			Name:         rule.Name,
 			Subject:      jwt.Subject(rule.Subject),
 			Type:         toJWTExportType(rule.Type),
 			ResponseType: jwt.ResponseType(rule.ResponseType),
 		}
 		if rule.ResponseThreshold != nil {
-			export.ResponseThreshold = *rule.ResponseThreshold
+			jwtExport.ResponseThreshold = *rule.ResponseThreshold
 		}
 		if rule.Latency != nil {
-			export.Latency = toJWTServiceLatency(*rule.Latency)
+			jwtExport.Latency = toJWTServiceLatency(*rule.Latency)
 		}
 		if rule.AccountTokenPosition != nil {
-			export.AccountTokenPosition = *rule.AccountTokenPosition
+			jwtExport.AccountTokenPosition = *rule.AccountTokenPosition
 		}
 		if rule.Advertise != nil {
-			export.Advertise = *rule.Advertise
+			jwtExport.Advertise = *rule.Advertise
 		}
 		if rule.AllowTrace != nil {
-			export.AllowTrace = *rule.AllowTrace
+			jwtExport.AllowTrace = *rule.AllowTrace
 		}
-		tmpClaim.Exports = appendExportIfMissing(tmpClaim.Exports, export)
+		jwtExports[i] = &jwtExport
 	}
-	validationResults := &jwt.ValidationResults{}
-	tmpClaim.Exports.Validate(validationResults)
-	validationErrors := validationResults.Errors()
-	if len(validationErrors) != 0 {
-		return fmt.Errorf("rules adoption failed: %w", errors.Join(validationErrors...))
+	result, err := mergeExports(b.claim.Exports, jwtExports)
+	if err != nil {
+		return fmt.Errorf("failed to append export rule group: %w", err)
 	}
-	b.claim.Exports = tmpClaim.Exports
+	b.claim.Exports = result
 	return nil
 }
 
@@ -395,13 +400,80 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) v1alpha1.AccountClaims 
 
 // Helpers
 
-func appendExportIfMissing(exports jwt.Exports, export jwt.Export) jwt.Exports {
-	for _, existing := range exports {
-		if existing != nil && reflect.DeepEqual(export, *existing) {
-			return exports
+func mergeExports(existing jwt.Exports, extras jwt.Exports) (jwt.Exports, error) {
+	tmpExports := existing
+	appendIfMissing := func(haystack jwt.Exports, needle jwt.Export) jwt.Exports {
+		for _, e := range haystack {
+			if e != nil && reflect.DeepEqual(*e, needle) {
+				return haystack
+			}
+		}
+		return append(haystack, &needle)
+	}
+	for _, e := range extras {
+		tmpExports = appendIfMissing(tmpExports, *e)
+	}
+	valResults := &jwt.ValidationResults{}
+	tmpExports.Validate(valResults)
+	validationErrors := valResults.Errors()
+	if len(validationErrors) != 0 {
+		return existing, errors.Join(validationErrors...)
+	}
+	return tmpExports, nil
+}
+
+func validateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error {
+	_, err := mergeImportRules(importAccountID, nil, rules)
+	return err
+}
+
+func mergeImportRules(importAccountID string, existing jwt.Imports, rules []v1alpha1.AccountImportRuleDerived) (jwt.Imports, error) {
+	jwtImports := make(jwt.Imports, len(rules))
+	for i, rule := range rules {
+		jwtImport := jwt.Import{
+			Account:      rule.Account,
+			Name:         rule.Name,
+			Subject:      jwt.Subject(rule.Subject),
+			Type:         toJWTExportType(rule.Type),
+			LocalSubject: jwt.RenamingSubject(rule.LocalSubject),
+		}
+		if rule.Share != nil {
+			jwtImport.Share = *rule.Share
+		}
+		if rule.AllowTrace != nil {
+			jwtImport.AllowTrace = *rule.AllowTrace
+		}
+		jwtImports[i] = &jwtImport
+	}
+	result, err := mergeImports(importAccountID, existing, jwtImports)
+	if err != nil {
+		return existing, err
+	}
+	return result, nil
+}
+
+func mergeImports(importAccountID string, existing jwt.Imports, extras jwt.Imports) (jwt.Imports, error) {
+	tmpResult := existing
+	appendIfMissing := func(haystack jwt.Imports, needle jwt.Import) jwt.Imports {
+		for _, e := range haystack {
+			if e != nil && reflect.DeepEqual(*e, needle) {
+				return haystack
+			}
+		}
+		return append(haystack, &needle)
+	}
+	for _, e := range extras {
+		if e != nil {
+			tmpResult = appendIfMissing(tmpResult, *e)
 		}
 	}
-	return append(exports, &export)
+	valResults := &jwt.ValidationResults{}
+	tmpResult.Validate(importAccountID, valResults)
+	validationErrors := valResults.Errors()
+	if len(validationErrors) != 0 {
+		return existing, errors.Join(validationErrors...)
+	}
+	return tmpResult, nil
 }
 
 func toJWTExportType(source v1alpha1.ExportType) jwt.ExportType {

--- a/internal/core/account_claims_test.go
+++ b/internal/core/account_claims_test.go
@@ -88,9 +88,11 @@ func Test_AccountClaims(t *testing.T) {
 				Exports:          nauthClaims.Exports,
 				Imports:          nauthClaims.Imports,
 			}
+			accountIDX := 0
 			natsClaimsRebuilt, err := unitUnderTest(rebuiltNatsClaims, func(accountRef domain.NamespacedName) (accountID string, err error) {
 				// For the rebuild, override the mock to always return the fake account ID (account ref is lost)
-				accountID = testClaimsFakeAccountID
+				accountIDX++
+				accountID = fakeAccountIdIdx(accountIDX)
 				return
 			})
 			require.NoError(t, err)
@@ -101,10 +103,45 @@ func Test_AccountClaims(t *testing.T) {
 
 			normalizedNatsClaimsRebuilt := normalizeClaimsForApproval(natsClaimsRebuilt)
 			// The rebuilt claims will have fake account ID for imports, normalize for equality check
+			overrideImportAccountIDs(normalizedNatsClaimsRebuilt, testClaimsFakeAccountID)
 			overrideImportAccountIDs(normalizedNatsClaims, testClaimsFakeAccountID)
 			assert.Equal(t, normalizedNatsClaims, normalizedNatsClaimsRebuilt)
 		})
 	}
+}
+
+func Test_AccountClaims_addExportRuleGroup_ShouldNotAlterExistingRulesOnConflict(t *testing.T) {
+	// Given
+	builder := newAccountClaimsBuilder(testClaimsDisplayName, testClaimsAccountPubKey, nil).
+		exports(v1alpha1.Exports{
+			{
+				Subject: "foo.>",
+				Type:    v1alpha1.Stream,
+			},
+		})
+
+	// When
+	err := builder.addExportRuleGroup([]v1alpha1.AccountExportRule{
+		{
+			Subject: "bar.>",
+			Type:    v1alpha1.Stream,
+		},
+		{
+			Subject: "foo.*",
+			Type:    v1alpha1.Stream,
+		},
+	})
+
+	// Then
+	require.ErrorContains(t, err, "failed to append export rule group:")
+	require.ErrorContains(t, err, "stream export subject \"foo.*\" already exports \"foo.>\"")
+	expected := jwt.Exports{
+		{
+			Subject: "foo.>",
+			Type:    jwt.Stream,
+		},
+	}
+	require.Equal(t, expected, builder.claim.Exports)
 }
 
 func Test_AccountClaims_convertNatsAccountClaims_ShouldSucceed_WhenMinimal(t *testing.T) {
@@ -181,7 +218,6 @@ func Test_AccountClaims_builder_ShouldReturnErrorWhenJetStreamEnablementConflict
 	// Then
 	require.ErrorContains(t, err, "ambiguous JetStream config; requested to be enabled, but no allowed MemoryStorage or DiskStorage supplied")
 	require.Nil(t, claims)
-
 }
 
 func Test_validateJetStreamLimits(t *testing.T) {
@@ -280,6 +316,10 @@ func Test_validateJetStreamLimits(t *testing.T) {
 
 func fakeAccountId(accountRef domain.NamespacedName) string {
 	return fmt.Sprintf("A%055s", strings.ToUpper(strings.ReplaceAll(accountRef.Name+accountRef.Namespace, "-", "")))
+}
+
+func fakeAccountIdIdx(idx int) string {
+	return fmt.Sprintf("A%055d", idx)
 }
 
 func loadAccountSpec(filePath string) (*v1alpha1.AccountSpec, error) {

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -602,7 +602,7 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountClaimsAreInv
 				string(v1alpha1.AccountLabelAccountID): importAccountID,
 			},
 		},
-	})
+	}).Once()
 
 	// When
 	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, domain.AccountResources{
@@ -641,8 +641,8 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountClaimsAreInv
 
 	// Then
 	t.Nil(result)
-	t.ErrorContains(err, "failed to sign account jwt")
-	t.ErrorContains(err, "account claims validation failed")
+	t.ErrorContains(err, "failed to build NATS account claims")
+	t.ErrorContains(err, "failed to add import \"import-twice\":")
 }
 
 func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.input.yaml
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.input.yaml
@@ -13,12 +13,19 @@ imports:
     subject: foo.service.>
     localSubject: imported.foo.service.>
     type: service
-  - name: my-complex
+  - name: my-max-stream
     accountRef:
       namespace: my-namespace
       name: complex-account
-    subject: complex.>
-    localSubject: imported.complex.>
+    subject: max.stream.>
+    localSubject: imported.max.stream.>
     type: stream
-    share: true
     allowTrace: true
+  - name: my-max-service
+    accountRef:
+      namespace: my-namespace
+      name: complex-account
+    subject: max.service.>
+    localSubject: imported.max.service.>
+    type: service
+    share: true

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nats.approved.json
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nats.approved.json
@@ -7,13 +7,6 @@
   "nats": {
     "imports": [
       {
-        "name": "my-complex",
-        "subject": "complex.\u003e",
-        "account": "A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE",
-        "local_subject": "imported.complex.\u003e",
-        "type": "stream"
-      },
-      {
         "name": "my-service-import",
         "subject": "foo.service.\u003e",
         "account": "A000000000000000000000000000000SERVICEACCOUNTMYNAMESPACE",
@@ -26,6 +19,22 @@
         "account": "A0000000000000000000000000000000STREAMACCOUNTMYNAMESPACE",
         "local_subject": "imported.foo.stream.\u003e",
         "type": "stream"
+      },
+      {
+        "name": "my-max-service",
+        "subject": "max.service.\u003e",
+        "account": "A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE",
+        "local_subject": "imported.max.service.\u003e",
+        "type": "service",
+        "share": true
+      },
+      {
+        "name": "my-max-stream",
+        "subject": "max.stream.\u003e",
+        "account": "A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE",
+        "local_subject": "imported.max.stream.\u003e",
+        "type": "stream",
+        "allow_trace": true
       }
     ],
     "limits": {

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nauth.approved.yaml
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nauth.approved.yaml
@@ -1,13 +1,5 @@
 displayName: test-namespace/test-account
 imports:
-- account: A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE
-  accountRef:
-    name: ""
-    namespace: ""
-  localSubject: imported.complex.>
-  name: my-complex
-  subject: complex.>
-  type: stream
 - account: A000000000000000000000000000000SERVICEACCOUNTMYNAMESPACE
   accountRef:
     name: ""
@@ -23,6 +15,24 @@ imports:
   localSubject: imported.foo.stream.>
   name: my-stream-import
   subject: foo.stream.>
+  type: stream
+- account: A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE
+  accountRef:
+    name: ""
+    namespace: ""
+  localSubject: imported.max.service.>
+  name: my-max-service
+  share: true
+  subject: max.service.>
+  type: service
+- account: A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE
+  accountRef:
+    name: ""
+    namespace: ""
+  allowTrace: true
+  localSubject: imported.max.stream.>
+  name: my-max-stream
+  subject: max.stream.>
   type: stream
 jetStreamEnabled: true
 jetStreamLimits:

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.approved.yaml
@@ -13,8 +13,8 @@ Adoptions:
     observedGeneration: 1
     status:
       desiredClaimObservedGeneration: 1
-      message: 'rules adoption failed: stream export subject "foo.*" already exports
-        "foo.*"'
+      message: 'failed to append export rule group: stream export subject "foo.*"
+        already exports "foo.*"'
       reason: Invalid
       status: "False"
     uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.approved.yaml
@@ -13,7 +13,8 @@ Adoptions:
     observedGeneration: 1
     status:
       desiredClaimObservedGeneration: 1
-      message: 'rules adoption failed: subject "invalid subject" cannot have spaces'
+      message: 'failed to append export rule group: subject "invalid subject" cannot
+        have spaces'
       reason: Invalid
       status: "False"
     uid: 2cecbfcb-e92d-4bc9-bf4d-67d82737e707

--- a/internal/core/mocks_test.go
+++ b/internal/core/mocks_test.go
@@ -375,8 +375,8 @@ func (a *AccountReaderMock) Get(ctx context.Context, accountRef domain.Namespace
 	return args.Get(0).(*v1alpha1.Account), args.Error(1)
 }
 
-func (a *AccountReaderMock) mockGet(ctx context.Context, accountRef domain.NamespacedName, result *v1alpha1.Account) {
-	a.On("Get", ctx, accountRef).Return(result, nil)
+func (a *AccountReaderMock) mockGet(ctx context.Context, accountRef domain.NamespacedName, result *v1alpha1.Account) *mock.Call {
+	return a.On("Get", ctx, accountRef).Return(result, nil)
 }
 
 var _ outbound.AccountReader = &AccountReaderMock{}

--- a/internal/ports/inbound/nauth.go
+++ b/internal/ports/inbound/nauth.go
@@ -17,6 +17,10 @@ type AccountExportManager interface {
 	Resolve(ctx context.Context, state *v1alpha1.AccountExport, account *v1alpha1.Account) *domain.AccountExportResolution
 }
 
+type AccountImportManager interface {
+	ValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error
+}
+
 type UserManager interface {
 	CreateOrUpdate(ctx context.Context, state *v1alpha1.User) error
 	Delete(ctx context.Context, desired *v1alpha1.User) error


### PR DESCRIPTION
## Summary

Validates AccountImport rules before exposing the desired import claim in status.

## What changed

- Wires AccountImport reconciliation through an `AccountImportManager`
- Derives import rules with the resolved export account ID
- Validates import rules through the account claims builder
- Sets `ValidRules=True` and `status.desiredClaim` only after successful validation
- Preserves `share` and `allowTrace` when converting imports into NATS JWT imports
- Adds controller, core, and approval coverage for valid and invalid import rules

### Commits in this PR

- `a0100e8` feat(core): validate account import rules for AccountImport CRD claim
- `c94d60b` fix(core): map Share and AllowTrace for imports
