### PR TITLE
refactor(export): move account export resolution into the controller

### DIFF
--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -78,40 +78,157 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	account := &v1alpha1.Account{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: state.Namespace, Name: state.Spec.AccountName}, account); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Error(err, "Failed to read account", "accountName", state.Spec.AccountName)
-			// TODO: #11 return quick in case account fetch failed.
+	updateConditionFalse := func(condType string, reason string, msg string) {
+		meta.SetStatusCondition(state.GetConditions(), newCondition(condType, metav1.ConditionFalse, reason, msg))
+	}
+	updateConditionTrue := func(condType string) {
+		meta.SetStatusCondition(state.GetConditions(), newCondition(condType, metav1.ConditionTrue, conditionReasonOK, ""))
+	}
+
+	var rules nauth.ExportRules
+	for _, rule := range state.Spec.Rules {
+		rules = append(rules, mapToExportRule(rule))
+	}
+
+	err := r.manager.ValidateRules(ctx, rules)
+	if err != nil {
+		updateConditionFalse(conditionTypeValidRules, conditionReasonInvalid, err.Error())
+	} else {
+		updateConditionTrue(conditionTypeValidRules)
+		(&state.Status).DesiredClaim = &v1alpha1.AccountExportClaim{
+			Rules:              state.Spec.Rules,
+			ObservedGeneration: state.Generation,
 		}
 	}
 
-	resolution := r.manager.Resolve(ctx, state, account)
-	patchLabels, updateStatus := mapResolutionToStatus(resolution, state)
+	patchLabels := false
+
+	account := &v1alpha1.Account{}
+	accountErr := r.Get(ctx, types.NamespacedName{Namespace: state.Namespace, Name: state.Spec.AccountName}, account)
+	if accountErr != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to read account", "accountName", state.Spec.AccountName)
+			msg := fmt.Sprintf("failed to read account: %v", err)
+			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonFailed, msg)
+		} else {
+			// account not found
+			msg := "Account not found"
+			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonNotFound, msg)
+		}
+	} else {
+		// account binding
+		accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
+		state.Status.AccountID = accountID
+		existingLabel := state.GetLabel(v1alpha1.AccountExportLabelAccountID)
+
+		if existingLabel == "" && accountID != "" {
+			// bind
+			state.SetLabel(v1alpha1.AccountExportLabelAccountID, accountID)
+			patchLabels = true
+		} else if existingLabel != "" && existingLabel != accountID {
+			// conflict
+			msg := fmt.Sprintf("account export is already bound to account: %s", existingLabel)
+			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonConflict, msg)
+		} else {
+			// bound
+			updateConditionTrue(conditionTypeBoundToAccount)
+		}
+
+		adoption := findAdoptionByUID(account, state.UID)
+		if adoption == nil {
+			// adoption not found
+			updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonAdopting, "waiting for account to adopt export")
+		} else {
+			adoptionGen := adoption.Status.DesiredClaimObservedGeneration
+			sameGeneration := adoptionGen != nil && *adoptionGen == state.Generation
+			if adoption.Status.Status == metav1.ConditionTrue && sameGeneration {
+				updateConditionTrue(conditionTypeAdoptedByAccount)
+			} else {
+				if !sameGeneration {
+					msg := fmt.Sprintf("waiting for account to adopt generation %d", state.Generation)
+					updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonAdopting, msg)
+				} else {
+					msg := fmt.Sprintf("%s: %s", adoption.Status.Reason, adoption.Status.Message)
+					updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonFailed, msg)
+				}
+			}
+		}
+	}
+
+	// ready condition
+	if isAccountExportReady(state) {
+		updateConditionTrue(conditionTypeReady)
+	} else {
+		updateConditionFalse(conditionTypeReady, conditionReasonReconciling, "All conditions not met")
+	}
 
 	if patchLabels {
-		err := r.patchLabels(ctx, state)
+		err = r.patchLabels(ctx, state)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to patch labels: %w", err)
 		}
-		// TODO: #11 Can we patch without returning, and update status in same reconcile loop?
 		return ctrl.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
