### PR TITLE
feat(core): introduce domain model for Imports and Limits

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -232,14 +232,57 @@ func toAPIAccountClaims(claims *nauth.AccountClaims) *v1alpha1.AccountClaims {
 	}
 
 	return &v1alpha1.AccountClaims{
-		AccountLimits:    claims.AccountLimits,
+		AccountLimits:    toAPIAccountLimits(claims.AccountLimits),
 		DisplayName:      claims.DisplayName,
 		SigningKeys:      claims.SigningKeys,
 		Exports:          claims.Exports,
 		Imports:          toAPIImports(claims.Imports),
 		JetStreamEnabled: claims.JetStreamEnabled,
-		JetStreamLimits:  claims.JetStreamLimits,
-		NatsLimits:       claims.NatsLimits,
+		JetStreamLimits:  toAPIAJetStreamLimits(claims.JetStreamLimits),
+		NatsLimits:       toAPINatsLimits(claims.NatsLimits),
+	}
+}
+
+func toAPIAccountLimits(source *nauth.AccountLimits) *v1alpha1.AccountLimits {
+	if source == nil {
+		return nil
+	}
+
+	return &v1alpha1.AccountLimits{
+		Imports:         source.Imports,
+		Exports:         source.Exports,
+		WildcardExports: source.WildcardExports,
+		Conn:            source.Conn,
+		LeafNodeConn:    source.LeafNodeConn,
+	}
+}
+
+func toAPIAJetStreamLimits(source *nauth.JetStreamLimits) *v1alpha1.JetStreamLimits {
+	if source == nil {
+		return nil
+	}
+
+	return &v1alpha1.JetStreamLimits{
+		MemoryStorage:        source.MemoryStorage,
+		DiskStorage:          source.DiskStorage,
+		Streams:              source.Streams,
+		Consumer:             source.Consumer,
+		MaxAckPending:        source.MaxAckPending,
+		MemoryMaxStreamBytes: source.MemoryMaxStreamBytes,
+		DiskMaxStreamBytes:   source.DiskMaxStreamBytes,
+		MaxBytesRequired:     source.MaxBytesRequired,
+	}
+}
+
+func toAPINatsLimits(source *nauth.NatsLimits) *v1alpha1.NatsLimits {
+	if source == nil {
+		return nil
+	}
+
+	return &v1alpha1.NatsLimits{
+		Subs:    source.Subs,
+		Data:    source.Data,
+		Payload: source.Payload,
 	}
 }
 

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -199,7 +200,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// UPDATE ACCOUNT STATUS
 	if result.Claims != nil {
-		natsAccount.Status.Claims = *result.Claims
+		natsAccount.Status.Claims = *toAPIAccountClaims(result.Claims)
 	}
 	natsAccount.Status.Adoptions = result.Adoptions
 	natsAccount.Status.ClaimsHash = result.ClaimsHash
@@ -223,6 +224,50 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return r.reporter.status(ctx, natsAccount)
+}
+
+func toAPIAccountClaims(claims *nauth.AccountClaims) *v1alpha1.AccountClaims {
+	if claims == nil {
+		return nil
+	}
+
+	return &v1alpha1.AccountClaims{
+		AccountLimits:    claims.AccountLimits,
+		DisplayName:      claims.DisplayName,
+		SigningKeys:      claims.SigningKeys,
+		Exports:          claims.Exports,
+		Imports:          toAPIImports(claims.Imports),
+		JetStreamEnabled: claims.JetStreamEnabled,
+		JetStreamLimits:  claims.JetStreamLimits,
+		NatsLimits:       claims.NatsLimits,
+	}
+}
+
+func toAPIImports(imports nauth.Imports) v1alpha1.Imports {
+	result := make(v1alpha1.Imports, len(imports))
+	for i, imp := range imports {
+		result[i] = &v1alpha1.Import{
+			Account:      string(imp.AccountID),
+			Name:         imp.Name,
+			Subject:      v1alpha1.Subject(imp.Subject),
+			LocalSubject: v1alpha1.RenamingSubject(imp.LocalSubject),
+			Type:         toAPIExportType(imp.Type),
+			Share:        imp.Share,
+			AllowTrace:   imp.AllowTrace,
+		}
+	}
+	return result
+}
+
+func toAPIExportType(exportType nauth.ExportType) v1alpha1.ExportType {
+	switch exportType {
+	case nauth.ExportTypeStream:
+		return v1alpha1.Stream
+	case nauth.ExportTypeService:
+		return v1alpha1.Service
+	default:
+		return v1alpha1.Stream
+	}
 }
 
 func (r *AccountReconciler) collectAccountResources(ctx context.Context, account *v1alpha1.Account, accountID string) (*domain.AccountResources, error) {

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -97,7 +98,7 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
 	}
 
-	validRules, validRulesErr := r.validateRules(importAccountID, exportAccountID, state.Spec.Rules)
+	derivedRules, validRulesErr := r.validateImports(importAccountID, exportAccountID, state.Spec.Rules)
 	var validRulesCondition metav1.Condition
 	if validRulesErr != nil {
 		validRulesCondition = metav1.Condition{
@@ -113,9 +114,10 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Reason:  conditionReasonOK,
 			Message: "Rules validation successful",
 		}
+
 		state.Status.DesiredClaim = &v1alpha1.AccountImportClaim{
 			ObservedGeneration: state.Generation,
-			Rules:              validRules,
+			Rules:              derivedRules,
 		}
 	}
 
@@ -136,22 +138,24 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return ctrl.Result{}, nil
 }
 
-func (r *AccountImportReconciler) validateRules(importAccountID string, exportAccountID string, rules []v1alpha1.AccountImportRule) ([]v1alpha1.AccountImportRuleDerived, error) {
-	var err error
-	var derivedRules []v1alpha1.AccountImportRuleDerived
+func (r *AccountImportReconciler) validateImports(importAccountID string, exportAccountID string, rules []v1alpha1.AccountImportRule) ([]v1alpha1.AccountImportRuleDerived, error) {
 	if importAccountID == "" {
-		err = fmt.Errorf("import account ID is required")
+		return nil, fmt.Errorf("import account ID is required")
 	} else if exportAccountID == "" {
-		err = fmt.Errorf("export account ID is required")
+		return nil, fmt.Errorf("export account ID is required")
 	} else if len(rules) == 0 {
-		err = fmt.Errorf("at least one rule is required")
-	} else {
-		derivedRules = deriveImportRules(rules, exportAccountID)
-		if err = r.manager.ValidateImportRules(importAccountID, derivedRules); err != nil {
-			err = fmt.Errorf("rules validation failed: %w", err)
-		}
+		return nil, fmt.Errorf("at least one rule is required")
 	}
-	return derivedRules, err
+
+	imports := toNAuthImports(exportAccountID, rules)
+	if err := r.manager.ValidateImports(nauth.AccountID(importAccountID), imports); err != nil {
+		return nil, fmt.Errorf("rules validation failed: %w", err)
+	}
+	result := make([]v1alpha1.AccountImportRuleDerived, len(imports))
+	for i, imp := range imports {
+		result[i] = toAPIAccountImportRuleDerived(*imp)
+	}
+	return result, nil
 }
 
 func (r *AccountImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -258,15 +262,4 @@ func (r *AccountImportReconciler) setConditions(state *v1alpha1.AccountImport, s
 		}
 	}
 	meta.SetStatusCondition(state.GetConditions(), ready)
-}
-
-func deriveImportRules(rules []v1alpha1.AccountImportRule, exportAccountID string) []v1alpha1.AccountImportRuleDerived {
-	result := make([]v1alpha1.AccountImportRuleDerived, len(rules))
-	for i, r := range rules {
-		result[i] = v1alpha1.AccountImportRuleDerived{
-			Account:           exportAccountID,
-			AccountImportRule: r,
-		}
-	}
-	return result
 }

--- a/internal/adapter/inbound/controller/account_import_test.go
+++ b/internal/adapter/inbound/controller/account_import_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/mock"
@@ -89,8 +90,14 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 		},
 	}
 	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
-	derivedRules := deriveImportRules(resourceInput.Spec.Rules, exportAccountID)
-	t.accountImportManagerMock.mockValidateImportRules(importAccountID, derivedRules).Once()
+	expectNAuthImports := nauth.Imports{
+		&nauth.Import{
+			AccountID: nauth.AccountID(exportAccountID),
+			Subject:   nauth.Subject("foo.*"),
+			Type:      nauth.ExportTypeStream,
+		},
+	}
+	t.accountImportManagerMock.mockValidateImports(nauth.AccountID(importAccountID), expectNAuthImports).Once()
 
 	// When
 	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
@@ -109,9 +116,20 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 	// TODO: [#11] Verify account adoption condition
 	t.assertCondition(resource, conditionTypeReady, metav1.ConditionFalse, conditionReasonNotReady)
 
