### PR TITLE
refactor(core): move signing keys into nauth domain model

### DIFF
--- a/internal/adapter/inbound/controller/account_converter.go
+++ b/internal/adapter/inbound/controller/account_converter.go
@@ -147,7 +147,7 @@ func toAPIAccountClaims(claims *nauth.AccountClaims) *v1alpha1.AccountClaims {
 	return &v1alpha1.AccountClaims{
 		AccountLimits:    toAPIAccountLimits(claims.AccountLimits),
 		DisplayName:      claims.DisplayName,
-		SigningKeys:      claims.SigningKeys,
+		SigningKeys:      toAPISigningKeys(claims.SigningKeys),
 		Exports:          toAPIExports(claims.Exports),
 		Imports:          toAPIImports(claims.Imports),
 		JetStreamEnabled: claims.JetStreamEnabled,
@@ -197,6 +197,17 @@ func toAPINatsLimits(source *nauth.NatsLimits) *v1alpha1.NatsLimits {
 		Data:    source.Data,
 		Payload: source.Payload,
 	}
+}
+
+func toAPISigningKeys(keys nauth.SigningKeys) v1alpha1.SigningKeys {
+	result := make(v1alpha1.SigningKeys, len(keys))
+	for i, key := range keys {
+		result[i] = &v1alpha1.SigningKey{
+			Key: key.Key,
+			// TODO: [#140] map Signing Key scope
+		}
+	}
+	return result
 }
 
 func toAPIImports(imports nauth.Imports) v1alpha1.Imports {

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/nats-io/jwt/v2"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -241,15 +240,15 @@ func convertNatsAccountClaims(claims *jwt.AccountClaims) nauth.AccountClaims {
 
 	// Signing Keys
 	if len(claims.SigningKeys) > 0 {
-		signingKeys := make(v1alpha1.SigningKeys, 0, len(claims.SigningKeys))
+		signingKeys := make(nauth.SigningKeys, 0, len(claims.SigningKeys))
 		for key := range claims.SigningKeys {
-			signingKey := v1alpha1.SigningKey{
+			signingKey := nauth.SigningKey{
 				Key: key,
+				// TODO: [#140] Map scope
 			}
 			signingKeys = append(signingKeys, &signingKey)
-			// TODO: [https://github.com/WirelessCar/nauth/issues/140] Populate optional *UserScope
 		}
-		// Sort by key to ensure predictable, and human searchable, order.
+		// Sort by key to ensure predictable, and human-searchable, order.
 		sort.Slice(signingKeys, func(i, j int) bool {
 			return signingKeys[i].Key < signingKeys[j].Key
 		})

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -157,10 +157,8 @@ func (r AdoptionResults) Get(ref Ref) *AdoptionResult {
 // AdoptionFailure must be TitleCased to comply with k8s metav1.StatusReason
 type AdoptionFailure string
 
-const ( // FIXME: Remove unused
-	AdoptionFailureNoDesiredClaim AdoptionFailure = "NoDesiredClaim"
-	AdoptionFailureConflict       AdoptionFailure = "Conflict"
-	AdoptionFailureInvalid        AdoptionFailure = "Invalid"
+const (
+	AdoptionFailureConflict AdoptionFailure = "Conflict"
 )
 
 type AdoptionResult struct {

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -3,13 +3,13 @@ package nauth
 import (
 	"fmt"
 	"time"
-
-	"github.com/WirelessCar/nauth/api/v1alpha1"
 )
 
 type Ref string
 
 type AccountID string
+
+type PublicKey string
 type Subject string
 
 type ExportType string
@@ -56,6 +56,13 @@ type NatsLimits struct {
 	Subs    *int64 `json:"subs,omitempty"`
 	Data    *int64 `json:"data,omitempty"`
 	Payload *int64 `json:"payload,omitempty"`
+}
+
+type SigningKeys []*SigningKey
+
+type SigningKey struct {
+	Key string `json:"key,omitempty"`
+	// TODO: [#140] Add signing key scope
 }
 
 type ImportGroup struct {
@@ -115,15 +122,15 @@ type ServiceLatency struct {
 }
 
 type AccountClaims struct {
-	AccountID        AccountID            `json:"accountId,omitempty"`
-	DisplayName      string               `json:"displayName,omitempty"`
-	AccountLimits    *AccountLimits       `json:"accountLimits,omitempty"`
-	JetStreamEnabled *bool                `json:"jetStreamEnabled,omitempty"`
-	JetStreamLimits  *JetStreamLimits     `json:"jetStreamLimits,omitempty"`
-	NatsLimits       *NatsLimits          `json:"natsLimits,omitempty"`
-	SigningKeys      v1alpha1.SigningKeys `json:"signingKeys,omitempty"` // TODO: Migrate to domain SigningKeys
-	Exports          Exports              `json:"exports,omitempty"`
-	Imports          Imports              `json:"imports,omitempty"`
+	AccountID        AccountID        `json:"accountId,omitempty"`
+	DisplayName      string           `json:"displayName,omitempty"`
+	AccountLimits    *AccountLimits   `json:"accountLimits,omitempty"`
+	JetStreamEnabled *bool            `json:"jetStreamEnabled,omitempty"`
+	JetStreamLimits  *JetStreamLimits `json:"jetStreamLimits,omitempty"`
+	NatsLimits       *NatsLimits      `json:"natsLimits,omitempty"`
+	SigningKeys      SigningKeys      `json:"signingKeys,omitempty"`
+	Exports          Exports          `json:"exports,omitempty"`
+	Imports          Imports          `json:"imports,omitempty"`
 }
 
 type AccountAdoptions struct {


### PR DESCRIPTION
## Summary

Moves signing keys into the NAuth domain model while keeping API-specific formatting at the controller boundary.

Refs #11
Refs #140

## What changed

- Added domain-level signing key types
- Converts NATS account claim signing keys into `nauth.SigningKeys`
- Converts domain signing keys back to Account CRD status claims in the controller
- Leaves scope mapping as explicit follow-up work for #140