-	if updateStatus {
-		// TODO: #11 Can we safely implement the updateStatus flag, currently always true
-		// TODO: #11 This would make watches simpler (not needing to be so specific)
-		if updateErr := r.Status().Update(ctx, state); updateErr != nil {
-			log.Error(updateErr, "Failed to update status")
-			return ctrl.Result{}, updateErr
+	if updateErr := r.Status().Update(ctx, state); updateErr != nil {
+		log.Error(updateErr, "Failed to update status: %w", updateErr)
+		return ctrl.Result{}, updateErr
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func findAdoptionByUID(account *v1alpha1.Account, uid types.UID) *v1alpha1.AccountAdoption {
+	if account.Status.Adoptions == nil {
+		return nil
+	}
+
+	for _, adoption := range account.Status.Adoptions.Exports {
+		if adoption.UID == uid {
+			return &adoption
 		}
 	}
 
-	// TODO: #11 Remove logging when i/e feature is complete
-	if meta.IsStatusConditionTrue(state.Status.Conditions, conditionTypeReady) {
-		log.Info("AccountExport reconciliation Ready")
+	return nil
+}
+
+func mapToExportRule(rule v1alpha1.AccountExportRule) nauth.ExportRule {
+	result := nauth.ExportRule{
+		Name:              rule.Name,
+		Subject:           nauth.Subject(rule.Subject),
+		Type:              mapExportType(rule.Type),
+		ResponseType:      nauth.ResponseType(rule.ResponseType),
+		ResponseThreshold: rule.ResponseThreshold,
 	}
-	return ctrl.Result{}, nil
+
+	if rule.Latency != nil {
+		result.Latency = &nauth.ServiceLatency{
+			Sampling: nauth.SamplingRate(rule.Latency.Sampling),
+			Results:  nauth.Subject(rule.Latency.Results),
+		}
+	}
+	if rule.AccountTokenPosition != nil {
+		result.AccountTokenPosition = *rule.AccountTokenPosition
+	}
+	if rule.Advertise != nil {
+		result.Advertise = *rule.Advertise
+	}
+	if rule.AllowTrace != nil {
+		result.AllowTrace = *rule.AllowTrace
+	}
+
+	return result
+}
+
+func mapExportType(t v1alpha1.ExportType) nauth.ExportType {
+	switch t {
+	case v1alpha1.Service:
+		return nauth.ExportTypeService
+	case v1alpha1.Stream:
+		return nauth.ExportTypeStream
+	}
+
+	return nauth.ExportTypeUnknown
 }
 
 func (r *AccountExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -241,88 +358,6 @@ func (r *AccountExportReconciler) patchLabels(ctx context.Context, resource *v1a
 		return fmt.Errorf("failed to patch label: %w", err)
 	}
 	return nil
-}
-
-func mapResolutionToStatus(resolution *domain.AccountExportResolution, state *v1alpha1.AccountExport) (patchLabels bool, updateStatus bool) {
-	patchLabels = false
-	updateStatus = true
-	status := &state.Status
-
-	updateConditionFalse := func(condType string, reason string, msg string) {
-		meta.SetStatusCondition(&status.Conditions, newCondition(condType, metav1.ConditionFalse, reason, msg))
-	}
-	updateConditionTrue := func(condType string) {
-		meta.SetStatusCondition(&status.Conditions, newCondition(condType, metav1.ConditionTrue, conditionReasonOK, ""))
-	}
-
-	// rule validations
-	if resolution.ValidationError != nil {
-		updateConditionFalse(conditionTypeValidRules, conditionReasonInvalid, resolution.ValidationError.Error())
-	} else {
-		updateConditionTrue(conditionTypeValidRules)
-		status.DesiredClaim = &v1alpha1.AccountExportClaim{
-			Rules:              resolution.DesiredClaim.Rules,
-			ObservedGeneration: resolution.ObservedGeneration,
-		}
-	}
-
-	// account lookup
-	if resolution.AccountID != "" {
-		status.AccountID = resolution.AccountID
-	}
-
-	// account binding
-	switch resolution.BindingState {
-	case domain.AccountBindingStateMissing:
-		if resolution.AccountID != "" {
-			state.SetLabel(v1alpha1.AccountExportLabelAccountID, resolution.AccountID)
-			patchLabels = true
-			msg := fmt.Sprintf("Binding to Account ID: %s", resolution.AccountID)
-			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonBinding, msg)
-		} else {
-			msg := "Account not found or could not be read"
-			updateConditionFalse(conditionTypeBoundToAccount, conditionReasonNotFound, msg)
-		}
-
-	case domain.AccountBindingStateConflict:
-		msg := fmt.Sprintf("Account ID conflict: previously bound to %s, now found %s", resolution.BoundAccountID, resolution.AccountID)
-		updateConditionFalse(conditionTypeBoundToAccount, conditionReasonConflict, msg)
-
-	case domain.AccountBindingStateBound:
-		updateConditionTrue(conditionTypeBoundToAccount)
-
-	default:
-		updateConditionFalse(conditionTypeBoundToAccount, conditionReasonErrored, "Unknown binding state")
-	}
-
-	// account adoption condition
-	switch resolution.AdoptionState {
-	case domain.AccountAdoptionStateMissing:
-		if resolution.AccountID == "" {
-			msg := "Account not found or could not be read"
-			updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonNotFound, msg)
-		} else {
-			updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonFailed, resolution.AdoptionError.Error())
-		}
-
-	case domain.AccountAdoptionStateNotAdopted:
-		updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonAdopting, resolution.AdoptionError.Error())
-
-	case domain.AccountAdoptionStateAdopted:
-		updateConditionTrue(conditionTypeAdoptedByAccount)
-
-	default:
-		updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonErrored, "Unknown adopted state")
-	}
-
-	// ready condition
-	if isAccountExportReady(state) {
-		updateConditionTrue(conditionTypeReady)
-	} else {
-		updateConditionFalse(conditionTypeReady, conditionReasonReconciling, "All conditions not met")
-	}
-
-	return patchLabels, updateStatus
 }
 
 func isAccountExportReady(state *v1alpha1.AccountExport) bool {

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -95,7 +95,7 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		updateConditionFalse(conditionTypeValidRules, conditionReasonInvalid, err.Error())
 	} else {
 		updateConditionTrue(conditionTypeValidRules)
-		(&state.Status).DesiredClaim = &v1alpha1.AccountExportClaim{
+		state.Status.DesiredClaim = &v1alpha1.AccountExportClaim{
 			Rules:              state.Spec.Rules,
 			ObservedGeneration: state.Generation,
 		}
@@ -143,15 +143,14 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			sameGeneration := adoptionGen != nil && *adoptionGen == state.Generation
 			if adoption.Status.Status == metav1.ConditionTrue && sameGeneration {
 				updateConditionTrue(conditionTypeAdoptedByAccount)
+			} else if !sameGeneration {
+				msg := fmt.Sprintf("waiting for account to adopt generation %d", state.Generation)
+				updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonAdopting, msg)
 			} else {
-				if !sameGeneration {
-					msg := fmt.Sprintf("waiting for account to adopt generation %d", state.Generation)
-					updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonAdopting, msg)
-				} else {
-					msg := fmt.Sprintf("%s: %s", adoption.Status.Reason, adoption.Status.Message)
-					updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonFailed, msg)
-				}
+				msg := fmt.Sprintf("%s: %s", adoption.Status.Reason, adoption.Status.Message)
+				updateConditionFalse(conditionTypeAdoptedByAccount, conditionReasonFailed, msg)
 			}