+	boolFalse := false
 	expectClaim := &v1alpha1.AccountImportClaim{
 		ObservedGeneration: 1,
-		Rules:              derivedRules,
+		Rules: []v1alpha1.AccountImportRuleDerived{
+			{
+				Account: exportAccountID,
+				AccountImportRule: v1alpha1.AccountImportRule{
+					Subject:    "foo.*",
+					Type:       v1alpha1.Stream,
+					Share:      &boolFalse,
+					AllowTrace: &boolFalse,
+				},
+			},
+		},
 	}
 	t.Equalf(expectClaim, resource.Status.DesiredClaim, "expected claim")
 	t.Equal(importAccountID, resource.GetLabel(v1alpha1.AccountImportLabelAccountID))
@@ -145,7 +163,14 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenExpo
 		},
 	}
 	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
-	t.accountImportManagerMock.mockValidateImportRules(importAccountID, deriveImportRules(resourceInput.Spec.Rules, exportAccountID)).Once()
+	expectImports := nauth.Imports{
+		{
+			AccountID: nauth.AccountID(exportAccountID),
+			Subject:   nauth.Subject("foo.*"),
+			Type:      nauth.ExportTypeStream,
+		},
+	}
+	t.accountImportManagerMock.mockValidateImports(nauth.AccountID(importAccountID), expectImports).Once()
 
 	// When
 	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
@@ -285,7 +310,14 @@ func (t *AccountImportControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenRule
 		},
 	}
 	t.Require().NoError(k8sClient.Create(t.ctx, &resourceInput))
-	t.accountImportManagerMock.mockValidateImportRulesError(importAccountID, deriveImportRules(resourceInput.Spec.Rules, exportAccountID), fmt.Errorf("invalid test rules")).Once()
+	expectImports := nauth.Imports{
+		&nauth.Import{
+			AccountID: nauth.AccountID(exportAccountID),
+			Subject:   nauth.Subject("foo.*"),
+			Type:      nauth.ExportTypeStream,
+		},
+	}
+	t.accountImportManagerMock.mockValidateImportsError(nauth.AccountID(importAccountID), expectImports, fmt.Errorf("invalid test rules")).Once()
 
 	// When
 	result, err := t.runReconcileLoopForNewResource(importAccountID, exportAccountID)
@@ -435,17 +467,17 @@ type accountImportManagerMock struct {
 	mock.Mock
 }
 