+
 		}
 	}
 
@@ -194,11 +193,13 @@ func findAdoptionByUID(account *v1alpha1.Account, uid types.UID) *v1alpha1.Accou
 
 func mapToExportRule(rule v1alpha1.AccountExportRule) nauth.ExportRule {
 	result := nauth.ExportRule{
-		Name:              rule.Name,
-		Subject:           nauth.Subject(rule.Subject),
-		Type:              mapExportType(rule.Type),
-		ResponseType:      nauth.ResponseType(rule.ResponseType),
-		ResponseThreshold: rule.ResponseThreshold,
+		Name:         rule.Name,
+		Subject:      nauth.Subject(rule.Subject),
+		Type:         mapExportType(rule.Type),
+		ResponseType: nauth.ResponseType(rule.ResponseType),
+	}
+	if rule.ResponseThreshold != nil {
+		result.ResponseThreshold = *rule.ResponseThreshold
 	}
 
 	if rule.Latency != nil {

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/core"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -206,12 +208,12 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldFail_WhenAccount
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
 	boundToAccountCondition := t.assertCondition(conditions, conditionTypeBoundToAccount, metav1.ConditionFalse, conditionReasonConflict)
-	t.Equal("Account ID conflict: previously bound to ACCA, now found ACCB", boundToAccountCondition.Message)
+	t.Equal("account export is already bound to account: ACCA", boundToAccountCondition.Message)
 	t.Equalf(t.accountIDB, accountExport.Status.AccountID, "Expected Status.AccountID")
 	t.Equalf(t.accountIDA, accountExport.GetLabel(v1alpha1.AccountExportLabelAccountID), "Expected label %q", v1alpha1.AccountExportLabelAccountID)
 
 	t.assertCondition(conditions, conditionTypeValidRules, metav1.ConditionTrue, conditionReasonOK)
-	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, conditionReasonFailed)
+	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, conditionReasonAdopting)
 	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonReconciling)
 }
 
@@ -347,7 +349,7 @@ func (t *AccountExportControllerTestSuite) Test_Reconcile_ShouldNotBeAdoptedByAc
 	conditions := accountExport.Status.Conditions
 	t.Require().NotEmpty(conditions)
 
-	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, conditionReasonAdopting)
+	t.assertCondition(conditions, conditionTypeAdoptedByAccount, metav1.ConditionFalse, conditionReasonFailed)
 	t.assertCondition(conditions, conditionTypeReady, metav1.ConditionFalse, conditionReasonReconciling)
 }
 
@@ -370,4 +372,180 @@ func (t *AccountExportControllerTestSuite) assertCondition(conditions []metav1.C
 func (t *AccountExportControllerTestSuite) assertBoundAccountID(export *v1alpha1.AccountExport, expectAccountID string) {
 	t.Equalf(expectAccountID, export.GetLabel(v1alpha1.AccountExportLabelAccountID), "Expected label %q", v1alpha1.AccountExportLabelAccountID)
 	t.Equalf(expectAccountID, export.Status.AccountID, "Expected Status.AccountID")
+}
+
+func Test_findAdoptionByUID(t *testing.T) {
+	adoptions := []v1alpha1.AccountAdoption{
+		{UID: "export-1", Name: "first"},
+		{UID: "export-2", Name: "second"},
+	}
+
+	tests := []struct {
+		name    string
+		account *v1alpha1.Account
+		uid     ktypes.UID
+		want    *v1alpha1.AccountAdoption
+	}{
+		{
+			name:    "nil_adoptions",
+			account: &v1alpha1.Account{},
+			uid:     "export-1",
+			want:    nil,
+		},
+		{
+			name: "matching_uid",
+			account: &v1alpha1.Account{
+				Status: v1alpha1.AccountStatus{
+					Adoptions: &v1alpha1.AccountAdoptions{Exports: adoptions},
+				},
+			},
+			uid:  "export-2",
+			want: &adoptions[1],
+		},
+		{
+			name: "missing_uid",
+			account: &v1alpha1.Account{
+				Status: v1alpha1.AccountStatus{
+					Adoptions: &v1alpha1.AccountAdoptions{Exports: adoptions},
+				},
+			},
+			uid:  "export-3",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findAdoptionByUID(tt.account, tt.uid)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_mapToExportRule(t *testing.T) {
+	responseThreshold := 25 * time.Millisecond
+	accountTokenPosition := uint(3)
+	advertise := true
+	allowTrace := true
+
+	t.Run("maps_all_fields", func(t *testing.T) {
+		rule := v1alpha1.AccountExportRule{
+			Name:              "my-export",
+			Subject:           "subject.>",
+			Type:              v1alpha1.Service,
+			ResponseType:      v1alpha1.ResponseType("Singleton"),
+			ResponseThreshold: &responseThreshold,
+			Latency: &v1alpha1.ServiceLatency{
+				Sampling: 50,
+				Results:  "latency.results",
+			},
+			AccountTokenPosition: &accountTokenPosition,
+			Advertise:            &advertise,
+			AllowTrace:           &allowTrace,
+		}
+
+		want := nauth.ExportRule{
+			Name:              "my-export",
+			Subject:           nauth.Subject("subject.>"),
+			Type:              nauth.ExportTypeService,
+			ResponseType:      nauth.ResponseType("Singleton"),
+			ResponseThreshold: &responseThreshold,
+			Latency: &nauth.ServiceLatency{
+				Sampling: 50,
+				Results:  nauth.Subject("latency.results"),
+			},
+			AccountTokenPosition: 3,
+			Advertise:            true,
+			AllowTrace:           true,
+		}
+
+		assert.Equal(t, want, mapToExportRule(rule))
+	})
+
+	t.Run("keeps_zero_values_when_optional_fields_missing", func(t *testing.T) {
+		rule := v1alpha1.AccountExportRule{
+			Subject: "subject",
+			Type:    v1alpha1.Stream,
+		}
+
+		want := nauth.ExportRule{
+			Subject: nauth.Subject("subject"),
+			Type:    nauth.ExportTypeStream,
+		}
+
+		assert.Equal(t, want, mapToExportRule(rule))
+	})
+}
+
+func Test_isAccountExportReady(t *testing.T) {
+	trueCondition := func(conditionType string) metav1.Condition {
+		return newCondition(conditionType, metav1.ConditionTrue, conditionReasonOK, "")
+	}
+
+	createExport := func(generation int64, desiredClaim *v1alpha1.AccountExportClaim, conditions ...metav1.Condition) *v1alpha1.AccountExport {
+		return &v1alpha1.AccountExport{
+			ObjectMeta: metav1.ObjectMeta{Generation: generation},
+			Status: v1alpha1.AccountExportStatus{
+				DesiredClaim: desiredClaim,
+				Conditions:   conditions,
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		export *v1alpha1.AccountExport
+		want   bool
+	}{
+		{
+			name: "all_conditions_true_and_claim_matches_generation",
+			export: createExport(
+				2,
+				&v1alpha1.AccountExportClaim{ObservedGeneration: 2},
+				trueCondition(conditionTypeBoundToAccount),
+				trueCondition(conditionTypeValidRules),
+				trueCondition(conditionTypeAdoptedByAccount),
+			),
+			want: true,
+		},
+		{
+			name: "missing_desired_claim",
+			export: createExport(
+				2,
+				nil,
+				trueCondition(conditionTypeBoundToAccount),
+				trueCondition(conditionTypeValidRules),
+				trueCondition(conditionTypeAdoptedByAccount),
+			),
+			want: false,
+		},
+		{
+			name: "stale_claim_generation",
+			export: createExport(
+				2,
+				&v1alpha1.AccountExportClaim{ObservedGeneration: 1},
+				trueCondition(conditionTypeBoundToAccount),
+				trueCondition(conditionTypeValidRules),
+				trueCondition(conditionTypeAdoptedByAccount),
+			),
+			want: false,
+		},
+		{
+			name: "missing_ready_condition_dependency",
+			export: createExport(
+				2,
+				&v1alpha1.AccountExportClaim{ObservedGeneration: 2},
+				trueCondition(conditionTypeBoundToAccount),
+				newCondition(conditionTypeValidRules, metav1.ConditionFalse, conditionReasonInvalid, "invalid rules"),
+				trueCondition(conditionTypeAdoptedByAccount),
+			),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAccountExportReady(tt.export))
+		})
+	}
 }

--- a/internal/adapter/inbound/controller/account_export_test.go
+++ b/internal/adapter/inbound/controller/account_export_test.go
@@ -449,7 +449,7 @@ func Test_mapToExportRule(t *testing.T) {
 			Subject:           nauth.Subject("subject.>"),
 			Type:              nauth.ExportTypeService,
 			ResponseType:      nauth.ResponseType("Singleton"),
-			ResponseThreshold: &responseThreshold,
+			ResponseThreshold: responseThreshold,
 			Latency: &nauth.ServiceLatency{
 				Sampling: 50,
 				Results:  nauth.Subject("latency.results"),

--- a/internal/core/account_export.go
+++ b/internal/core/account_export.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/nats-io/jwt/v2"
-	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -21,60 +19,50 @@ func NewAccountExportManager() *AccountExportManager {
 	return &AccountExportManager{}
 }
 
-func (a *AccountExportManager) Resolve(ctx context.Context, state *v1alpha1.AccountExport, account *v1alpha1.Account) *domain.AccountExportResolution {
-	result := &domain.AccountExportResolution{
-		ObservedGeneration: state.Generation,
-	}
-
-	result.DesiredClaim, result.ValidationError = createClaim(ctx, state)
-
-	if account == nil {
-		result.BindingState = domain.AccountBindingStateMissing
-		result.AdoptionState = domain.AccountAdoptionStateMissing
-		return result
-	}
-
-	result.AccountID = account.GetLabel(v1alpha1.AccountLabelAccountID)
-	result.BoundAccountID = state.GetLabel(v1alpha1.AccountExportLabelAccountID)
-
-	if result.BoundAccountID == "" {
-		result.BindingState = domain.AccountBindingStateMissing
-	} else if result.BoundAccountID != result.AccountID {
-		result.BindingState = domain.AccountBindingStateConflict
-	} else {
-		result.BindingState = domain.AccountBindingStateBound
-	}
-
-	adoption, err := findAdoption(state, account)
-	if err != nil {
-		result.AdoptionState = domain.AccountAdoptionStateMissing
-		result.AdoptionError = err
-	} else {
-		result.Adoption = adoption
-
-		adoptionGen := adoption.Status.DesiredClaimObservedGeneration
-		sameGeneration := adoptionGen != nil && *adoptionGen == state.Generation
-		if adoption.Status.Status == "True" && sameGeneration {
-			result.AdoptionState = domain.AccountAdoptionStateAdopted
-		} else {
-			result.AdoptionState = domain.AccountAdoptionStateNotAdopted
-			if !sameGeneration {
-				result.AdoptionError = fmt.Errorf("generation %d has not been adopted yet", state.Generation)
-			} else {
-				result.AdoptionError = fmt.Errorf("%s: %s", adoption.Status.Reason, adoption.Status.Message)
-			}
-		}
-	}
-
-	return result
-}
-
-func createClaim(ctx context.Context, state *v1alpha1.AccountExport) (*domain.AccountExportClaim, error) {
+func (a *AccountExportManager) ValidateRules(ctx context.Context, rules nauth.ExportRules) error {
 	exports := &jwt.Exports{}
-	for _, r := range state.Spec.Rules {
+	for _, r := range rules {
 		exports.Add(mapToJwtExport(r))
 	}
 
+	return validateRules(ctx, exports)
+}
+
+func mapToJwtExport(r nauth.ExportRule) *jwt.Export {
+	export := &jwt.Export{
+		Name:                 r.Name,
+		Subject:              jwt.Subject(r.Subject),
+		Type:                 mapExportType(r.Type),
+		ResponseType:         jwt.ResponseType(r.ResponseType),
+		AccountTokenPosition: r.AccountTokenPosition,
+		Advertise:            r.Advertise,
+		AllowTrace:           r.AllowTrace,
+	}
+	if r.ResponseThreshold != nil {
+		export.ResponseThreshold = *r.ResponseThreshold
+	}
+	if r.Latency != nil {
+		export.Latency = &jwt.ServiceLatency{
+			Sampling: jwt.SamplingRate(r.Latency.Sampling),
+			Results:  jwt.Subject(r.Latency.Results),
+		}
+	}
+
+	return export
+}
+
+func mapExportType(t nauth.ExportType) jwt.ExportType {
+	switch t {
+	case nauth.ExportTypeService:
+		return jwt.Service
+	case nauth.ExportTypeStream:
+		return jwt.Stream
+	}
+
+	return jwt.Unknown
+}
+
+func validateRules(ctx context.Context, exports *jwt.Exports) error {
 	results := &jwt.ValidationResults{}
 	exports.Validate(results)
 
@@ -89,78 +77,9 @@ func createClaim(ctx context.Context, state *v1alpha1.AccountExport) (*domain.Ac
 		for _, e := range results.Errors() {
 			err = errors.Join(err, e)
 		}
-		return nil, err
+		return err
 	}
-
-	rules := make([]v1alpha1.AccountExportRule, len(state.Spec.Rules))
-	for i := range state.Spec.Rules {
-		state.Spec.Rules[i].DeepCopyInto(&rules[i])
-	}
-
-	return &domain.AccountExportClaim{Rules: rules}, nil
-}
-
-func mapToJwtExport(r v1alpha1.AccountExportRule) *jwt.Export {
-	// TODO: [#11] Move v1alpha/jwt conversions to domain
-	export := &jwt.Export{
-		Name:         r.Name,
-		Subject:      jwt.Subject(r.Subject),
-		Type:         mapExportType(r.Type),
-		ResponseType: jwt.ResponseType(r.ResponseType),
-	}
-
-	if r.ResponseThreshold != nil {
-		export.ResponseThreshold = *r.ResponseThreshold
-	}
-	if r.AccountTokenPosition != nil {
-		export.AccountTokenPosition = *r.AccountTokenPosition
-	}
-	if r.Advertise != nil {
-		export.Advertise = *r.Advertise
-	}
-	if r.AllowTrace != nil {
-		export.AllowTrace = *r.AllowTrace
-	}
-	if r.Latency != nil {
-		export.Latency = &jwt.ServiceLatency{
-			Sampling: jwt.SamplingRate(r.Latency.Sampling),
-			Results:  jwt.Subject(r.Latency.Results),
-		}
-	}
-
-	return export
-}
-
-func mapExportType(t v1alpha1.ExportType) jwt.ExportType {
-	switch t {
-	case v1alpha1.Service:
-		return jwt.Service
-	case v1alpha1.Stream:
-		return jwt.Stream
-	}
-
-	return jwt.Unknown
-}
-
-func findAdoption(state *v1alpha1.AccountExport, account *v1alpha1.Account) (*v1alpha1.AccountAdoption, error) {
-	if found, adoption := findAdoptionByUID(account, state.UID); found {
-		return &adoption, nil
-	}
-
-	return nil, fmt.Errorf("account export is not yet processed by account")
-}
-
-func findAdoptionByUID(account *v1alpha1.Account, uid types.UID) (bool, v1alpha1.AccountAdoption) {
-	if account.Status.Adoptions == nil {
-		return false, v1alpha1.AccountAdoption{}
-	}
-
-	for _, adoption := range account.Status.Adoptions.Exports {
-		if adoption.UID == uid {
-			return true, adoption
-		}
-	}
-	return false, v1alpha1.AccountAdoption{}
+	return nil
 }
 
 var _ inbound.AccountExportManager = (*AccountExportManager)(nil)

--- a/internal/core/account_export.go
+++ b/internal/core/account_export.go
@@ -37,9 +37,7 @@ func mapToJwtExport(r nauth.ExportRule) *jwt.Export {
 		AccountTokenPosition: r.AccountTokenPosition,
 		Advertise:            r.Advertise,
 		AllowTrace:           r.AllowTrace,
-	}
-	if r.ResponseThreshold != nil {
-		export.ResponseThreshold = *r.ResponseThreshold
+		ResponseThreshold:    r.ResponseThreshold,
 	}
 	if r.Latency != nil {
 		export.Latency = &jwt.ServiceLatency{

--- a/internal/core/account_export_test.go
+++ b/internal/core/account_export_test.go
@@ -5,33 +5,27 @@ import (
 	"testing"
 	"time"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/nats-io/jwt/v2"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func Test_mapToJwtExport(t *testing.T) {
 	responseThreshold := time.Duration(10)
-	tokenPos := uint(2)
-	advertise := true
-	allowTrace := true
 
-	have := v1alpha1.AccountExportRule{
+	have := nauth.ExportRule{
 		Name:              "Name",
 		Subject:           "Subject.*",
-		Type:              "service",
+		Type:              nauth.ExportTypeService,
 		ResponseType:      "Singleton",
 		ResponseThreshold: &responseThreshold,
-		Latency: &v1alpha1.ServiceLatency{
+		Latency: &nauth.ServiceLatency{
 			Sampling: 20,
 			Results:  "Results",
 		},
-		AccountTokenPosition: &tokenPos,
-		Advertise:            &advertise,
-		AllowTrace:           &allowTrace,
+		AccountTokenPosition: 2,
+		Advertise:            true,
+		AllowTrace:           true,
 	}
 	want := &jwt.Export{
 		Name:              "Name",
@@ -45,9 +39,9 @@ func Test_mapToJwtExport(t *testing.T) {
 			Sampling: 20,
 			Results:  "Results",
 		},
-		AccountTokenPosition: tokenPos,
-		Advertise:            advertise,
-		AllowTrace:           allowTrace,
+		AccountTokenPosition: 2,
+		Advertise:            true,
+		AllowTrace:           true,
 		Info:                 jwt.Info{},
 	}
 
@@ -56,10 +50,9 @@ func Test_mapToJwtExport(t *testing.T) {
 }
 
 func Test_mapToJwtExport_requiredFields(t *testing.T) {
-
-	have := v1alpha1.AccountExportRule{
+	have := nauth.ExportRule{
 		Subject: "Subject",
-		Type:    "service",
+		Type:    nauth.ExportTypeService,
 	}
 	want := &jwt.Export{
 		Subject: "Subject",
@@ -70,58 +63,68 @@ func Test_mapToJwtExport_requiredFields(t *testing.T) {
 	assert.Equalf(t, want, got, "should be equal")
 }
 
-func TestAccountExportManager_CreateClaim(t *testing.T) {
-	state := &v1alpha1.AccountExport{
-		Spec: v1alpha1.AccountExportSpec{
-			AccountName: "MyAccount",
-			Rules: []v1alpha1.AccountExportRule{
+func TestAccountExportManager_ValidateRules(t *testing.T) {
+	responseThreshold := 50 * time.Millisecond
+
+	tests := []struct {
+		name    string
+		rules   nauth.ExportRules
+		wantErr bool
+	}{
+		{
+			name: "valid_rules",
+			rules: nauth.ExportRules{
 				{
-					Name:    "export1",
-					Subject: "mysubject",
-					Type:    "service",
-				},
-			},
-		},
-	}
-
-	claim, err := createClaim(context.Background(), state)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, claim)
-	assert.Len(t, claim.Rules, 1)
-
-	exportRule := claim.Rules[0]
-	assert.Equal(t, "export1", exportRule.Name)
-	assert.Equal(t, v1alpha1.Subject("mysubject"), exportRule.Subject)
-	assert.Equal(t, v1alpha1.ExportType("service"), exportRule.Type)
-}
-
-func TestAccountExportManager_CreateClaim_conflict(t *testing.T) {
-	state := &v1alpha1.AccountExport{
-		Spec: v1alpha1.AccountExportSpec{
-			AccountName: "MyAccount",
-			Rules: []v1alpha1.AccountExportRule{
-				{
-					Name:    "export1",
-					Subject: "mysubject",
-					Type:    "service",
+					Name:              "export1",
+					Subject:           "my.subject",
+					Type:              nauth.ExportTypeService,
+					ResponseType:      "Singleton",
+					ResponseThreshold: &responseThreshold,
+					Latency: &nauth.ServiceLatency{
+						Sampling: 100,
+						Results:  "results.subject",
+					},
+					Advertise:  true,
+					AllowTrace: true,
 				},
 				{
 					Name:    "export2",
-					Subject: "mysubject",
-					Type:    "service",
+					Subject: "stream.subject",
+					Type:    nauth.ExportTypeStream,
 				},
 			},
+			wantErr: false,
+		},
+		{
+			name: "invalid_subject",
+			rules: nauth.ExportRules{
+				{
+					Name:    "invalid",
+					Subject: ".",
+					Type:    nauth.ExportTypeStream,
+				},
+			},
+			wantErr: true,
 		},
 	}
 
-	_, err := createClaim(context.Background(), state)
-	assert.Error(t, err, "should fail")
+	manager := NewAccountExportManager()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := manager.ValidateRules(context.Background(), tt.rules)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func Test_mapExportType(t *testing.T) {
 	type args struct {
-		t v1alpha1.ExportType
+		t nauth.ExportType
 	}
 	tests := []struct {
 		name string
@@ -137,264 +140,4 @@ func Test_mapExportType(t *testing.T) {
 			assert.Equalf(t, tt.want, mapExportType(tt.args.t), "should be equal")
 		})
 	}
-}
-
-func Test_findAdoptionByUID(t *testing.T) {
-	type args struct {
-		account *v1alpha1.Account
-		export  *v1alpha1.AccountExport
-	}
-
-	adoptions := []v1alpha1.AccountAdoption{
-		{
-			UID:    "1",
-			Status: v1alpha1.AccountAdoptionStatus{},
-		},
-	}
-	acc := &v1alpha1.Account{
-		Status: v1alpha1.AccountStatus{
-			Adoptions: &v1alpha1.AccountAdoptions{
-				Exports: adoptions,
-			},
-		},
-	}
-
-	createExport := func(uid string) *v1alpha1.AccountExport {
-		a := v1alpha1.AccountExport{}
-		a.UID = types.UID(uid)
-		return &a
-	}
-
-	tests := []struct {
-		name         string
-		args         args
-		wantErr      bool
-		wantAdoption *v1alpha1.AccountAdoption
-	}{
-		{
-			name:         "account has adoption with matching UID",
-			args:         args{account: acc, export: createExport("1")},
-			wantErr:      false,
-			wantAdoption: &adoptions[0],
-		},
-		{
-			name:         "account has no adoption with matching UID",
-			args:         args{account: acc, export: createExport("2")},
-			wantErr:      true,
-			wantAdoption: nil,
-		},
-		{
-			name:         "account has no adoptions",
-			args:         args{account: &v1alpha1.Account{}, export: createExport("1")},
-			wantErr:      true,
-			wantAdoption: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := findAdoption(tt.args.export, tt.args.account)
-			assert.Equalf(t, tt.wantErr, err != nil, "shouldBeEqual")
-			assert.Equalf(t, tt.wantAdoption, got, "shouldBeEqual")
-		})
-	}
-}
-
-func TestAccountExportManager_Resolve(t *testing.T) {
-	createExport := func() *v1alpha1.AccountExport {
-		export := &v1alpha1.AccountExport{
-			ObjectMeta: metav1.ObjectMeta{
-				UID:        "UID1",
-				Generation: 1,
-			},
-			Spec: v1alpha1.AccountExportSpec{
-				AccountName: "MyAccount",
-				Rules: []v1alpha1.AccountExportRule{
-					{
-						Name:    "Rule1",
-						Subject: "my.subject",
-						Type:    "stream",
-					},
-				},
-			},
-		}
-		return export
-	}
-	createAccount := func() *v1alpha1.Account {
-		account := &v1alpha1.Account{
-			Spec: v1alpha1.AccountSpec{},
-			Status: v1alpha1.AccountStatus{
-				Adoptions: &v1alpha1.AccountAdoptions{},
-			},
-		}
-		return account
-	}
-
-	aem := NewAccountExportManager()
-
-	t.Run("observedGeneration should match spec.Generation", func(t *testing.T) {
-		resolution := aem.Resolve(context.Background(), createExport(), createAccount())
-
-		assert.Equal(t, int64(1), resolution.ObservedGeneration)
-	})
-
-	t.Run("valid rules should generate desiredClaim", func(t *testing.T) {
-		export := createExport()
-		resolution := aem.Resolve(context.Background(), export, createAccount())
-
-		assert.NoError(t, resolution.ValidationError)
-		assert.NotNil(t, resolution.DesiredClaim)
-		assert.Equal(t, export.Spec.Rules, resolution.DesiredClaim.Rules)
-	})
-
-	t.Run("invalid rules should not generate desiredClaim", func(t *testing.T) {
-		export := createExport()
-		export.Spec.Rules[0].Subject = ""
-		resolution := aem.Resolve(context.Background(), export, createAccount())
-
-		assert.Error(t, resolution.ValidationError)
-		assert.Nil(t, resolution.DesiredClaim)
-	})
-
-	t.Run("account not found should set bindingState missing", func(t *testing.T) {
-		resolution := aem.Resolve(context.Background(), createExport(), nil)
-
-		assert.Equal(t, domain.AccountBindingStateMissing, resolution.BindingState)
-	})
-
-	t.Run("account not found should set adoptionState missing", func(t *testing.T) {
-		resolution := aem.Resolve(context.Background(), createExport(), nil)
-
-		assert.Equal(t, domain.AccountAdoptionStateMissing, resolution.AdoptionState)
-	})
-
-	t.Run("account found should set accountID", func(t *testing.T) {
-		account := createAccount()
-		account.SetLabel(v1alpha1.AccountLabelAccountID, "ACC1")
-		resolution := aem.Resolve(context.Background(), createExport(), account)
-
-		assert.Equal(t, "ACC1", resolution.AccountID)
-	})
-
-	t.Run("account found should set accountID", func(t *testing.T) {
-		account := createAccount()
-		account.SetLabel(v1alpha1.AccountLabelAccountID, "ACC1")
-		resolution := aem.Resolve(context.Background(), createExport(), account)
-
-		assert.Equal(t, "ACC1", resolution.AccountID)
-	})
-
-	t.Run("No boundAccountID should set bindingState missing", func(t *testing.T) {
-		resolution := aem.Resolve(context.Background(), createExport(), createAccount())
-
-		assert.Equal(t, domain.AccountBindingStateMissing, resolution.BindingState)
-		assert.Empty(t, resolution.BoundAccountID)
-	})
-
-	t.Run("matching boundAccountID should set bindingState bound", func(t *testing.T) {
-		accountExport := createExport()
-		accountExport.SetLabel(v1alpha1.AccountExportLabelAccountID, "ACC1")
-		account := createAccount()
-		account.SetLabel(v1alpha1.AccountLabelAccountID, "ACC1")
-
-		resolution := aem.Resolve(context.Background(), accountExport, account)
-
-		assert.Equal(t, domain.AccountBindingStateBound, resolution.BindingState)
-		assert.Equal(t, "ACC1", resolution.BoundAccountID)
-	})
-
-	t.Run("non matching boundAccountID should set bindingState conflict", func(t *testing.T) {
-		accountExport := createExport()
-		accountExport.SetLabel(v1alpha1.AccountExportLabelAccountID, "ACC2")
-		account := createAccount()
-		account.SetLabel(v1alpha1.AccountLabelAccountID, "ACC1")
-
-		resolution := aem.Resolve(context.Background(), accountExport, account)
-
-		assert.Equal(t, domain.AccountBindingStateConflict, resolution.BindingState)
-		assert.Equal(t, "ACC2", resolution.BoundAccountID)
-	})
-
-	t.Run("adoption not found should set adoptionState missing", func(t *testing.T) {
-		accountExport := createExport()
-		account := createAccount()
-
-		resolution := aem.Resolve(context.Background(), accountExport, account)
-
-		assert.Equal(t, domain.AccountAdoptionStateMissing, resolution.AdoptionState)
-		assert.Error(t, resolution.AdoptionError)
-	})
-
-	t.Run("adoption found should set adoptionState adopted", func(t *testing.T) {
-		accountExport := createExport()
-		accountExport.Generation = 2
-
-		account := createAccount()
-		desiredGen := int64(2)
-		account.Status.Adoptions.Exports = []v1alpha1.AccountAdoption{
-			{
-				Name: "Rule1",
-				UID:  accountExport.UID,
-				Status: v1alpha1.AccountAdoptionStatus{
-					Status:                         metav1.ConditionTrue,
-					DesiredClaimObservedGeneration: &desiredGen,
-				},
-			},
-		}
-
-		resolution := aem.Resolve(context.Background(), accountExport, account)
-
-		assert.Equal(t, domain.AccountAdoptionStateAdopted, resolution.AdoptionState)
-		assert.NoError(t, resolution.AdoptionError)
-	})
-
-	t.Run("adoption wrong generation should set adoptionState notAdopted", func(t *testing.T) {
-		accountExport := createExport()
-		accountExport.Generation = 2
-
-		account := createAccount()
-		desiredGen := int64(1)
-		account.Status.Adoptions.Exports = []v1alpha1.AccountAdoption{
-			{
-				Name: "Rule1",
-				UID:  accountExport.UID,
-				Status: v1alpha1.AccountAdoptionStatus{
-					Status:                         metav1.ConditionTrue,
-					DesiredClaimObservedGeneration: &desiredGen,
-				},
-			},
-		}
-
-		resolution := aem.Resolve(context.Background(), accountExport, account)
-
-		assert.Equal(t, domain.AccountAdoptionStateNotAdopted, resolution.AdoptionState)
-		assert.Error(t, resolution.AdoptionError)
-		assert.Equal(t, "generation 2 has not been adopted yet", resolution.AdoptionError.Error())
-	})
-
-	t.Run("adoption error should set adoptionState notAdopted", func(t *testing.T) {
-		accountExport := createExport()
-		accountExport.Generation = 2
-
-		account := createAccount()
-		desiredGen := int64(2)
-		account.Status.Adoptions.Exports = []v1alpha1.AccountAdoption{
-			{
-				Name: "Rule1",
-				UID:  accountExport.UID,
-				Status: v1alpha1.AccountAdoptionStatus{
-					Status:                         metav1.ConditionFalse,
-					DesiredClaimObservedGeneration: &desiredGen,
-					Reason:                         "ConflictReason",
-					Message:                        "conflict with",
-				},
-			},
-		}
-
-		resolution := aem.Resolve(context.Background(), accountExport, account)
-
-		assert.Equal(t, domain.AccountAdoptionStateNotAdopted, resolution.AdoptionState)
-		assert.Error(t, resolution.AdoptionError)
-		assert.Equal(t, "ConflictReason: conflict with", resolution.AdoptionError.Error())
-	})
 }

--- a/internal/core/account_export_test.go
+++ b/internal/core/account_export_test.go
@@ -18,7 +18,7 @@ func Test_mapToJwtExport(t *testing.T) {
 		Subject:           "Subject.*",
 		Type:              nauth.ExportTypeService,
 		ResponseType:      "Singleton",
-		ResponseThreshold: &responseThreshold,
+		ResponseThreshold: responseThreshold,
 		Latency: &nauth.ServiceLatency{
 			Sampling: 20,
 			Results:  "Results",
@@ -79,7 +79,7 @@ func TestAccountExportManager_ValidateRules(t *testing.T) {
 					Subject:           "my.subject",
 					Type:              nauth.ExportTypeService,
 					ResponseType:      "Singleton",
-					ResponseThreshold: &responseThreshold,
+					ResponseThreshold: responseThreshold,
 					Latency: &nauth.ServiceLatency{
 						Sampling: 100,
 						Results:  "results.subject",

--- a/internal/domain/nauth/export.go
+++ b/internal/domain/nauth/export.go
@@ -1,0 +1,34 @@
+package nauth
+
+import "time"
+
+type ExportRules []ExportRule
+
+type ExportRule struct {
+	// +optional
+	Name string
+	// +required
+	Subject Subject
+	// +required
+	Type ExportType
+	// +optional
+	ResponseType ResponseType
+	// +optional
+	ResponseThreshold *time.Duration
+	// +optional
+	Latency *ServiceLatency
+	// +optional
+	AccountTokenPosition uint
+	// +optional
+	Advertise bool
+	// +optional
+	AllowTrace bool
+}
+
+type ResponseType string
+type SamplingRate int
+
+type ServiceLatency struct {
+	Sampling SamplingRate
+	Results  Subject
+}

--- a/internal/domain/nauth/export.go
+++ b/internal/domain/nauth/export.go
@@ -14,7 +14,7 @@ type ExportRule struct {
 	// +optional
 	ResponseType ResponseType
 	// +optional
-	ResponseThreshold *time.Duration
+	ResponseThreshold time.Duration
 	// +optional
 	Latency *ServiceLatency
 	// +optional

--- a/internal/ports/inbound/nauth.go
+++ b/internal/ports/inbound/nauth.go
@@ -15,7 +15,7 @@ type AccountManager interface {
 }
 
 type AccountExportManager interface {
-	Resolve(ctx context.Context, state *v1alpha1.AccountExport, account *v1alpha1.Account) *domain.AccountExportResolution
+	ValidateRules(ctx context.Context, rules nauth.ExportRules) error
 }
 
 type AccountImportManager interface {


### PR DESCRIPTION
## Description

This refactor narrows the core account export manager to rule validation and JWT export mapping, while moving account binding, adoption tracking, and desired-claim/status handling into the AccountExport controller.

It also introduces domain-level export rule types and updates the test suite to cover the new controller-owned reconciliation flow and the slimmer core validation behavior.