-func (m *accountImportManagerMock) ValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error {
-	args := m.Called(importAccountID, rules)
+func (m *accountImportManagerMock) ValidateImports(importAccountID nauth.AccountID, imports nauth.Imports) error {
+	args := m.Called(importAccountID, imports)
 	return args.Error(0)
 }
 
-func (m *accountImportManagerMock) mockValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) *mock.Call {
-	return m.On("ValidateImportRules", importAccountID, rules).Return(nil)
+func (m *accountImportManagerMock) mockValidateImports(importAccountID nauth.AccountID, imports nauth.Imports) *mock.Call {
+	return m.On("ValidateImports", importAccountID, imports).Return(nil)
 }
 
-func (m *accountImportManagerMock) mockValidateImportRulesError(importAccountID string, rules []v1alpha1.AccountImportRuleDerived, err error) *mock.Call {
-	return m.On("ValidateImportRules", importAccountID, rules).Return(err)
+func (m *accountImportManagerMock) mockValidateImportsError(importAccountID nauth.AccountID, imports nauth.Imports, err error) *mock.Call {
+	return m.On("ValidateImports", importAccountID, imports).Return(err)
 }
 
 var _ inbound.AccountImportManager = (*accountImportManagerMock)(nil)

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/mock"
@@ -111,7 +112,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAc
 	mockResult := &domain.AccountResult{
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &v1alpha1.AccountClaims{},
+		Claims:          &nauth.AccountClaims{},
 		ClaimsHash:      "CLAIMS_HASH",
 	}
 	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
@@ -163,7 +164,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldNotDeleteObservedAccou
 	mockResult := &domain.AccountResult{
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &v1alpha1.AccountClaims{},
+		Claims:          &nauth.AccountClaims{},
 	}
 	// Note: Expect manager.Import during setup only
 	t.accountManagerMock.mockImport(t.ctx, mock.Anything, mockResult).Once()
@@ -205,7 +206,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldDeleteAccountMarkedFor
 	mockResult := &domain.AccountResult{
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &v1alpha1.AccountClaims{},
+		Claims:          &nauth.AccountClaims{},
 	}
 	// Note: Expect manager.CreateOrUpdate during setup only
 	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
@@ -246,7 +247,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenDeleteFails()
 	mockResult := &domain.AccountResult{
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &v1alpha1.AccountClaims{},
+		Claims:          &nauth.AccountClaims{},
 	}
 	// Note: Expect manager.CreateOrUpdate during setup only
 	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
@@ -288,7 +289,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldImportObservedAccount(
 	mockResult := &domain.AccountResult{
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &v1alpha1.AccountClaims{},
+		Claims:          &nauth.AccountClaims{},
 	}
 
 	account := &v1alpha1.Account{}
@@ -314,7 +315,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenOperatorVe
 	mockResult := &domain.AccountResult{
 		AccountID:       accountPublicKey,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &v1alpha1.AccountClaims{},
+		Claims:          &nauth.AccountClaims{},
 	}
 	// Note: Expect manager.CreateOrUpdate during setup only
 	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
@@ -357,7 +358,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenAccountExp
 	mockResult := &domain.AccountResult{
 		AccountID:       accountID,
 		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &v1alpha1.AccountClaims{},
+		Claims:          &nauth.AccountClaims{},
 	}
 	// Note: Expect manager.CreateOrUpdate during setup only
 	var accountResources0 domain.AccountResources

--- a/internal/adapter/inbound/controller/converter.go
+++ b/internal/adapter/inbound/controller/converter.go
@@ -1,0 +1,52 @@
+package controller
+
+import (
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
+)
+
+func toNAuthImports(exportAccountID string, sources []v1alpha1.AccountImportRule) nauth.Imports {
+	target := make(nauth.Imports, len(sources))
+	for i, rule := range sources {
+		imp := nauth.Import{
+			AccountID:    nauth.AccountID(exportAccountID),
+			Name:         rule.Name,
+			Subject:      nauth.Subject(rule.Subject),
+			LocalSubject: nauth.Subject(rule.LocalSubject),
+			Type:         toNAuthExportType(rule.Type),
+		}
+		if rule.Share != nil {
+			imp.Share = *rule.Share
+		}
+		if rule.AllowTrace != nil {
+			imp.AllowTrace = *rule.AllowTrace
+		}
+		target[i] = &imp
+	}
+	return target
+}
+
+func toAPIAccountImportRuleDerived(source nauth.Import) v1alpha1.AccountImportRuleDerived {
+	return v1alpha1.AccountImportRuleDerived{
+		Account: string(source.AccountID),
+		AccountImportRule: v1alpha1.AccountImportRule{
+			Name:         source.Name,
+			Subject:      v1alpha1.Subject(source.Subject),
+			LocalSubject: v1alpha1.RenamingSubject(source.LocalSubject),
+			Type:         toAPIExportType(source.Type),
+			Share:        &source.Share,
+			AllowTrace:   &source.AllowTrace,
+		},
+	}
+}
+
+func toNAuthExportType(source v1alpha1.ExportType) nauth.ExportType {
+	switch source {
+	case v1alpha1.Stream:
+		return nauth.ExportTypeStream
+	case v1alpha1.Service:
+		return nauth.ExportTypeService
+	default:
+		return nauth.ExportTypeUnknown
+	}
+}

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -17,6 +17,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const GroupNameInline = "inline"
+
 type AccountManager struct {
 	natsSysClient         outbound.NatsSysClient
 	natsAccClient         outbound.NatsAccountClient
@@ -153,17 +155,12 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 	}
 
 	accountIDReader := cachedAccountIDReader(ctx, a.accountReader)
-	inlineImports, err := toInlineImports(accountIDReader, account.Spec.Imports)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert account inline imports domain model: %w", err)
+	claimsBuilder := newAccountClaimsBuilder(accountPublicKey, account.Spec.JetStreamEnabled).
+		displayName(getDisplayName(account)).
+		signingKey(accountSigningPublicKey)
+	if err = applySpec(accountIDReader, claimsBuilder, account.Spec); err != nil {
+		return nil, fmt.Errorf("failed to prepare account claims: %w", err)
 	}
-	claimsBuilder := newAccountClaimsBuilder(getDisplayName(account), accountPublicKey, account.Spec.JetStreamEnabled).
-		accountLimits(account.Spec.AccountLimits).
-		jetStreamLimits(account.Spec.JetStreamLimits).
-		natsLimits(account.Spec.NatsLimits).
-		exports(account.Spec.Exports).
-		imports(inlineImports)
-	claimsBuilder.signingKey(accountSigningPublicKey)
 	adoptions := &v1alpha1.AccountAdoptions{
 		Exports: adoptExports(claimsBuilder, resources.Exports),
 	}
@@ -207,6 +204,25 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 		ClaimsHash:      claimsHash,
 		Adoptions:       adoptions,
 	}, nil
+}
+
+func applySpec(accountIDReader resolveAccountIDFn, builder *accountClaimsBuilder, spec v1alpha1.AccountSpec) error {
+	builder.
+		accountLimits(spec.AccountLimits).
+		jetStreamLimits(spec.JetStreamLimits).
+		natsLimits(spec.NatsLimits).
+		exports(spec.Exports)
+	if len(spec.Imports) > 0 {
+		inlineImportGroup, inlineImportsErr := toInlineImportGroup(accountIDReader, spec.Imports)
+		if inlineImportsErr != nil {
+			return fmt.Errorf("failed to convert inline imports to domain model: %w", inlineImportsErr)
+		}
+		err := builder.addImportGroup(*inlineImportGroup)
+		if err != nil {
+			return fmt.Errorf("failed to add inline imports: %w", err)
+		}
+	}
+	return nil
 }
 
 func adoptExports(builder *accountClaimsBuilder, exports []v1alpha1.AccountExport) []v1alpha1.AccountAdoption {
@@ -522,19 +538,23 @@ func cachedAccountIDReader(ctx context.Context, accountReader outbound.AccountRe
 	}
 }
 
-func toInlineImports(reader resolveAccountIDFn, imports v1alpha1.Imports) (nauth.Imports, error) {
-	var result nauth.Imports
-	for _, source := range imports {
+func toInlineImportGroup(reader resolveAccountIDFn, sources v1alpha1.Imports) (*nauth.ImportGroup, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("no inline imports defined")
+	}
+
+	var imports nauth.Imports
+	for _, source := range sources {
 		accountRef := domain.NewNamespacedName(source.AccountRef.Namespace, source.AccountRef.Name)
 		var err error
 		accountID, err := reader(accountRef)
 		if err != nil {
-			return result, fmt.Errorf("failed to resolve account ID for import %s: %w", accountRef, err)
+			return nil, fmt.Errorf("failed to resolve account ID for inline import %s: %w", accountRef, err)
 		}
 		if accountID == "" {
-			return result, fmt.Errorf("account ID is missing for import %s", accountRef)
+			return nil, fmt.Errorf("account ID is missing for inline import %s", accountRef)
 		}
-		result = append(result, &nauth.Import{
+		imports = append(imports, &nauth.Import{
 			AccountID:    nauth.AccountID(accountID),
 			Name:         source.Name,
 			Subject:      nauth.Subject(source.Subject),
@@ -544,7 +564,10 @@ func toInlineImports(reader resolveAccountIDFn, imports v1alpha1.Imports) (nauth
 			AllowTrace:   source.AllowTrace,
 		})
 	}
-	return result, nil
+	return &nauth.ImportGroup{
+		Name:    GroupNameInline,
+		Imports: imports,
+	}, nil
 }
 
 func toNAuthExportTypeFromAPI(exportType v1alpha1.ExportType) nauth.ExportType {

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
@@ -150,12 +151,18 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operator signing public key: %w", err)
 	}
+
+	accountIDReader := cachedAccountIDReader(ctx, a.accountReader)
+	inlineImports, err := toInlineImports(accountIDReader, account.Spec.Imports)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert account inline imports domain model: %w", err)
+	}
 	claimsBuilder := newAccountClaimsBuilder(getDisplayName(account), accountPublicKey, account.Spec.JetStreamEnabled).
 		accountLimits(account.Spec.AccountLimits).
 		jetStreamLimits(account.Spec.JetStreamLimits).
 		natsLimits(account.Spec.NatsLimits).
 		exports(account.Spec.Exports).
-		imports(account.Spec.Imports, cachedAccountIDReader(ctx, a.accountReader))
+		imports(inlineImports)
 	claimsBuilder.signingKey(accountSigningPublicKey)
 	adoptions := &v1alpha1.AccountAdoptions{
 		Exports: adoptExports(claimsBuilder, resources.Exports),
@@ -472,8 +479,8 @@ func (a *AccountManager) SignUserJWT(ctx context.Context, accountRef domain.Name
 	}, nil
 }
 
-func (a *AccountManager) ValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error {
-	return validateImportRules(importAccountID, rules)
+func (a *AccountManager) ValidateImports(importAccountID nauth.AccountID, imports nauth.Imports) error {
+	return validateImports(string(importAccountID), imports)
 }
 
 func (a *AccountManager) resolveClusterTarget(ctx context.Context, account *v1alpha1.Account) (*clusterTarget, error) {
@@ -493,6 +500,8 @@ func getDisplayName(account *v1alpha1.Account) string {
 	return fmt.Sprintf("%s/%s", account.GetNamespace(), account.GetName())
 }
 
+type resolveAccountIDFn func(accountRef domain.NamespacedName) (accountID string, err error)
+
 func cachedAccountIDReader(ctx context.Context, accountReader outbound.AccountReader) resolveAccountIDFn {
 	cache := make(map[domain.NamespacedName]string)
 	return func(accountRef domain.NamespacedName) (string, error) {
@@ -510,6 +519,42 @@ func cachedAccountIDReader(ctx context.Context, accountReader outbound.AccountRe
 			return "", fmt.Errorf("account ID label %s is missing for account %q", v1alpha1.AccountLabelAccountID, accountRef)
 		}
 		return accountID, nil
+	}
+}
+
+func toInlineImports(reader resolveAccountIDFn, imports v1alpha1.Imports) (nauth.Imports, error) {
+	var result nauth.Imports
+	for _, source := range imports {
+		accountRef := domain.NewNamespacedName(source.AccountRef.Namespace, source.AccountRef.Name)
+		var err error
+		accountID, err := reader(accountRef)
+		if err != nil {
+			return result, fmt.Errorf("failed to resolve account ID for import %s: %w", accountRef, err)
+		}
+		if accountID == "" {
+			return result, fmt.Errorf("account ID is missing for import %s", accountRef)
+		}
+		result = append(result, &nauth.Import{
+			AccountID:    nauth.AccountID(accountID),
+			Name:         source.Name,
+			Subject:      nauth.Subject(source.Subject),
+			LocalSubject: nauth.Subject(source.LocalSubject),
+			Type:         toNAuthExportTypeFromAPI(source.Type),
+			Share:        source.Share,
+			AllowTrace:   source.AllowTrace,
+		})
+	}
+	return result, nil
+}
+
+func toNAuthExportTypeFromAPI(exportType v1alpha1.ExportType) nauth.ExportType {
+	switch exportType {
+	case v1alpha1.Stream:
+		return nauth.ExportTypeStream
+	case v1alpha1.Service:
+		return nauth.ExportTypeService
+	default:
+		return nauth.ExportTypeUnknown
 	}
 }
 

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -208,9 +208,9 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources domain.Ac
 
 func applySpec(accountIDReader resolveAccountIDFn, builder *accountClaimsBuilder, spec v1alpha1.AccountSpec) error {
 	builder.
-		accountLimits(spec.AccountLimits).
-		jetStreamLimits(spec.JetStreamLimits).
-		natsLimits(spec.NatsLimits).
+		accountLimits(toNAuthAccountLimits(spec.AccountLimits)).
+		jetStreamLimits(toNAuthJetStreamLimits(spec.JetStreamLimits)).
+		natsLimits(toNAuthNatsLimits(spec.NatsLimits)).
 		exports(spec.Exports)
 	if len(spec.Imports) > 0 {
 		inlineImportGroup, inlineImportsErr := toInlineImportGroup(accountIDReader, spec.Imports)
@@ -535,6 +535,46 @@ func cachedAccountIDReader(ctx context.Context, accountReader outbound.AccountRe
 			return "", fmt.Errorf("account ID label %s is missing for account %q", v1alpha1.AccountLabelAccountID, accountRef)
 		}
 		return accountID, nil
+	}
+}
+
+func toNAuthAccountLimits(source *v1alpha1.AccountLimits) *nauth.AccountLimits {
+	if source == nil {
+		return nil
+	}
+	return &nauth.AccountLimits{
+		Imports:         source.Imports,
+		Exports:         source.Exports,
+		WildcardExports: source.WildcardExports,
+		Conn:            source.Conn,
+		LeafNodeConn:    source.LeafNodeConn,
+	}
+}
+
+func toNAuthJetStreamLimits(source *v1alpha1.JetStreamLimits) *nauth.JetStreamLimits {
+	if source == nil {
+		return nil
+	}
+	return &nauth.JetStreamLimits{
+		MemoryStorage:        source.MemoryStorage,
+		DiskStorage:          source.DiskStorage,
+		Streams:              source.Streams,
+		Consumer:             source.Consumer,
+		MaxAckPending:        source.MaxAckPending,
+		MemoryMaxStreamBytes: source.MemoryMaxStreamBytes,
+		DiskMaxStreamBytes:   source.DiskMaxStreamBytes,
+		MaxBytesRequired:     source.MaxBytesRequired,
+	}
+}
+
+func toNAuthNatsLimits(source *v1alpha1.NatsLimits) *nauth.NatsLimits {
+	if source == nil {
+		return nil
+	}
+	return &nauth.NatsLimits{
+		Subs:    source.Subs,
+		Data:    source.Data,
+		Payload: source.Payload,
 	}
 }
 

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -9,12 +9,10 @@ import (
 	"sort"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/nats-io/jwt/v2"
 	"k8s.io/apimachinery/pkg/util/json"
 )
-
-type resolveAccountIDFn func(accountRef domain.NamespacedName) (accountID string, err error)
 
 type accountClaimsBuilder struct {
 	jetStreamRequested *bool
@@ -116,7 +114,7 @@ func (b *accountClaimsBuilder) exports(exports v1alpha1.Exports) *accountClaimsB
 		exportClaim := &jwt.Export{
 			Name:                 export.Name,
 			Subject:              jwt.Subject(export.Subject),
-			Type:                 toJWTExportType(export.Type),
+			Type:                 toJWTExportTypeFromAPI(export.Type),
 			TokenReq:             export.TokenReq,
 			Revocations:          jwt.RevocationList(export.Revocations),
 			ResponseType:         jwt.ResponseType(export.ResponseType),
@@ -133,31 +131,14 @@ func (b *accountClaimsBuilder) exports(exports v1alpha1.Exports) *accountClaimsB
 	return b
 }
 
-func (b *accountClaimsBuilder) imports(imports v1alpha1.Imports, resolveAccountIDFn resolveAccountIDFn) *accountClaimsBuilder {
+func (b *accountClaimsBuilder) imports(imports nauth.Imports) *accountClaimsBuilder {
 	for _, imp := range imports {
-		accountRef := domain.NewNamespacedName(imp.AccountRef.Namespace, imp.AccountRef.Name)
-		exportAccountID, err := resolveAccountIDFn(accountRef)
-		if err != nil {
-			b.errs = append(b.errs, fmt.Errorf("failed to resolve account ID for import %q (account: %q): %w",
-				imp.Name,
-				accountRef,
-				err))
-		} else {
-			jwtImport := &jwt.Import{
-				Name:         imp.Name,
-				Subject:      jwt.Subject(imp.Subject),
-				Type:         jwt.ExportType(imp.Type.ToInt()),
-				Account:      exportAccountID,
-				LocalSubject: jwt.RenamingSubject(imp.LocalSubject),
-				Share:        imp.Share,
-				AllowTrace:   imp.AllowTrace,
-			}
-			result, mergeErr := mergeImports(b.claim.Subject, b.claim.Imports, jwt.Imports{jwtImport})
-			if mergeErr != nil {
-				b.errs = append(b.errs, fmt.Errorf("failed to add import %q: %w", imp.Name, mergeErr))
-			}
-			b.claim.Imports = result
+		jwtImport := toJWTImport(*imp)
+		result, mergeErr := mergeJWTImports(b.claim.Subject, b.claim.Imports, jwt.Imports{jwtImport})
+		if mergeErr != nil {
+			b.errs = append(b.errs, fmt.Errorf("failed to add import %q: %w", imp.Name, mergeErr))
 		}
+		b.claim.Imports = result
 	}
 	return b
 }
@@ -168,7 +149,7 @@ func (b *accountClaimsBuilder) addExportRuleGroup(rules []v1alpha1.AccountExport
 		jwtExport := jwt.Export{
 			Name:         rule.Name,
 			Subject:      jwt.Subject(rule.Subject),
-			Type:         toJWTExportType(rule.Type),
+			Type:         toJWTExportTypeFromAPI(rule.Type),
 			ResponseType: jwt.ResponseType(rule.ResponseType),
 		}
 		if rule.ResponseThreshold != nil {
@@ -250,13 +231,13 @@ func toPtrDefNil[V int64 | bool](value V, defaultValue V) *V {
 	return nil
 }
 
-func convertNatsAccountClaims(claims *jwt.AccountClaims) v1alpha1.AccountClaims {
+func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 	if claims == nil {
-		return v1alpha1.AccountClaims{}
+		return nauth.AccountClaims{}
 	}
 
 	claimsDefaults := jwt.NewAccountClaims("N/A")
-	out := v1alpha1.AccountClaims{}
+	out := nauth.AccountClaims{}
 	out.DisplayName = claims.Name
 
 	jetStreamEnabled := claims.Limits.IsJSEnabled()
@@ -367,30 +348,12 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) v1alpha1.AccountClaims 
 
 	// Imports
 	if len(claims.Imports) > 0 {
-		imports := make(v1alpha1.Imports, 0, len(claims.Imports))
+		imports := make(nauth.Imports, 0, len(claims.Imports))
 		for _, i := range claims.Imports {
 			if i == nil {
 				continue
 			}
-			var it v1alpha1.ExportType
-			switch i.Type {
-			case jwt.Stream:
-				it = v1alpha1.Stream
-			case jwt.Service:
-				it = v1alpha1.Service
-			default:
-				it = v1alpha1.Stream
-			}
-			imp := &v1alpha1.Import{
-				Name:         i.Name,
-				Subject:      v1alpha1.Subject(i.Subject),
-				Account:      i.Account,
-				LocalSubject: v1alpha1.RenamingSubject(i.LocalSubject),
-				Type:         it,
-				Share:        i.Share,
-				AllowTrace:   i.AllowTrace,
-			}
-			imports = append(imports, imp)
+			imports = append(imports, toNAuthImport(*i))
 		}
 		out.Imports = imports
 	}
@@ -422,37 +385,48 @@ func mergeExports(existing jwt.Exports, extras jwt.Exports) (jwt.Exports, error)
 	return tmpExports, nil
 }
 
-func validateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error {
-	_, err := mergeImportRules(importAccountID, nil, rules)
+func validateImports(importAccountID string, imports nauth.Imports) error {
+	_, err := mergeImports(importAccountID, nil, imports)
 	return err
 }
 
-func mergeImportRules(importAccountID string, existing jwt.Imports, rules []v1alpha1.AccountImportRuleDerived) (jwt.Imports, error) {
-	jwtImports := make(jwt.Imports, len(rules))
-	for i, rule := range rules {
-		jwtImport := jwt.Import{
-			Account:      rule.Account,
-			Name:         rule.Name,
-			Subject:      jwt.Subject(rule.Subject),
-			Type:         toJWTExportType(rule.Type),
-			LocalSubject: jwt.RenamingSubject(rule.LocalSubject),
-		}
-		if rule.Share != nil {
-			jwtImport.Share = *rule.Share
-		}
-		if rule.AllowTrace != nil {
-			jwtImport.AllowTrace = *rule.AllowTrace
-		}
-		jwtImports[i] = &jwtImport
+func mergeImports(importAccountID string, existing jwt.Imports, imports nauth.Imports) (jwt.Imports, error) {
+	jwtImports := make(jwt.Imports, len(imports))
+	for i, imp := range imports {
+		jwtImports[i] = toJWTImport(*imp)
 	}
-	result, err := mergeImports(importAccountID, existing, jwtImports)
+	result, err := mergeJWTImports(importAccountID, existing, jwtImports)
 	if err != nil {
 		return existing, err
 	}
 	return result, nil
 }
 
-func mergeImports(importAccountID string, existing jwt.Imports, extras jwt.Imports) (jwt.Imports, error) {
+func toJWTImport(source nauth.Import) *jwt.Import {
+	return &jwt.Import{
+		Account:      string(source.AccountID),
+		Name:         source.Name,
+		Subject:      jwt.Subject(source.Subject),
+		Type:         toJWTExportType(source.Type),
+		LocalSubject: jwt.RenamingSubject(source.LocalSubject),
+		Share:        source.Share,
+		AllowTrace:   source.AllowTrace,
+	}
+}
+
+func toNAuthImport(source jwt.Import) *nauth.Import {
+	return &nauth.Import{
+		AccountID:    nauth.AccountID(source.Account),
+		Name:         source.Name,
+		Subject:      nauth.Subject(source.Subject),
+		Type:         toNAuthExportType(source.Type),
+		LocalSubject: nauth.Subject(source.LocalSubject),
+		Share:        source.Share,
+		AllowTrace:   source.AllowTrace,
+	}
+}
+
+func mergeJWTImports(importAccountID string, existing jwt.Imports, extras jwt.Imports) (jwt.Imports, error) {
 	tmpResult := existing
 	appendIfMissing := func(haystack jwt.Imports, needle jwt.Import) jwt.Imports {
 		for _, e := range haystack {
@@ -476,7 +450,7 @@ func mergeImports(importAccountID string, existing jwt.Imports, extras jwt.Impor
 	return tmpResult, nil
 }
 
-func toJWTExportType(source v1alpha1.ExportType) jwt.ExportType {
+func toJWTExportTypeFromAPI(source v1alpha1.ExportType) jwt.ExportType {
 	var result jwt.ExportType
 	switch source {
 	case v1alpha1.Stream:
@@ -487,6 +461,28 @@ func toJWTExportType(source v1alpha1.ExportType) jwt.ExportType {
 		result = jwt.Stream
 	}
 	return result
+}
+
+func toJWTExportType(source nauth.ExportType) jwt.ExportType {
+	switch source {
+	case nauth.ExportTypeService:
+		return jwt.Service
+	case nauth.ExportTypeStream:
+		return jwt.Stream
+	default:
+		return jwt.Stream
+	}
+}
+
+func toNAuthExportType(source jwt.ExportType) nauth.ExportType {
+	switch source {
+	case jwt.Service:
+		return nauth.ExportTypeService
+	case jwt.Stream:
+		return nauth.ExportTypeStream
+	default:
+		return nauth.ExportTypeUnknown
+	}
 }
 
 func toJWTServiceLatency(source v1alpha1.ServiceLatency) *jwt.ServiceLatency {

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -46,7 +46,7 @@ func (b *accountClaimsBuilder) displayName(name string) *accountClaimsBuilder {
 	return b
 }
 
-func (b *accountClaimsBuilder) accountLimits(limits *v1alpha1.AccountLimits) *accountClaimsBuilder {
+func (b *accountClaimsBuilder) accountLimits(limits *nauth.AccountLimits) *accountClaimsBuilder {
 	if limits != nil {
 		if limits.Imports != nil {
 			b.claim.Limits.Imports = *limits.Imports
@@ -67,7 +67,7 @@ func (b *accountClaimsBuilder) accountLimits(limits *v1alpha1.AccountLimits) *ac
 	return b
 }
 
-func (b *accountClaimsBuilder) natsLimits(limits *v1alpha1.NatsLimits) *accountClaimsBuilder {
+func (b *accountClaimsBuilder) natsLimits(limits *nauth.NatsLimits) *accountClaimsBuilder {
 	if limits != nil {
 		if limits.Subs != nil {
 			b.claim.Limits.Subs = *limits.Subs
@@ -82,7 +82,7 @@ func (b *accountClaimsBuilder) natsLimits(limits *v1alpha1.NatsLimits) *accountC
 	return b
 }
 
-func (b *accountClaimsBuilder) jetStreamLimits(limits *v1alpha1.JetStreamLimits) *accountClaimsBuilder {
+func (b *accountClaimsBuilder) jetStreamLimits(limits *nauth.JetStreamLimits) *accountClaimsBuilder {
 	if limits != nil {
 		if limits.MemoryStorage != nil {
 			b.claim.Limits.MemoryStorage = *limits.MemoryStorage
@@ -254,7 +254,7 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 		source := claims.Limits.AccountLimits
 		if !source.IsUnlimited() {
 			defaults := claimsDefaults.Limits.AccountLimits
-			out.AccountLimits = &v1alpha1.AccountLimits{}
+			out.AccountLimits = &nauth.AccountLimits{}
 			out.AccountLimits.Imports = toPtrDefNil(source.Imports, defaults.Imports)
 			out.AccountLimits.Exports = toPtrDefNil(source.Exports, defaults.Exports)
 			out.AccountLimits.WildcardExports = toPtrDefNil(source.WildcardExports, defaults.WildcardExports)
@@ -268,7 +268,7 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 		source := claims.Limits.NatsLimits
 		if !source.IsUnlimited() {
 			defaults := claimsDefaults.Limits.NatsLimits
-			out.NatsLimits = &v1alpha1.NatsLimits{}
+			out.NatsLimits = &nauth.NatsLimits{}
 			out.NatsLimits.Data = toPtrDefNil(source.Data, defaults.Data)
 			out.NatsLimits.Subs = toPtrDefNil(source.Subs, defaults.Subs)
 			out.NatsLimits.Payload = toPtrDefNil(source.Payload, defaults.Payload)
@@ -280,7 +280,7 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 		source := claims.Limits.JetStreamLimits
 		defaults := claimsDefaults.Limits.JetStreamLimits
 		if source != defaults {
-			out.JetStreamLimits = &v1alpha1.JetStreamLimits{}
+			out.JetStreamLimits = &nauth.JetStreamLimits{}
 			out.JetStreamLimits.MemoryStorage = toPtrDefNil(source.MemoryStorage, defaults.MemoryStorage)
 			out.JetStreamLimits.DiskStorage = toPtrDefNil(source.DiskStorage, defaults.DiskStorage)
 			out.JetStreamLimits.Streams = toPtrDefNil(source.Streams, defaults.Streams)

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -21,12 +21,10 @@ type accountClaimsBuilder struct {
 }
 
 func newAccountClaimsBuilder(
-	displayName string,
 	accountPublicKey string,
 	jetStreamEnabled *bool,
 ) *accountClaimsBuilder {
 	claim := jwt.NewAccountClaims(accountPublicKey)
-	claim.Name = displayName
 	if jetStreamEnabled == nil || *jetStreamEnabled {
 		// TODO: [#245] Switch to opt-in (enabled != nil && enabled) once we are ready to release a breaking change
 		// Initialize claims with unlimited JetStream (to comply with current NAuth behaviour, later this will be due to explicit request)
@@ -41,6 +39,11 @@ func newAccountClaimsBuilder(
 		jetStreamRequested: jetStreamEnabled,
 		claim:              claim,
 	}
+}
+
+func (b *accountClaimsBuilder) displayName(name string) *accountClaimsBuilder {
+	b.claim.Name = name
+	return b
 }
 
 func (b *accountClaimsBuilder) accountLimits(limits *v1alpha1.AccountLimits) *accountClaimsBuilder {
@@ -131,16 +134,19 @@ func (b *accountClaimsBuilder) exports(exports v1alpha1.Exports) *accountClaimsB
 	return b
 }
 
-func (b *accountClaimsBuilder) imports(imports nauth.Imports) *accountClaimsBuilder {
-	for _, imp := range imports {
-		jwtImport := toJWTImport(*imp)
-		result, mergeErr := mergeJWTImports(b.claim.Subject, b.claim.Imports, jwt.Imports{jwtImport})
-		if mergeErr != nil {
-			b.errs = append(b.errs, fmt.Errorf("failed to add import %q: %w", imp.Name, mergeErr))
+func (b *accountClaimsBuilder) addImportGroup(group nauth.ImportGroup) error {
+	if len(group.Imports) == 0 {
+		return fmt.Errorf("import group %q has no imports", group.Name)
+	}
+	for _, i := range group.Imports {
+		jwtImport := toJWTImport(*i)
+		result, err := mergeJWTImports(b.claim.Subject, b.claim.Imports, jwt.Imports{jwtImport})
+		if err != nil {
+			return fmt.Errorf("failed to add import %q from group %q: %w", i.Name, group.Name, err)
 		}
 		b.claim.Imports = result
 	}
-	return b
+	return nil
 }
 
 func (b *accountClaimsBuilder) addExportRuleGroup(rules []v1alpha1.AccountExportRule) error {

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -230,7 +230,7 @@ func hashSignedAccountJWTClaims(accountJWT string) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func toPtrDefNil[V int64 | bool](value V, defaultValue V) *V {
+func toPointerDefaultNil[V int64 | bool](value V, defaultValue V) *V {
 	if value != defaultValue {
 		return &value
 	}
@@ -255,11 +255,11 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 		if !source.IsUnlimited() {
 			defaults := claimsDefaults.Limits.AccountLimits
 			out.AccountLimits = &nauth.AccountLimits{}
-			out.AccountLimits.Imports = toPtrDefNil(source.Imports, defaults.Imports)
-			out.AccountLimits.Exports = toPtrDefNil(source.Exports, defaults.Exports)
-			out.AccountLimits.WildcardExports = toPtrDefNil(source.WildcardExports, defaults.WildcardExports)
-			out.AccountLimits.Conn = toPtrDefNil(source.Conn, defaults.Conn)
-			out.AccountLimits.LeafNodeConn = toPtrDefNil(source.LeafNodeConn, defaults.LeafNodeConn)
+			out.AccountLimits.Imports = toPointerDefaultNil(source.Imports, defaults.Imports)
+			out.AccountLimits.Exports = toPointerDefaultNil(source.Exports, defaults.Exports)
+			out.AccountLimits.WildcardExports = toPointerDefaultNil(source.WildcardExports, defaults.WildcardExports)
+			out.AccountLimits.Conn = toPointerDefaultNil(source.Conn, defaults.Conn)
+			out.AccountLimits.LeafNodeConn = toPointerDefaultNil(source.LeafNodeConn, defaults.LeafNodeConn)
 		}
 	}
 
@@ -269,9 +269,9 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 		if !source.IsUnlimited() {
 			defaults := claimsDefaults.Limits.NatsLimits
 			out.NatsLimits = &nauth.NatsLimits{}
-			out.NatsLimits.Data = toPtrDefNil(source.Data, defaults.Data)
-			out.NatsLimits.Subs = toPtrDefNil(source.Subs, defaults.Subs)
-			out.NatsLimits.Payload = toPtrDefNil(source.Payload, defaults.Payload)
+			out.NatsLimits.Data = toPointerDefaultNil(source.Data, defaults.Data)
+			out.NatsLimits.Subs = toPointerDefaultNil(source.Subs, defaults.Subs)
+			out.NatsLimits.Payload = toPointerDefaultNil(source.Payload, defaults.Payload)
 		}
 	}
 
@@ -281,14 +281,14 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 		defaults := claimsDefaults.Limits.JetStreamLimits
 		if source != defaults {
 			out.JetStreamLimits = &nauth.JetStreamLimits{}
-			out.JetStreamLimits.MemoryStorage = toPtrDefNil(source.MemoryStorage, defaults.MemoryStorage)
-			out.JetStreamLimits.DiskStorage = toPtrDefNil(source.DiskStorage, defaults.DiskStorage)
-			out.JetStreamLimits.Streams = toPtrDefNil(source.Streams, defaults.Streams)
-			out.JetStreamLimits.Consumer = toPtrDefNil(source.Consumer, defaults.Consumer)
-			out.JetStreamLimits.MaxAckPending = toPtrDefNil(source.MaxAckPending, defaults.MaxAckPending)
-			out.JetStreamLimits.MemoryMaxStreamBytes = toPtrDefNil(source.MemoryMaxStreamBytes, defaults.MemoryMaxStreamBytes)
-			out.JetStreamLimits.DiskMaxStreamBytes = toPtrDefNil(source.DiskMaxStreamBytes, defaults.DiskMaxStreamBytes)
-			out.JetStreamLimits.MaxBytesRequired = toPtrDefNil(source.MaxBytesRequired, defaults.MaxBytesRequired)
+			out.JetStreamLimits.MemoryStorage = toPointerDefaultNil(source.MemoryStorage, defaults.MemoryStorage)
+			out.JetStreamLimits.DiskStorage = toPointerDefaultNil(source.DiskStorage, defaults.DiskStorage)
+			out.JetStreamLimits.Streams = toPointerDefaultNil(source.Streams, defaults.Streams)
+			out.JetStreamLimits.Consumer = toPointerDefaultNil(source.Consumer, defaults.Consumer)
+			out.JetStreamLimits.MaxAckPending = toPointerDefaultNil(source.MaxAckPending, defaults.MaxAckPending)
+			out.JetStreamLimits.MemoryMaxStreamBytes = toPointerDefaultNil(source.MemoryMaxStreamBytes, defaults.MemoryMaxStreamBytes)
+			out.JetStreamLimits.DiskMaxStreamBytes = toPointerDefaultNil(source.DiskMaxStreamBytes, defaults.DiskMaxStreamBytes)
+			out.JetStreamLimits.MaxBytesRequired = toPointerDefaultNil(source.MaxBytesRequired, defaults.MaxBytesRequired)
 		}
 	}
 

--- a/internal/core/account_claims_test.go
+++ b/internal/core/account_claims_test.go
@@ -26,12 +26,12 @@ const (
 )
 
 type TestAccountClaimsSpec struct {
-	AccountLimits    *v1alpha1.AccountLimits   `json:"accountLimits,omitempty"`   // TODO: Migrate to nauth.AccountLimits
-	JetStreamLimits  *v1alpha1.JetStreamLimits `json:"jetStreamLimits,omitempty"` // TODO: Migrate to nauth.JetStreamLimits
-	JetStreamEnabled *bool                     `json:"jetStreamEnabled,omitempty"`
-	NatsLimits       *v1alpha1.NatsLimits      `json:"natsLimits,omitempty"` // TODO: Migrate to nauth.NatsLimits
-	Exports          v1alpha1.Exports          `json:"exports,omitempty"`    // TODO: Migrate to nauth.Exports
-	Imports          nauth.Imports             `json:"imports,omitempty"`
+	AccountLimits    *nauth.AccountLimits   `json:"accountLimits,omitempty"`
+	JetStreamLimits  *nauth.JetStreamLimits `json:"jetStreamLimits,omitempty"`
+	JetStreamEnabled *bool                  `json:"jetStreamEnabled,omitempty"`
+	NatsLimits       *nauth.NatsLimits      `json:"natsLimits,omitempty"`
+	Exports          v1alpha1.Exports       `json:"exports,omitempty"` // TODO: Migrate to nauth.Exports
+	Imports          nauth.Imports          `json:"imports,omitempty"`
 }
 
 func Test_AccountClaims(t *testing.T) {
@@ -212,7 +212,7 @@ func Test_AccountClaims_builder_ShouldReturnErrorWhenJetStreamEnablementConflict
 	boolTrue := true
 
 	builder := newAccountClaimsBuilder("ACCID", &boolTrue).
-		jetStreamLimits(&v1alpha1.JetStreamLimits{DiskStorage: &zero, MemoryStorage: &zero})
+		jetStreamLimits(&nauth.JetStreamLimits{DiskStorage: &zero, MemoryStorage: &zero})
 
 	// When
 	claims, err := builder.build()

--- a/internal/core/account_claims_test.go
+++ b/internal/core/account_claims_test.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	approvals "github.com/approvals/go-approval-tests"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
@@ -20,12 +19,20 @@ import (
 
 const (
 	testClaimsDisplayName   = "test-namespace/test-account"
-	testClaimsFakeAccountID = "A000000000000000000000000000000000000000000000000000FAKE"
 	testClaimsOperatorSeed  = "SOAF43LTJSU54DLV5VPWKF2ROVF2V6FZZG662Z2CCHDAFKCK5JGLQRP7SA"
 	testClaimsAccountPubKey = "AAJCK7774DXTQZAFJLSQIVU76UHGXFZNJVWMT4F7PNRBCYM75LS75UYE"
 	testClaimsSigningKey01  = "ACI73NE4LXWVHSYSFXY73WTZVKIKE54PQUMRDYA4EUFYFGEGHKTPCOI4"
 	testClaimsSigningKey02  = "ADCECGT44IBBMSNGOEZTVK2QUQSVTJW6FABW7JBFFTITDBHMP6TXM4XG"
 )
+
+type TestAccountClaimsSpec struct {
+	AccountLimits    *v1alpha1.AccountLimits   `json:"accountLimits,omitempty"`   // TODO: Migrate to nauth.AccountLimits
+	JetStreamLimits  *v1alpha1.JetStreamLimits `json:"jetStreamLimits,omitempty"` // TODO: Migrate to nauth.JetStreamLimits
+	JetStreamEnabled *bool                     `json:"jetStreamEnabled,omitempty"`
+	NatsLimits       *v1alpha1.NatsLimits      `json:"natsLimits,omitempty"` // TODO: Migrate to nauth.NatsLimits
+	Exports          v1alpha1.Exports          `json:"exports,omitempty"`    // TODO: Migrate to nauth.Exports
+	Imports          nauth.Imports             `json:"imports,omitempty"`
+}
 
 func Test_AccountClaims(t *testing.T) {
 
@@ -36,26 +43,23 @@ func Test_AccountClaims(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
-			spec, err := loadAccountSpec(testCase.InputFile)
+			spec, err := loadTestAccountClaimsSpec(testCase.InputFile)
 			require.NoError(t, err)
 
-			unitUnderTest := func(spec *v1alpha1.AccountSpec, resolveAccountID resolveAccountIDFn) (*jwt.AccountClaims, error) {
+			unitUnderTest := func(spec *TestAccountClaimsSpec) (*jwt.AccountClaims, error) {
 				builder := newAccountClaimsBuilder(testClaimsDisplayName, testClaimsAccountPubKey, spec.JetStreamEnabled).
 					accountLimits(spec.AccountLimits).
 					jetStreamLimits(spec.JetStreamLimits).
 					natsLimits(spec.NatsLimits).
 					exports(spec.Exports).
-					imports(spec.Imports, resolveAccountID)
+					imports(spec.Imports)
 				builder.signingKey(testClaimsSigningKey01)
 				builder.signingKey(testClaimsSigningKey02)
 				return builder.build()
 			}
 
 			// Build NATS JWT AccountClaims from AccountSpec
-			natsClaims, err := unitUnderTest(spec, func(accountRef domain.NamespacedName) (accountID string, err error) {
-				accountID = fakeAccountId(accountRef)
-				return
-			})
+			natsClaims, err := unitUnderTest(spec)
 			require.NoError(t, err)
 			require.NotNil(t, natsClaims)
 			// Ensure that the NATS JWT can be encoded
@@ -80,7 +84,7 @@ func Test_AccountClaims(t *testing.T) {
 			// Finally; rebuild the claims from the output to verify round-trip integrity
 
 			// Verify that the resulting NAuth AccountClaim generates the same NATS JWT when encoded
-			rebuiltNatsClaims := &v1alpha1.AccountSpec{
+			rebuiltNatsClaims := &TestAccountClaimsSpec{
 				JetStreamEnabled: nauthClaims.JetStreamEnabled,
 				AccountLimits:    nauthClaims.AccountLimits,
 				JetStreamLimits:  nauthClaims.JetStreamLimits,
@@ -88,13 +92,7 @@ func Test_AccountClaims(t *testing.T) {
 				Exports:          nauthClaims.Exports,
 				Imports:          nauthClaims.Imports,
 			}
-			accountIDX := 0
-			natsClaimsRebuilt, err := unitUnderTest(rebuiltNatsClaims, func(accountRef domain.NamespacedName) (accountID string, err error) {
-				// For the rebuild, override the mock to always return the fake account ID (account ref is lost)
-				accountIDX++
-				accountID = fakeAccountIdIdx(accountIDX)
-				return
-			})
+			natsClaimsRebuilt, err := unitUnderTest(rebuiltNatsClaims)
 			require.NoError(t, err)
 			require.NotNil(t, natsClaimsRebuilt)
 			// Sign the JWT to ensure matching issuer details
@@ -102,9 +100,6 @@ func Test_AccountClaims(t *testing.T) {
 			require.NoError(t, err)
 
 			normalizedNatsClaimsRebuilt := normalizeClaimsForApproval(natsClaimsRebuilt)
-			// The rebuilt claims will have fake account ID for imports, normalize for equality check
-			overrideImportAccountIDs(normalizedNatsClaimsRebuilt, testClaimsFakeAccountID)
-			overrideImportAccountIDs(normalizedNatsClaims, testClaimsFakeAccountID)
 			assert.Equal(t, normalizedNatsClaims, normalizedNatsClaimsRebuilt)
 		})
 	}
@@ -146,14 +141,14 @@ func Test_AccountClaims_addExportRuleGroup_ShouldNotAlterExistingRulesOnConflict
 
 func Test_AccountClaims_convertNatsAccountClaims_ShouldSucceed_WhenMinimal(t *testing.T) {
 	// Given
-	claims := jwt.NewAccountClaims(testClaimsFakeAccountID)
+	claims := jwt.NewAccountClaims("ACCID")
 
 	// When
 	result := convertNatsAccountClaims(claims)
 
 	// Then
 	boolFalse := false
-	require.Equal(t, v1alpha1.AccountClaims{
+	require.Equal(t, nauth.AccountClaims{
 		JetStreamEnabled: &boolFalse,
 	}, result)
 }
@@ -314,21 +309,13 @@ func Test_validateJetStreamLimits(t *testing.T) {
 	}
 }
 
-func fakeAccountId(accountRef domain.NamespacedName) string {
-	return fmt.Sprintf("A%055s", strings.ToUpper(strings.ReplaceAll(accountRef.Name+accountRef.Namespace, "-", "")))
-}
-
-func fakeAccountIdIdx(idx int) string {
-	return fmt.Sprintf("A%055d", idx)
-}
-
-func loadAccountSpec(filePath string) (*v1alpha1.AccountSpec, error) {
+func loadTestAccountClaimsSpec(filePath string) (*TestAccountClaimsSpec, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	var spec v1alpha1.AccountSpec
+	var spec TestAccountClaimsSpec
 	if err := yaml.UnmarshalStrict(data, &spec); err != nil {
 		return nil, err
 	}
@@ -346,10 +333,4 @@ func normalizeClaimsForApproval(claims *jwt.AccountClaims) *jwt.AccountClaims {
 	result.IssuedAt = int64(1700000000)
 	result.ID = "TEST-JWT-ID-STATIC-FOR-APPROVAL-TESTS"
 	return result
-}
-
-func overrideImportAccountIDs(claims *jwt.AccountClaims, overrideAccount string) {
-	for _, importClaim := range claims.Imports {
-		importClaim.Account = overrideAccount
-	}
 }

--- a/internal/core/account_claims_test.go
+++ b/internal/core/account_claims_test.go
@@ -47,12 +47,19 @@ func Test_AccountClaims(t *testing.T) {
 			require.NoError(t, err)
 
 			unitUnderTest := func(spec *TestAccountClaimsSpec) (*jwt.AccountClaims, error) {
-				builder := newAccountClaimsBuilder(testClaimsDisplayName, testClaimsAccountPubKey, spec.JetStreamEnabled).
+				builder := newAccountClaimsBuilder(testClaimsAccountPubKey, spec.JetStreamEnabled).
+					displayName(testClaimsDisplayName).
 					accountLimits(spec.AccountLimits).
 					jetStreamLimits(spec.JetStreamLimits).
 					natsLimits(spec.NatsLimits).
-					exports(spec.Exports).
-					imports(spec.Imports)
+					exports(spec.Exports)
+				if len(spec.Imports) > 0 {
+					inlineImportGroup := nauth.ImportGroup{
+						Name:    GroupNameInline,
+						Imports: spec.Imports,
+					}
+					require.NoError(t, builder.addImportGroup(inlineImportGroup))
+				}
 				builder.signingKey(testClaimsSigningKey01)
 				builder.signingKey(testClaimsSigningKey02)
 				return builder.build()
@@ -107,7 +114,7 @@ func Test_AccountClaims(t *testing.T) {
 
 func Test_AccountClaims_addExportRuleGroup_ShouldNotAlterExistingRulesOnConflict(t *testing.T) {
 	// Given
-	builder := newAccountClaimsBuilder(testClaimsDisplayName, testClaimsAccountPubKey, nil).
+	builder := newAccountClaimsBuilder(testClaimsAccountPubKey, nil).
 		exports(v1alpha1.Exports{
 			{
 				Subject: "foo.>",
@@ -204,7 +211,7 @@ func Test_AccountClaims_builder_ShouldReturnErrorWhenJetStreamEnablementConflict
 	var zero int64 = 0
 	boolTrue := true
 
-	builder := newAccountClaimsBuilder("my-claims", "ACCID", &boolTrue).
+	builder := newAccountClaimsBuilder("ACCID", &boolTrue).
 		jetStreamLimits(&v1alpha1.JetStreamLimits{DiskStorage: &zero, MemoryStorage: &zero})
 
 	// When

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -641,8 +641,8 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountClaimsAreInv
 
 	// Then
 	t.Nil(result)
-	t.ErrorContains(err, "failed to build NATS account claims")
-	t.ErrorContains(err, "failed to add import \"import-twice\":")
+	t.ErrorContains(err, "failed to add inline imports")
+	t.ErrorContains(err, "failed to add import \"import-twice\"")
 }
 
 func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {
@@ -654,7 +654,7 @@ func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {
 	accountSignKeyPublic, _ := accountSignKey.PublicKey()
 
 	existingNatsLimitsSubs := int64(100)
-	existingClaims, err := newAccountClaimsBuilder("Existing Account", accountID, nil).
+	existingClaims, err := newAccountClaimsBuilder(accountID, nil).
 		natsLimits(&v1alpha1.NatsLimits{Subs: &existingNatsLimitsSubs}).
 		signingKey(accountSignKeyPublic).
 		build()

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	approvals "github.com/approvals/go-approval-tests"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
@@ -655,7 +656,7 @@ func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {
 
 	existingNatsLimitsSubs := int64(100)
 	existingClaims, err := newAccountClaimsBuilder(accountID, nil).
-		natsLimits(&v1alpha1.NatsLimits{Subs: &existingNatsLimitsSubs}).
+		natsLimits(&nauth.NatsLimits{Subs: &existingNatsLimitsSubs}).
 		signingKey(accountSignKeyPublic).
 		build()
 	t.NoError(err, "failed to build existing account claims")

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports-multi-js-fc.input.yaml
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports-multi-js-fc.input.yaml
@@ -1,13 +1,9 @@
 imports:
   - name: account-a-fc
-    accountRef:
-      namespace: my-namespace
-      name: account-a
+    accountID: ACCA
     subject: $JS.FC.>
     type: service
   - name: account-b-fc
-    accountRef:
-      namespace: my-namespace
-      name: account-b
+    accountID: ACCB
     subject: $JS.FC.>
     type: service

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports-multi-js-fc.output.nats.approved.json
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports-multi-js-fc.output.nats.approved.json
@@ -9,13 +9,13 @@
       {
         "name": "account-a-fc",
         "subject": "$JS.FC.\u003e",
-        "account": "A000000000000000000000000000000000000ACCOUNTAMYNAMESPACE",
+        "account": "ACCA",
         "type": "service"
       },
       {
         "name": "account-b-fc",
         "subject": "$JS.FC.\u003e",
-        "account": "A000000000000000000000000000000000000ACCOUNTBMYNAMESPACE",
+        "account": "ACCB",
         "type": "service"
       }
     ],

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports-multi-js-fc.output.nauth.approved.yaml
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports-multi-js-fc.output.nauth.approved.yaml
@@ -1,16 +1,10 @@
 displayName: test-namespace/test-account
 imports:
-- account: A000000000000000000000000000000000000ACCOUNTAMYNAMESPACE
-  accountRef:
-    name: ""
-    namespace: ""
+- accountId: ACCA
   name: account-a-fc
   subject: $JS.FC.>
   type: service
-- account: A000000000000000000000000000000000000ACCOUNTBMYNAMESPACE
-  accountRef:
-    name: ""
-    namespace: ""
+- accountId: ACCB
   name: account-b-fc
   subject: $JS.FC.>
   type: service

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.input.yaml
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.input.yaml
@@ -1,30 +1,22 @@
 imports:
   - name: my-stream-import
-    accountRef:
-      namespace: my-namespace
-      name: stream-account
+    accountID: ACCA
     subject: foo.stream.>
     localSubject: imported.foo.stream.>
     type: stream
   - name: my-service-import
-    accountRef:
-      namespace: my-namespace
-      name: service-account
+    accountID: ACCB
     subject: foo.service.>
     localSubject: imported.foo.service.>
     type: service
   - name: my-max-stream
-    accountRef:
-      namespace: my-namespace
-      name: complex-account
+    accountID: ACCC
     subject: max.stream.>
     localSubject: imported.max.stream.>
     type: stream
     allowTrace: true
   - name: my-max-service
-    accountRef:
-      namespace: my-namespace
-      name: complex-account
+    accountID: ACCD
     subject: max.service.>
     localSubject: imported.max.service.>
     type: service

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nats.approved.json
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nats.approved.json
@@ -9,21 +9,21 @@
       {
         "name": "my-service-import",
         "subject": "foo.service.\u003e",
-        "account": "A000000000000000000000000000000SERVICEACCOUNTMYNAMESPACE",
+        "account": "ACCB",
         "local_subject": "imported.foo.service.\u003e",
         "type": "service"
       },
       {
         "name": "my-stream-import",
         "subject": "foo.stream.\u003e",
-        "account": "A0000000000000000000000000000000STREAMACCOUNTMYNAMESPACE",
+        "account": "ACCA",
         "local_subject": "imported.foo.stream.\u003e",
         "type": "stream"
       },
       {
         "name": "my-max-service",
         "subject": "max.service.\u003e",
-        "account": "A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE",
+        "account": "ACCD",
         "local_subject": "imported.max.service.\u003e",
         "type": "service",
         "share": true
@@ -31,7 +31,7 @@
       {
         "name": "my-max-stream",
         "subject": "max.stream.\u003e",
-        "account": "A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE",
+        "account": "ACCC",
         "local_subject": "imported.max.stream.\u003e",
         "type": "stream",
         "allow_trace": true

--- a/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nauth.approved.yaml
+++ b/internal/core/approvals/account_claims_test.Test_AccountClaims.imports.output.nauth.approved.yaml
@@ -1,34 +1,22 @@
 displayName: test-namespace/test-account
 imports:
-- account: A000000000000000000000000000000SERVICEACCOUNTMYNAMESPACE
-  accountRef:
-    name: ""
-    namespace: ""
+- accountId: ACCB
   localSubject: imported.foo.service.>
   name: my-service-import
   subject: foo.service.>
   type: service
-- account: A0000000000000000000000000000000STREAMACCOUNTMYNAMESPACE
-  accountRef:
-    name: ""
-    namespace: ""
+- accountId: ACCA
   localSubject: imported.foo.stream.>
   name: my-stream-import
   subject: foo.stream.>
   type: stream
-- account: A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE
-  accountRef:
-    name: ""
-    namespace: ""
+- accountId: ACCD
   localSubject: imported.max.service.>
   name: my-max-service
   share: true
   subject: max.service.>
   type: service
-- account: A000000000000000000000000000000COMPLEXACCOUNTMYNAMESPACE
-  accountRef:
-    name: ""
-    namespace: ""
+- accountId: ACCC
   allowTrace: true
   localSubject: imported.max.stream.>
   name: my-max-stream

--- a/internal/domain/nauth.go
+++ b/internal/domain/nauth.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 )
 
 type AccountResources struct {
@@ -12,7 +13,7 @@ type AccountResources struct {
 type AccountResult struct {
 	AccountID       string
 	AccountSignedBy string
-	Claims          *v1alpha1.AccountClaims
+	Claims          *nauth.AccountClaims
 	ClaimsHash      string
 	Adoptions       *v1alpha1.AccountAdoptions
 }

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -13,6 +13,11 @@ const (
 	ExportTypeService ExportType = "service"
 )
 
+type ImportGroup struct {
+	Name    string  `json:"name,omitempty"`
+	Imports Imports `json:"imports,omitempty"`
+}
+
 type Imports []*Import
 
 type Import struct {

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -1,0 +1,38 @@
+package nauth
+
+import "github.com/WirelessCar/nauth/api/v1alpha1"
+
+type AccountID string
+type Subject string
+
+type ExportType string
+
+const (
+	ExportTypeUnknown ExportType = "unknown"
+	ExportTypeStream  ExportType = "stream"
+	ExportTypeService ExportType = "service"
+)
+
+type Imports []*Import
+
+type Import struct {
+	AccountID    AccountID  `json:"accountId,omitempty"`
+	Name         string     `json:"name,omitempty"`
+	Subject      Subject    `json:"subject,omitempty"`
+	LocalSubject Subject    `json:"localSubject,omitempty"`
+	Type         ExportType `json:"type,omitempty"`
+	Share        bool       `json:"share,omitempty"`
+	AllowTrace   bool       `json:"allowTrace,omitempty"`
+}
+
+type AccountClaims struct {
+	AccountID        AccountID                 `json:"accountId,omitempty"`
+	DisplayName      string                    `json:"displayName,omitempty"`
+	AccountLimits    *v1alpha1.AccountLimits   `json:"accountLimits,omitempty"` // TODO: Migrate to domain AccountLimits
+	JetStreamEnabled *bool                     `json:"jetStreamEnabled,omitempty"`
+	JetStreamLimits  *v1alpha1.JetStreamLimits `json:"jetStreamLimits,omitempty"` // TODO: Migrate to domain JetStreamLimits
+	NatsLimits       *v1alpha1.NatsLimits      `json:"natsLimits,omitempty"`      // TODO: Migrate to domain NatsLimits
+	SigningKeys      v1alpha1.SigningKeys `json:"signingKeys,omitempty"` // TODO: Migrate to domain SigningKeys
+	Exports          v1alpha1.Exports     `json:"exports,omitempty"`     // TODO: Migrate to domain Exports
+	Imports          Imports              `json:"imports,omitempty"`
+}

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -13,6 +13,32 @@ const (
 	ExportTypeService ExportType = "service"
 )
 
+type AccountLimits struct {
+	Imports         *int64 `json:"imports,omitempty"`
+	Exports         *int64 `json:"exports,omitempty"`
+	WildcardExports *bool  `json:"wildcards,omitempty"`
+	DisallowBearer  *bool  `json:"disallow_bearer,omitempty"`
+	Conn            *int64 `json:"conn,omitempty"`
+	LeafNodeConn    *int64 `json:"leaf,omitempty"`
+}
+
+type JetStreamLimits struct {
+	MemoryStorage        *int64 `json:"memStorage,omitempty"`
+	DiskStorage          *int64 `json:"diskStorage,omitempty"`
+	Streams              *int64 `json:"streams,omitempty"`
+	Consumer             *int64 `json:"consumer,omitempty"`
+	MaxAckPending        *int64 `json:"maxAckPending,omitempty"`
+	MemoryMaxStreamBytes *int64 `json:"memMaxStreamBytes,omitempty"`
+	DiskMaxStreamBytes   *int64 `json:"diskMaxStreamBytes,omitempty"`
+	MaxBytesRequired     *bool  `json:"maxBytesRequired,omitempty"`
+}
+
+type NatsLimits struct {
+	Subs    *int64 `json:"subs,omitempty"`
+	Data    *int64 `json:"data,omitempty"`
+	Payload *int64 `json:"payload,omitempty"`
+}
+
 type ImportGroup struct {
 	Name    string  `json:"name,omitempty"`
 	Imports Imports `json:"imports,omitempty"`
@@ -31,12 +57,12 @@ type Import struct {
 }
 
 type AccountClaims struct {
-	AccountID        AccountID                 `json:"accountId,omitempty"`
-	DisplayName      string                    `json:"displayName,omitempty"`
-	AccountLimits    *v1alpha1.AccountLimits   `json:"accountLimits,omitempty"` // TODO: Migrate to domain AccountLimits
-	JetStreamEnabled *bool                     `json:"jetStreamEnabled,omitempty"`
-	JetStreamLimits  *v1alpha1.JetStreamLimits `json:"jetStreamLimits,omitempty"` // TODO: Migrate to domain JetStreamLimits
-	NatsLimits       *v1alpha1.NatsLimits      `json:"natsLimits,omitempty"`      // TODO: Migrate to domain NatsLimits
+	AccountID        AccountID            `json:"accountId,omitempty"`
+	DisplayName      string               `json:"displayName,omitempty"`
+	AccountLimits    *AccountLimits       `json:"accountLimits,omitempty"`
+	JetStreamEnabled *bool                `json:"jetStreamEnabled,omitempty"`
+	JetStreamLimits  *JetStreamLimits     `json:"jetStreamLimits,omitempty"`
+	NatsLimits       *NatsLimits          `json:"natsLimits,omitempty"`
 	SigningKeys      v1alpha1.SigningKeys `json:"signingKeys,omitempty"` // TODO: Migrate to domain SigningKeys
 	Exports          v1alpha1.Exports     `json:"exports,omitempty"`     // TODO: Migrate to domain Exports
 	Imports          Imports              `json:"imports,omitempty"`

--- a/internal/ports/inbound/nauth.go
+++ b/internal/ports/inbound/nauth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 )
 
 type AccountManager interface {
@@ -18,7 +19,7 @@ type AccountExportManager interface {
 }
 
 type AccountImportManager interface {
-	ValidateImportRules(importAccountID string, rules []v1alpha1.AccountImportRuleDerived) error
+	ValidateImports(importAccountID nauth.AccountID, imports nauth.Imports) error
 }
 
 type UserManager interface {


### PR DESCRIPTION
## Summary

Introduces NAuth domain types for account claims and import handling, then moves core claim-building toward that domain model.

## What changed

- Added domain types for account claims, imports, import groups, account IDs, subjects, export types, and limits
- Treats Account CRD inline imports as a named `inline` import group
- Moves import validation to `nauth.Imports`
- Adds API/domain conversion at controller and core boundaries
- Updates tests and approval snapshots for the new domain flow

## How to validate

Not run locally.

### Commits in this PR

- `c37a3a7` refactor(core): move limits into nauth domain model
- `245e7d3` refactor(core): model inline imports as an import group
- `c3accae` feat: introduce domain model for imports