### PR TITLE
refactor(core): move NatsCluster API handling to adapters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,7 @@ linters:
         path: internal/*
       - linters:
           - unparam
+          - goconst
         path: .*_test\.go
     paths:
       - third_party$

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -246,15 +247,13 @@ func main() {
 	secretClient := k8s.NewSecretClient(mgr.GetClient())
 	configMapClient := k8s.NewConfigMapClient(mgr.GetClient())
 	accountClient := k8s.NewAccountClient(mgr.GetClient())
-	natsClusterClient := k8s.NewNatsClusterClient(mgr.GetClient())
+	clusterClient := k8s.NewClusterClient(mgr.GetClient(), secretClient, configMapClient)
 	natsSysClient := nats.NewSysClient()
 	natsAccClient := nats.NewAccountClient()
 
 	clusterManager, err := core.NewClusterManager(
-		natsClusterClient,
+		clusterClient,
 		natsSysClient,
-		secretClient,
-		configMapClient,
 		config,
 	)
 	if err != nil {
@@ -334,6 +333,7 @@ func main() {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		clusterManager,
+		clusterClient,
 		mgr.GetEventRecorder("natscluster-controller"),
 	)
 	if err = natsClusterReconciler.SetupWithManager(mgr); err != nil {
@@ -364,7 +364,7 @@ func main() {
 	}
 }
 
-func parseNatsClusterRef(refStr string) (*v1alpha1.NatsClusterRef, error) {
+func parseNatsClusterRef(refStr string) (*nauth.ClusterRef, error) {
 	parts := strings.Split(refStr, "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid cluster ref pattern %q, expected namespace/name", refStr)
@@ -372,6 +372,14 @@ func parseNatsClusterRef(refStr string) (*v1alpha1.NatsClusterRef, error) {
 
 	namespace := parts[0]
 	name := parts[1]
+	namespacedName := domain.NewNamespacedName(namespace, name)
+	if err := namespacedName.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid cluster ref namespaced name %q: %w", refStr, err)
+	}
+	result := nauth.ClusterRef(refStr)
+	if err := result.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid cluster ref %q: %w", refStr, err)
+	}
 
-	return &v1alpha1.NatsClusterRef{Name: name, Namespace: namespace}, nil
+	return &result, nil
 }

--- a/internal/adapter/inbound/controller/account_converter.go
+++ b/internal/adapter/inbound/controller/account_converter.go
@@ -106,7 +106,7 @@ func toAPIAdoptions(adoptions *nauth.AccountAdoptions, adoptionRefs accountAdopt
 			status = v1alpha1.AccountAdoptionStatus{
 				Status:                         metav1.ConditionTrue,
 				Reason:                         conditionReasonOK,
-				Message:                        "Adopted",
+				Message:                        conditionMessageAdopted,
 				DesiredClaimObservedGeneration: adpRef.ObservedGenerationDesiredClaim,
 			}
 		} else {
@@ -125,7 +125,7 @@ func toAPIAdoptions(adoptions *nauth.AccountAdoptions, adoptionRefs accountAdopt
 				status.Reason = string(failure)
 				status.Message = adpResult.Message
 			} else {
-				status.Message = "Adopted"
+				status.Message = conditionMessageAdopted
 			}
 		}
 		result.Exports = append(result.Exports, v1alpha1.AccountAdoption{

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -421,7 +421,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenAccountExp
 				Status: v1alpha1.AccountAdoptionStatus{
 					Status:                         metav1.ConditionTrue,
 					Reason:                         conditionReasonOK,
-					Message:                        "Adopted",
+					Message:                        conditionMessageAdopted,
 					DesiredClaimObservedGeneration: &export1.Status.DesiredClaim.ObservedGeneration,
 				},
 			},
@@ -442,7 +442,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenAccountExp
 				Status: v1alpha1.AccountAdoptionStatus{
 					Status:                         metav1.ConditionTrue,
 					Reason:                         conditionReasonOK,
-					Message:                        "Adopted",
+					Message:                        conditionMessageAdopted,
 					DesiredClaimObservedGeneration: &export5.Status.DesiredClaim.ObservedGeneration,
 				},
 			},

--- a/internal/adapter/inbound/controller/constants.go
+++ b/internal/adapter/inbound/controller/constants.go
@@ -24,6 +24,9 @@ const ( // Conditions
 	conditionReasonNotFound    = "NotFound"
 	conditionReasonAdopting    = "Adopting"
 	conditionReasonFailed      = "Failed"
+
+	// Messages
+	conditionMessageAdopted = "Adopted"
 )
 
 const ( // Events

--- a/internal/adapter/inbound/controller/natscluster.go
+++ b/internal/adapter/inbound/controller/natscluster.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -36,18 +37,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type ClusterResolver interface {
+	ResolveClusterTarget(ctx context.Context, cluster *v1alpha1.NatsCluster) (*nauth.ClusterTarget, error)
+}
+
 type NatsClusterReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
-	manager  inbound.NatsClusterManager
+	manager  inbound.ClusterManager
+	resolver ClusterResolver
 	reporter *statusReporter
 }
 
-func NewNatsClusterReconciler(k8sClient client.Client, scheme *runtime.Scheme, manager inbound.NatsClusterManager, recorder events.EventRecorder) *NatsClusterReconciler {
+func NewNatsClusterReconciler(
+	k8sClient client.Client,
+	scheme *runtime.Scheme,
+	manager inbound.ClusterManager,
+	resolver ClusterResolver,
+	recorder events.EventRecorder,
+) *NatsClusterReconciler {
 	return &NatsClusterReconciler{
 		Client:   k8sClient,
 		Scheme:   scheme,
 		manager:  manager,
+		resolver: resolver,
 		reporter: newStatusReporter(k8sClient, recorder),
 	}
 }
@@ -86,7 +99,12 @@ func (r *NatsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if err := r.manager.Validate(ctx, natsCluster); err != nil {
+	clusterTarget, err := r.resolver.ResolveClusterTarget(ctx, natsCluster)
+	if err != nil {
+		return r.reporter.error(ctx, natsCluster, fmt.Errorf("failed to resolve NatsCluster target: %w", err))
+	}
+
+	if err = r.manager.Validate(ctx, *clusterTarget); err != nil {
 		return r.reporter.error(ctx, natsCluster, fmt.Errorf("failed to validate NatsCluster: %w", err))
 	}
 

--- a/internal/adapter/inbound/controller/natscluster_test.go
+++ b/internal/adapter/inbound/controller/natscluster_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
+	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +36,9 @@ type NatsClusterControllerTestSuite struct {
 	suite.Suite
 	ctx context.Context
 
-	natsClusterManagerMock *NatsClusterManagerMock
-	fakeRecorder           *events.FakeRecorder
+	managerMock  *ClusterManagerMock
+	resolverMock *ClusterResolverMock
+	fakeRecorder *events.FakeRecorder
 
 	resourceName    ktypes.NamespacedName
 	operatorVersion string
@@ -60,12 +63,14 @@ func (t *NatsClusterControllerTestSuite) SetupTest() {
 		Namespace: namespace,
 	}
 
-	t.natsClusterManagerMock = &NatsClusterManagerMock{}
+	t.managerMock = &ClusterManagerMock{}
+	t.resolverMock = &ClusterResolverMock{}
 	t.fakeRecorder = events.NewFakeRecorder(5)
 	t.unitUnderTest = NewNatsClusterReconciler(
 		k8sClient,
 		k8sClient.Scheme(),
-		t.natsClusterManagerMock,
+		t.managerMock,
+		t.resolverMock,
 		t.fakeRecorder,
 	)
 
@@ -84,13 +89,21 @@ func (t *NatsClusterControllerTestSuite) SetupTest() {
 }
 
 func (t *NatsClusterControllerTestSuite) TearDownTest() {
-	t.natsClusterManagerMock.AssertExpectations(t.T())
+	t.managerMock.AssertExpectations(t.T())
+	t.resolverMock.AssertExpectations(t.T())
 	t.Require().NoError(os.Unsetenv(envOperatorVersion))
 }
 
 func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 	// Given
-	t.natsClusterManagerMock.On("Validate", mock.Anything).Return(nil).Once()
+	target := t.anyClusterTarget()
+	t.resolverMock.mockResolveClusterTarget(&target, nil)
+
+	var targetSpied *nauth.ClusterTarget
+	t.managerMock.mockValidateSpy(func(target nauth.ClusterTarget) error {
+		targetSpied = &target
+		return nil
+	})
 
 	// When
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.resourceName})
@@ -108,12 +121,20 @@ func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldSucceed() {
 		t.Equal(conditionReasonReconciled, c.Reason)
 	}
 	t.Empty(t.fakeRecorder.Events)
+	t.Require().NotNil(targetSpied, "expected manager.Validate to be called with a ClusterTarget")
+	t.Equal(target, *targetSpied)
 }
 
-func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldFail() {
+func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldFail_WhenValidationFails() {
 	// Given
 	validateErr := fmt.Errorf("a test error")
-	t.natsClusterManagerMock.On("Validate", mock.Anything).Return(validateErr).Once()
+	target := t.anyClusterTarget()
+	t.resolverMock.mockResolveClusterTarget(&target, nil)
+	var targetSpied *nauth.ClusterTarget
+	t.managerMock.mockValidateSpy(func(target nauth.ClusterTarget) error {
+		targetSpied = &target
+		return validateErr
+	})
 
 	// When
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.resourceName})
@@ -130,12 +151,38 @@ func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldFail() {
 	}
 	t.Len(t.fakeRecorder.Events, 1)
 	t.Contains(<-t.fakeRecorder.Events, "failed to validate NatsCluster: a test error")
+	t.Require().NotNil(targetSpied, "expected manager.Validate to be called with a ClusterTarget")
+	t.Equal(target, *targetSpied)
+}
+
+func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldFail_WhenResolveTargetFails() {
+	// Given
+	resolveErr := fmt.Errorf("a test error")
+	t.resolverMock.mockResolveClusterTarget(nil, resolveErr)
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.resourceName})
+
+	// Then
+	t.Error(err)
+	t.Contains(err.Error(), resolveErr.Error())
+
+	cluster := &v1alpha1.NatsCluster{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.resourceName, cluster))
+	for _, c := range cluster.Status.Conditions {
+		t.Equal(metav1.ConditionFalse, c.Status)
+		t.Equal(conditionReasonErrored, c.Reason)
+	}
+	t.Len(t.fakeRecorder.Events, 1)
+	t.Contains(<-t.fakeRecorder.Events, "failed to resolve NatsCluster target: a test error")
 }
 
 func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldSkip_WhenGenerationAndOperatorVersionAreUnchanged() {
 	// Given
-	// Note: Expect manager.Validate during setup only
-	t.natsClusterManagerMock.On("Validate", mock.Anything).Return(nil).Once()
+	// Note: Expect during setup only
+	target := t.anyClusterTarget()
+	t.resolverMock.mockResolveClusterTarget(&target, nil)
+	t.managerMock.mockValidate(nil)
 
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.resourceName})
 
@@ -146,7 +193,7 @@ func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldSkip_WhenGeneratio
 	t.Equal(cluster.Generation, cluster.Status.ObservedGeneration)
 
 	// Note: assert mock calls during setup and reset for test case
-	t.natsClusterManagerMock.AssertExpectations(t.T())
+	t.managerMock.AssertExpectations(t.T())
 
 	// When (expect no manager calls)
 	_, err = t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.resourceName})
@@ -155,11 +202,46 @@ func (t *NatsClusterControllerTestSuite) Test_Reconcile_ShouldSkip_WhenGeneratio
 	t.NoError(err)
 }
 
-type NatsClusterManagerMock struct {
+// Helpers
+
+func (t *NatsClusterControllerTestSuite) anyClusterTarget() nauth.ClusterTarget {
+	return nauth.ClusterTarget{NatsURL: fmt.Sprintf("nats://%s.my-cluster:4222", shortHash(t.T().Name()))}
+}
+
+type ClusterManagerMock struct {
 	mock.Mock
 }
 
-func (m *NatsClusterManagerMock) Validate(ctx context.Context, state *v1alpha1.NatsCluster) error {
-	args := m.Called(state)
+func (m *ClusterManagerMock) Validate(ctx context.Context, target nauth.ClusterTarget) error {
+	args := m.Called(ctx, target)
 	return args.Error(0)
 }
+
+func (m *ClusterManagerMock) mockValidate(err error) {
+	m.On("Validate", mock.Anything, mock.Anything).Return(err).Once()
+}
+
+func (m *ClusterManagerMock) mockValidateSpy(spy func(target nauth.ClusterTarget) error) {
+	call := m.On("Validate", mock.Anything, mock.Anything).Once()
+	call.Run(func(args mock.Arguments) { call.Return(spy(args.Get(1).(nauth.ClusterTarget))) })
+}
+
+var _ inbound.ClusterManager = (*ClusterManagerMock)(nil)
+
+type ClusterResolverMock struct {
+	mock.Mock
+}
+
+func (m *ClusterResolverMock) ResolveClusterTarget(ctx context.Context, cluster *v1alpha1.NatsCluster) (*nauth.ClusterTarget, error) {
+	args := m.Called(ctx, cluster)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*nauth.ClusterTarget), args.Error(1)
+}
+
+func (m *ClusterResolverMock) mockResolveClusterTarget(result *nauth.ClusterTarget, err error) {
+	m.On("ResolveClusterTarget", mock.Anything, mock.Anything).Return(result, err).Once()
+}
+
+var _ ClusterResolver = (*ClusterResolverMock)(nil)

--- a/internal/adapter/outbound/k8s/cluster.go
+++ b/internal/adapter/outbound/k8s/cluster.go
@@ -6,32 +6,164 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/outbound"
+	"github.com/nats-io/nkeys"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type NatsClusterClient struct {
-	reader client.Reader
+type ClusterClient struct {
+	k8sReader       client.Reader
+	secretReader    outbound.SecretReader
+	configMapReader outbound.ConfigMapReader
 }
 
-func NewNatsClusterClient(reader client.Reader) *NatsClusterClient {
-	return &NatsClusterClient{
-		reader: reader,
+func NewClusterClient(
+	k8sReader client.Reader,
+	secretReader outbound.SecretReader,
+	configMapReader outbound.ConfigMapReader,
+) *ClusterClient {
+	return &ClusterClient{
+		k8sReader:       k8sReader,
+		secretReader:    secretReader,
+		configMapReader: configMapReader,
 	}
 }
 
-func (c *NatsClusterClient) Get(ctx context.Context, clusterRef domain.NamespacedName) (*v1alpha1.NatsCluster, error) {
-	if err := clusterRef.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid NATS cluster reference %q: %w", clusterRef, err)
-	}
-
-	r := &v1alpha1.NatsCluster{}
-	err := c.reader.Get(ctx, client.ObjectKey{Namespace: clusterRef.Namespace, Name: clusterRef.Name}, r)
+func (c *ClusterClient) GetTarget(ctx context.Context, clusterRef nauth.ClusterRef) (*nauth.ClusterTarget, error) {
+	namespacedNameRef, err := clusterRef.AsNamespacedName()
 	if err != nil {
-		return nil, fmt.Errorf("failed getting NatsCluster %s/%s: %w", clusterRef.Namespace, clusterRef.Name, err)
+		return nil, fmt.Errorf("invalid cluster reference %q (expected NamespacedName): %w", clusterRef, err)
 	}
-	return r, nil
+
+	cluster := &v1alpha1.NatsCluster{}
+	if err = c.k8sReader.Get(ctx, client.ObjectKey{Namespace: namespacedNameRef.Namespace, Name: namespacedNameRef.Name}, cluster); err != nil {
+		return nil, fmt.Errorf("failed getting NatsCluster resource %s: %w", namespacedNameRef.String(), err)
+	}
+
+	return c.ResolveClusterTarget(ctx, cluster)
 }
 
-// Compile-time assertion that implementation satisfies the ports interface
-var _ outbound.NatsClusterReader = (*NatsClusterClient)(nil)
+// ResolveClusterTarget implements the controller.ClusterResolver interface.
+func (c *ClusterClient) ResolveClusterTarget(ctx context.Context, cluster *v1alpha1.NatsCluster) (*nauth.ClusterTarget, error) {
+	clusterRef := domain.NewNamespacedName(cluster.GetNamespace(), cluster.GetName())
+	natsURL, err := c.resolveNatsURL(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("resolve NATS URL for NatsCluster %s: %w", clusterRef, err)
+	}
+	sysAdminCreds, err := c.resolveSysAdminCreds(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("resolve system account user creds for NatsCluster %s: %w", clusterRef, err)
+	}
+	opSigningKey, err := c.resolveOperatorSigningKey(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("resolve operator signing key for NatsCluster %s: %w", clusterRef, err)
+	}
+	target, err := nauth.NewClusterTarget(natsURL, *sysAdminCreds, opSigningKey)
+	if err != nil {
+		return nil, fmt.Errorf("create cluster target for NatsCluster %s: %w", clusterRef, err)
+	}
+	return target, nil
+}
+
+func (c *ClusterClient) resolveSysAdminCreds(ctx context.Context, cluster *v1alpha1.NatsCluster) (*domain.NatsUserCreds, error) {
+	secretKeyRef := cluster.Spec.SystemAccountUserCredsSecretRef
+	secretRef := domain.NewNamespacedName(cluster.GetNamespace(), secretKeyRef.Name)
+	creds, err := c.resolveSecret(ctx, secretRef, secretKeyRef.Key)
+	if err != nil {
+		return nil, err
+	}
+	userCreds, err := domain.NewNatsUserCreds(creds)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user creds: %w", err)
+	}
+	return userCreds, nil
+}
+
+func (c *ClusterClient) resolveOperatorSigningKey(ctx context.Context, cluster *v1alpha1.NatsCluster) (domain.NatsOperatorSigningKey, error) {
+	secretKeyRef := cluster.Spec.OperatorSigningKeySecretRef
+	secretRef := domain.NewNamespacedName(cluster.GetNamespace(), secretKeyRef.Name)
+	keyData, err := c.resolveSecret(ctx, secretRef, secretKeyRef.Key)
+	if err != nil {
+		return nil, err
+	}
+	opSigningKey, err := nkeys.FromSeed(keyData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid operator signing key: %w", err)
+	}
+	return opSigningKey, nil
+}
+
+func (c *ClusterClient) resolveSecret(ctx context.Context, namespacedName domain.NamespacedName, key string) ([]byte, error) {
+	secretData, found, err := c.secretReader.Get(ctx, namespacedName)
+	if err != nil {
+		return nil, fmt.Errorf("resolve secret %s: %w", namespacedName, err)
+	}
+	if !found {
+		return nil, fmt.Errorf("secret %s not found", namespacedName)
+	}
+
+	if key == "" {
+		key = DefaultSecretKeyName
+	}
+
+	value, ok := secretData[key]
+	if !ok {
+		return nil, fmt.Errorf("secret %s does not contain key %q", namespacedName, key)
+	}
+
+	return []byte(value), nil
+}
+
+func (c *ClusterClient) resolveNatsURL(ctx context.Context, cluster *v1alpha1.NatsCluster) (string, error) {
+	url := cluster.Spec.URL
+	urlFrom := ""
+	if cluster.Spec.URLFrom != nil {
+		var err error
+		urlFrom, err = c.resolveNatsURLFromResource(ctx, cluster.Spec.URLFrom, cluster.GetNamespace())
+		if err != nil {
+			return "", fmt.Errorf("resolve NATS URL from urlFrom reference: %w", err)
+		}
+		if url != "" && urlFrom != url {
+			return "", fmt.Errorf("ambiguous NATS URL, url and urlFrom reference resolve to different URLs (%q vs %q)", url, urlFrom)
+		}
+		return urlFrom, nil
+	}
+	if url == "" {
+		return "", fmt.Errorf("NATS URL must be specified via url or urlFrom")
+	}
+	return url, nil
+}
+
+func (c *ClusterClient) resolveNatsURLFromResource(ctx context.Context, urlFromRef *v1alpha1.URLFromReference, fallbackNamespace string) (string, error) {
+	resourceRef := domain.NewNamespacedName(urlFromRef.Namespace, urlFromRef.Name)
+	if resourceRef.Namespace == "" {
+		resourceRef.Namespace = fallbackNamespace
+	}
+	if err := resourceRef.Validate(); err != nil {
+		return "", fmt.Errorf("invalid resource reference for urlFrom: %w", err)
+	}
+
+	switch urlFromRef.Kind {
+	case v1alpha1.URLFromKindConfigMap:
+		data, err := c.configMapReader.Get(ctx, resourceRef)
+		if err != nil {
+			return "", fmt.Errorf("get ConfigMap %s: %w", resourceRef, err)
+		}
+		if natsURL, ok := data[urlFromRef.Key]; ok {
+			return natsURL, nil
+		}
+		return "", fmt.Errorf("configMap %s has no key %q", resourceRef, urlFromRef.Key)
+	case v1alpha1.URLFromKindSecret:
+		data, err := c.resolveSecret(ctx, resourceRef, urlFromRef.Key)
+		if err != nil {
+			return "", fmt.Errorf("get URL secret: %w", err)
+		}
+		return string(data), nil
+	default:
+		return "", fmt.Errorf("unsupported urlFrom.kind %q", urlFromRef.Kind)
+	}
+}
+
+// Compile-time assertion that implementation satisfies the port interface
+var _ outbound.ClusterReader = (*ClusterClient)(nil)

--- a/internal/adapter/outbound/k8s/cluster_test.go
+++ b/internal/adapter/outbound/k8s/cluster_test.go
@@ -6,18 +6,21 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
+	"github.com/nats-io/jwt/v2"
+	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/suite"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type NatsClusterClientTestSuite struct {
 	suite.Suite
 	ctx        context.Context
-	clusterRef domain.NamespacedName
+	clusterNsN domain.NamespacedName
+	clusterRef nauth.ClusterRef
 
-	unitUnderTest *NatsClusterClient
+	unitUnderTest *ClusterClient
 }
 
 func TestNatsClusterClient_TestSuite(t *testing.T) {
@@ -26,71 +29,379 @@ func TestNatsClusterClient_TestSuite(t *testing.T) {
 
 func (t *NatsClusterClientTestSuite) SetupTest() {
 	t.ctx = context.Background()
-	t.clusterRef = domain.NewNamespacedName(testNamespace, sanitizeTestName(t.T().Name()))
+
+	namespace := scopedTestName("cluster-ns", t.T().Name())
+	t.clusterNsN = domain.NewNamespacedName(namespace, sanitizeTestName(t.T().Name()))
+	t.Require().NoError(t.clusterNsN.Validate())
+
+	t.clusterRef = nauth.ClusterRef(t.clusterNsN.String())
 	t.Require().NoError(t.clusterRef.Validate())
-	t.unitUnderTest = NewNatsClusterClient(k8sClient)
-	t.Require().NoError(cleanNatsCluster(t.ctx, t.clusterRef))
+
+	secretReader := NewSecretClient(k8sClient)
+	configMapReader := NewConfigMapClient(k8sClient)
+	t.unitUnderTest = NewClusterClient(k8sClient, secretReader, configMapReader)
 }
 
-func (t *NatsClusterClientTestSuite) TearDownTest() {
-	t.Require().NoError(cleanNatsCluster(t.ctx, t.clusterRef))
-}
-
-func (t *NatsClusterClientTestSuite) Test_Get_ShouldSucceed_WhenClusterExists() {
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldSucceed() {
 	// Given
-	want := &v1alpha1.NatsCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      t.clusterRef.Name,
-			Namespace: t.clusterRef.Namespace,
+	t.createNatsCluster(v1alpha1.NatsClusterSpec{
+		URL: "nats://nats:4222",
+		OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+			Name: "op-sign-secret",
+			Key:  "seed",
 		},
-		Spec: v1alpha1.NatsClusterSpec{
-			URL: "nats://nats:4222",
-			OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
-				Name: "operator-signing-key",
-				Key:  "seed",
-			},
-			SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
-				Name: "system-account-user-creds",
-				Key:  "user.creds",
-			},
+		SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+			Name: "sau-creds-secret",
+			Key:  "user.creds",
 		},
-	}
-	t.Require().NoError(k8sClient.Create(t.ctx, want))
+	})
+	testData := t.generateTestSecrets()
+	t.createSecret(t.clusterNsN.Namespace, "op-sign-secret", map[string]string{"seed": string(testData.opSignKeySeed)})
+	t.createSecret(t.clusterNsN.Namespace, "sau-creds-secret", map[string]string{"user.creds": string(testData.sauCredsData)})
 
 	// When
-	result, err := t.unitUnderTest.Get(t.ctx, t.clusterRef)
+	result, err := t.unitUnderTest.GetTarget(t.ctx, t.clusterRef)
 
 	// Then
 	t.NoError(err)
 	t.NotNil(result)
-	t.Equal(want.GetName(), result.GetName())
-	t.Equal(want.GetNamespace(), result.GetNamespace())
-	t.Equal(want.Spec, result.Spec)
+	t.Require().Equal(&nauth.ClusterTarget{
+		NatsURL:            "nats://nats:4222",
+		SystemAdminCreds:   testData.sauCreds,
+		OperatorSigningKey: testData.opSignKey,
+	}, result)
 }
 
-func (t *NatsClusterClientTestSuite) Test_Get_ShouldFail_WhenClusterDoesNotExist() {
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldSucceed_WhenSecretsUsingDefaultKey() {
 	// Given
-	missingClusterRef := domain.NewNamespacedName(testNamespace, "missing-cluster")
-	t.Require().NoError(missingClusterRef.Validate())
+	t.createNatsCluster(v1alpha1.NatsClusterSpec{
+		URL: "nats://nats:4222",
+		OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+			Name: "op-sign-secret",
+		},
+		SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+			Name: "sau-creds-secret",
+		},
+	})
+	testData := t.generateTestSecrets()
+	t.createSecret(t.clusterNsN.Namespace, "op-sign-secret", map[string]string{"default": string(testData.opSignKeySeed)})
+	t.createSecret(t.clusterNsN.Namespace, "sau-creds-secret", map[string]string{"default": string(testData.sauCredsData)})
 
 	// When
-	result, err := t.unitUnderTest.Get(t.ctx, missingClusterRef)
+	result, err := t.unitUnderTest.GetTarget(t.ctx, t.clusterRef)
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.Require().Equal(&nauth.ClusterTarget{
+		NatsURL:            "nats://nats:4222",
+		SystemAdminCreds:   testData.sauCreds,
+		OperatorSigningKey: testData.opSignKey,
+	}, result)
+}
+
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldSucceed_WhenNatsURLFromConfigMap() {
+	// Given
+	t.createNatsCluster(v1alpha1.NatsClusterSpec{
+		URLFrom: &v1alpha1.URLFromReference{
+			Kind: v1alpha1.URLFromKindConfigMap,
+			Name: "url-configmap",
+			Key:  "nats.url",
+		},
+		OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+			Name: "op-sign-secret",
+			Key:  "seed",
+		},
+		SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+			Name: "sau-creds-secret",
+			Key:  "user.creds",
+		},
+	})
+	testData := t.generateTestSecrets()
+	t.createConfigMap(t.clusterNsN.Namespace, "url-configmap", map[string]string{"nats.url": "nats://cm-cluster:4222"})
+	t.createSecret(t.clusterNsN.Namespace, "op-sign-secret", map[string]string{"seed": string(testData.opSignKeySeed)})
+	t.createSecret(t.clusterNsN.Namespace, "sau-creds-secret", map[string]string{"user.creds": string(testData.sauCredsData)})
+
+	// When
+	result, err := t.unitUnderTest.GetTarget(t.ctx, t.clusterRef)
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.Require().Equal(&nauth.ClusterTarget{
+		NatsURL:            "nats://cm-cluster:4222",
+		SystemAdminCreds:   testData.sauCreds,
+		OperatorSigningKey: testData.opSignKey,
+	}, result)
+}
+
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldSucceed_WhenNatsURLFromConfigMapWithExplicitNamespace() {
+	// Given
+	configNamespace := scopedTestName("config-ns", t.T().Name())
+	t.createNatsCluster(v1alpha1.NatsClusterSpec{
+		URLFrom: &v1alpha1.URLFromReference{
+			Kind:      v1alpha1.URLFromKindConfigMap,
+			Name:      "url-configmap",
+			Namespace: configNamespace, // Explicit namespace different from cluster resource namespace
+			Key:       "nats.url",
+		},
+		OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+			Name: "op-sign-secret",
+			Key:  "seed",
+		},
+		SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+			Name: "sau-creds-secret",
+			Key:  "user.creds",
+		},
+	})
+	testData := t.generateTestSecrets()
+	t.createConfigMap(configNamespace, "url-configmap", map[string]string{"nats.url": "nats://cm-cluster:4222"})
+	t.createSecret(t.clusterNsN.Namespace, "op-sign-secret", map[string]string{"seed": string(testData.opSignKeySeed)})
+	t.createSecret(t.clusterNsN.Namespace, "sau-creds-secret", map[string]string{"user.creds": string(testData.sauCredsData)})
+
+	// When
+	result, err := t.unitUnderTest.GetTarget(t.ctx, t.clusterRef)
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.Require().Equal(&nauth.ClusterTarget{
+		NatsURL:            "nats://cm-cluster:4222",
+		SystemAdminCreds:   testData.sauCreds,
+		OperatorSigningKey: testData.opSignKey,
+	}, result)
+}
+
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldSucceed_WhenNatsURLFromSecret() {
+	// Given
+	t.createNatsCluster(v1alpha1.NatsClusterSpec{
+		URLFrom: &v1alpha1.URLFromReference{
+			Kind: v1alpha1.URLFromKindSecret,
+			Name: "url-secret",
+			Key:  "nats.url",
+		},
+		OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+			Name: "op-sign-secret",
+			Key:  "seed",
+		},
+		SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+			Name: "sau-creds-secret",
+			Key:  "user.creds",
+		},
+	})
+	testData := t.generateTestSecrets()
+	t.createSecret(t.clusterNsN.Namespace, "url-secret", map[string]string{"nats.url": "nats://cm-cluster:4222"})
+	t.createSecret(t.clusterNsN.Namespace, "op-sign-secret", map[string]string{"seed": string(testData.opSignKeySeed)})
+	t.createSecret(t.clusterNsN.Namespace, "sau-creds-secret", map[string]string{"user.creds": string(testData.sauCredsData)})
+
+	// When
+	result, err := t.unitUnderTest.GetTarget(t.ctx, t.clusterRef)
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.Require().Equal(&nauth.ClusterTarget{
+		NatsURL:            "nats://cm-cluster:4222",
+		SystemAdminCreds:   testData.sauCreds,
+		OperatorSigningKey: testData.opSignKey,
+	}, result)
+}
+
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldSucceed_WhenNatsURLFromSecretWithExplicitNamespace() {
+	// Given
+	secretNamespace := scopedTestName("secret-ns", t.T().Name())
+	t.createNatsCluster(v1alpha1.NatsClusterSpec{
+		URLFrom: &v1alpha1.URLFromReference{
+			Kind:      v1alpha1.URLFromKindSecret,
+			Name:      "url-secret",
+			Namespace: secretNamespace, // Explicit namespace different from cluster resource namespace
+			Key:       "nats.url",
+		},
+		OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+			Name: "op-sign-secret",
+			Key:  "seed",
+		},
+		SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+			Name: "sau-creds-secret",
+			Key:  "user.creds",
+		},
+	})
+	testData := t.generateTestSecrets()
+	t.createSecret(secretNamespace, "url-secret", map[string]string{"nats.url": "nats://cm-cluster:4222"})
+	t.createSecret(t.clusterNsN.Namespace, "op-sign-secret", map[string]string{"seed": string(testData.opSignKeySeed)})
+	t.createSecret(t.clusterNsN.Namespace, "sau-creds-secret", map[string]string{"user.creds": string(testData.sauCredsData)})
+
+	// When
+	result, err := t.unitUnderTest.GetTarget(t.ctx, t.clusterRef)
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.Require().Equal(&nauth.ClusterTarget{
+		NatsURL:            "nats://cm-cluster:4222",
+		SystemAdminCreds:   testData.sauCreds,
+		OperatorSigningKey: testData.opSignKey,
+	}, result)
+}
+
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldSucceed_WhenAllDetailsInSameSecret() {
+	// Given
+	t.createNatsCluster(v1alpha1.NatsClusterSpec{
+		URLFrom: &v1alpha1.URLFromReference{
+			Kind: v1alpha1.URLFromKindSecret,
+			Name: "cluster-secret",
+			Key:  "nats-url",
+		},
+		OperatorSigningKeySecretRef: v1alpha1.SecretKeyReference{
+			Name: "cluster-secret",
+			Key:  "op-sign-seed",
+		},
+		SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{
+			Name: "cluster-secret",
+			Key:  "sau-creds",
+		},
+	})
+	testData := t.generateTestSecrets()
+	t.createSecret(t.clusterNsN.Namespace, "cluster-secret", map[string]string{
+		"nats-url":     "nats://cm-cluster:4222",
+		"op-sign-seed": string(testData.opSignKeySeed),
+		"sau-creds":    string(testData.sauCredsData),
+	})
+
+	// When
+	result, err := t.unitUnderTest.GetTarget(t.ctx, t.clusterRef)
+
+	// Then
+	t.NoError(err)
+	t.NotNil(result)
+	t.Require().Equal(&nauth.ClusterTarget{
+		NatsURL:            "nats://cm-cluster:4222",
+		SystemAdminCreds:   testData.sauCreds,
+		OperatorSigningKey: testData.opSignKey,
+	}, result)
+}
+
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldFail_WhenClusterRefIsNotNamespacedName() {
+	// Given
+	clusterRef := nauth.ClusterRef("not a namespaced name")
+
+	// When
+	result, err := t.unitUnderTest.GetTarget(t.ctx, clusterRef)
 
 	// Then
 	t.Error(err)
 	t.Nil(result)
-	t.ErrorContains(err, "failed getting NatsCluster "+testNamespace+"/missing-cluster")
+	t.ErrorContains(err, "invalid cluster reference \"not a namespaced name\" (expected NamespacedName):")
+}
+
+func (t *NatsClusterClientTestSuite) Test_GetTarget_ShouldFail_WhenNatsClusterResourceDoesNotExist() {
+	// Given
+	clusterRef := nauth.ClusterRef(testNamespace + "/missing-cluster")
+	t.Require().NoError(clusterRef.Validate())
+
+	// When
+	result, err := t.unitUnderTest.GetTarget(t.ctx, clusterRef)
+
+	// Then
+	t.Error(err)
+	t.Nil(result)
+	t.ErrorContains(err, "failed getting NatsCluster resource "+testNamespace+"/missing-cluster")
 	t.ErrorContains(err, "not found")
 }
 
-func cleanNatsCluster(ctx context.Context, clusterRef domain.NamespacedName) error {
-	cluster := &v1alpha1.NatsCluster{}
-	key := client.ObjectKey{Namespace: clusterRef.Namespace, Name: clusterRef.Name}
-	if err := k8sClient.Get(ctx, key, cluster); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
+func (t *NatsClusterClientTestSuite) Test_resolveNatsURL_ShouldFail_WhenURLAmbiguous() {
+	// Given
+	cluster := v1alpha1.NatsCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.clusterNsN.Name,
+			Namespace: t.clusterNsN.Namespace,
+		},
+		Spec: v1alpha1.NatsClusterSpec{
+			URL: "nats://cluster-1:4222",
+			URLFrom: &v1alpha1.URLFromReference{
+				Kind: v1alpha1.URLFromKindConfigMap,
+				Name: "url-configmap",
+				Key:  "nats.url",
+			},
+		},
 	}
-	return k8sClient.Delete(ctx, cluster)
+	t.createConfigMap(t.clusterNsN.Namespace, "url-configmap", map[string]string{"nats.url": "nats://cluster-2:4222"})
+
+	// When
+	url, err := t.unitUnderTest.resolveNatsURL(t.ctx, &cluster)
+
+	// Then
+	t.Empty(url)
+	t.ErrorContains(err, "ambiguous NATS URL, url and urlFrom reference resolve to different URLs (\"nats://cluster-1:4222\" vs \"nats://cluster-2:4222\")")
+}
+
+// Helpers
+
+func (t *NatsClusterClientTestSuite) createNatsCluster(spec v1alpha1.NatsClusterSpec) {
+	t.Require().NoError(ensureNamespace(t.ctx, t.clusterNsN.Namespace))
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.NatsCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.clusterNsN.Name,
+			Namespace: t.clusterNsN.Namespace,
+		},
+		Spec: spec,
+	}))
+}
+
+func (t *NatsClusterClientTestSuite) createConfigMap(namespace string, resourceName string, data map[string]string) {
+	t.Require().NoError(ensureNamespace(t.ctx, namespace))
+	t.Require().NoError(k8sClient.Create(t.ctx, &k8sv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: namespace,
+		},
+		Data: data,
+	}))
+}
+
+func (t *NatsClusterClientTestSuite) createSecret(namespace string, resourceName string, data map[string]string) {
+	t.Require().NoError(ensureNamespace(t.ctx, namespace))
+	t.Require().NoError(k8sClient.Create(t.ctx, &k8sv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceName,
+			Namespace: namespace,
+		},
+		StringData: data,
+	}))
+}
+
+type clusterTestSecrets struct {
+	opSignKeySeed []byte
+	opSignKey     domain.NatsOperatorSigningKey
+	sauCredsData  []byte
+	sauCreds      domain.NatsUserCreds
+}
+
+func (t *NatsClusterClientTestSuite) generateTestSecrets() clusterTestSecrets {
+	opSign, _ := nkeys.CreateOperator()
+	opSeed, _ := opSign.Seed()
+	opSignKey := domain.NatsOperatorSigningKey(opSign)
+
+	acKey, _ := nkeys.CreateAccount()
+	acKeyPub, _ := acKey.PublicKey()
+
+	sauKey, _ := nkeys.CreateUser()
+	sauKeySeed, _ := sauKey.Seed()
+	sauKeyPub, _ := sauKey.PublicKey()
+
+	sauClaims := jwt.NewUserClaims(sauKeyPub)
+	sauClaims.IssuerAccount = acKeyPub
+
+	sauJwt, err := sauClaims.Encode(acKey)
+	t.Require().Nilf(err, "failed to encode SAU JWT: %v", err)
+	sauCredsData, err := jwt.FormatUserConfig(sauJwt, sauKeySeed)
+	t.Require().Nilf(err, "failed to format SAU creds: %v", err)
+	sauCreds, err := domain.NewNatsUserCreds(sauCredsData)
+	t.Require().Nilf(err, "failed to create NatsUserCreds from SAU creds: %v", err)
+	return clusterTestSecrets{
+		opSignKeySeed: opSeed,
+		opSignKey:     opSignKey,
+		sauCredsData:  sauCredsData,
+		sauCreds:      *sauCreds,
+	}
 }

--- a/internal/adapter/outbound/k8s/secret_test.go
+++ b/internal/adapter/outbound/k8s/secret_test.go
@@ -3,11 +3,9 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/WirelessCar/nauth/internal/domain"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -162,13 +160,4 @@ func cleanSecret(ctx context.Context, secretRef domain.NamespacedName) error {
 	}
 
 	return k8sClient.Delete(ctx, k8sSecret)
-}
-
-func sanitizeTestName(name string) string {
-	replacer := strings.NewReplacer("/", "-", " ", "-", ":", "-", "#", "-", "_", "-")
-	return strings.ToLower(replacer.Replace(name))
-}
-
-func TestSanitizeTestName(t *testing.T) {
-	require.Equal(t, "test-name", sanitizeTestName("Test Name"))
 }

--- a/internal/adapter/outbound/k8s/suite_test.go
+++ b/internal/adapter/outbound/k8s/suite_test.go
@@ -18,8 +18,11 @@ package k8s
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -114,4 +117,41 @@ func getFirstFoundEnvTestBinaryDir() string {
 		}
 	}
 	return ""
+}
+
+func sanitizeTestName(name string) string {
+	replacer := strings.NewReplacer("/", "-", " ", "-", ":", "-", "#", "-", "_", "-")
+	return strings.ToLower(replacer.Replace(name))
+}
+
+func scopedTestName(prefix, testName string) string {
+	slug := sanitizeTestName(testName)
+	hash := shortHash(testName)
+	maxSlugLen := 63 - len(prefix) - len(hash) - 2
+	if maxSlugLen < 1 {
+		return prefix + "-" + hash
+	}
+	if len(slug) > maxSlugLen {
+		slug = slug[:maxSlugLen]
+	}
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		return prefix + "-" + hash
+	}
+	return prefix + "-" + slug + "-" + hash
+}
+
+func shortHash(value string) string {
+	sum := md5.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])[:6]
+}
+
+func ensureNamespace(ctx context.Context, namespace string) error {
+	err := k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
 }

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -374,7 +374,7 @@ func (a *AccountManager) Delete(ctx context.Context, state *v1alpha1.Account) er
 	return nil
 }
 
-func (a *AccountManager) listAccountStreams(cluster *clusterTarget, accountSecrets *Secrets, accountID string) ([]string, error) {
+func (a *AccountManager) listAccountStreams(cluster *nauth.ClusterTarget, accountSecrets *Secrets, accountID string) ([]string, error) {
 	tempUserCreds, err := createTempJetStreamCreds(accountID, accountSecrets.Root)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary account JetStream credentials: %w", err)
@@ -471,14 +471,24 @@ func (a *AccountManager) SignUserJWT(ctx context.Context, accountRef domain.Name
 	}, nil
 }
 
-func (a *AccountManager) resolveClusterTarget(ctx context.Context, account *v1alpha1.Account) (*clusterTarget, error) {
+// TODO: [#11] Migrate from API- to domain model
+func (a *AccountManager) resolveClusterTarget(ctx context.Context, account *v1alpha1.Account) (*nauth.ClusterTarget, error) {
+	var optAccClusterRef *nauth.ClusterRef
 	natsClusterRef := account.Spec.NatsClusterRef
-	if natsClusterRef != nil && natsClusterRef.Namespace == "" {
-		natsClusterRef = natsClusterRef.DeepCopy()
-		natsClusterRef.Namespace = account.GetNamespace()
+	if natsClusterRef != nil {
+		namespace := natsClusterRef.Namespace
+		if namespace == "" {
+			namespace = account.GetNamespace()
+		}
+		namespacedName := domain.NewNamespacedName(namespace, natsClusterRef.Name)
+		clusterRef, err := nauth.NewClusterRef(namespacedName.String())
+		if err != nil {
+			return nil, fmt.Errorf("invalid account NatsClusterRef %q: %w", namespacedName, err)
+		}
+		optAccClusterRef = &clusterRef
 	}
 
-	return a.clusterTargetResolver.GetClusterTarget(ctx, natsClusterRef)
+	return a.clusterTargetResolver.GetClusterTarget(ctx, optAccClusterRef)
 }
 
 func getDisplayName(account *v1alpha1.Account) string {

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -25,7 +25,8 @@ type AccountManagerTestSuite struct {
 	keys          testKeys
 	sauCreds      domain.NatsUserCreds
 	natsURL       string
-	clusterTarget clusterTarget
+	clusterRef    nauth.ClusterRef
+	clusterTarget nauth.ClusterTarget
 
 	accountReaderMock         *AccountReaderMock
 	natsSysClientMock         *NatsSysClientMock
@@ -47,7 +48,8 @@ func (t *AccountManagerTestSuite) SetupTest() {
 		AccountID: "FAKE_SYS_ACCOUNT_ID",
 	}
 	t.natsURL = "nats://nats:4222"
-	t.clusterTarget = clusterTarget{
+	t.clusterRef = "account-namespace/account-namespace-cluster"
+	t.clusterTarget = nauth.ClusterTarget{
 		NatsURL:            t.natsURL,
 		OperatorSigningKey: t.keys.OpSign.KeyPair,
 		SystemAdminCreds:   t.sauCreds,
@@ -166,10 +168,7 @@ func (t *AccountManagerTestSuite) Test_Create_ShouldSucceed_WhenAccountExplicitC
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
 	natsLimitsSubs := int64(100)
 
-	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, &v1alpha1.NatsClusterRef{
-		Namespace: "account-namespace",
-		Name:      "account-namespace-cluster",
-	}, &t.clusterTarget)
+	t.clusterTargetResolverMock.mockGetClusterTarget(t.ctx, &t.clusterRef, &t.clusterTarget)
 	t.secretManagerMock.mockGetSecretsMissing(t.ctx, accountRef, "")
 	t.secretManagerMock.mockApplyRootSecretUnknown(t.ctx, accountRef, func(rootKeyPair nkeys.KeyPair) {
 		caughtRootKeyPair = rootKeyPair
@@ -984,17 +983,17 @@ func newClusterTargetResolverMock() *clusterTargetResolverMock {
 	return &clusterTargetResolverMock{}
 }
 
-func (m *clusterTargetResolverMock) GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*clusterTarget, error) {
+func (m *clusterTargetResolverMock) GetClusterTarget(ctx context.Context, accountClusterRef *nauth.ClusterRef) (*nauth.ClusterTarget, error) {
 	args := m.Called(ctx, accountClusterRef)
-	return args.Get(0).(*clusterTarget), args.Error(1)
+	return args.Get(0).(*nauth.ClusterTarget), args.Error(1)
 }
 
-func (m *clusterTargetResolverMock) mockGetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef, result *clusterTarget) {
+func (m *clusterTargetResolverMock) mockGetClusterTarget(ctx context.Context, accountClusterRef *nauth.ClusterRef, result *nauth.ClusterTarget) {
 	m.On("GetClusterTarget", ctx, accountClusterRef).Return(result, nil)
 }
 
-func (m *clusterTargetResolverMock) mockGetClusterTargetError(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef, err error) {
-	m.On("GetClusterTarget", ctx, accountClusterRef).Return((*clusterTarget)(nil), err)
+func (m *clusterTargetResolverMock) mockGetClusterTargetError(ctx context.Context, accountClusterRef *nauth.ClusterRef, err error) {
+	m.On("GetClusterTarget", ctx, accountClusterRef).Return((*nauth.ClusterTarget)(nil), err)
 }
 
 var _ clusterTargetResolver = (*clusterTargetResolverMock)(nil)

--- a/internal/core/cluster.go
+++ b/internal/core/cluster.go
@@ -4,85 +4,37 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/adapter/outbound/k8s" // TODO: [#185] Core must not depend on adapter code
-	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
 	"github.com/WirelessCar/nauth/internal/ports/outbound"
-	"github.com/nats-io/nkeys"
 )
 
-type clusterTarget struct {
-	NatsURL            string
-	SystemAdminCreds   domain.NatsUserCreds
-	OperatorSigningKey domain.NatsOperatorSigningKey
-}
-
-func (c *clusterTarget) validate() error {
-	if c.NatsURL == "" {
-		return fmt.Errorf("NATS URL is required")
-	}
-	if err := c.SystemAdminCreds.Validate(); err != nil {
-		return fmt.Errorf("invalid system admin credentials: %w", err)
-	}
-	if c.OperatorSigningKey == nil {
-		return fmt.Errorf("operator signing key is required")
-	}
-	return nil
-}
-
-func newClusterTarget(natsURL string, systemAdminCreds domain.NatsUserCreds, operatorSigningKey domain.NatsOperatorSigningKey) (*clusterTarget, error) {
-	result := &clusterTarget{
-		NatsURL:            natsURL,
-		SystemAdminCreds:   systemAdminCreds,
-		OperatorSigningKey: operatorSigningKey,
-	}
-
-	if err := result.validate(); err != nil {
-		return nil, fmt.Errorf("invalid clusterTarget: %w", err)
-	}
-
-	return result, nil
-}
-
 type clusterTargetResolver interface {
-	GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*clusterTarget, error)
+	GetClusterTarget(ctx context.Context, accountClusterRef *nauth.ClusterRef) (*nauth.ClusterTarget, error)
 }
 
 type ClusterManager struct {
-	natsClusterReader outbound.NatsClusterReader
-	natsSysClient     outbound.NatsSysClient
-	secretReader      outbound.SecretReader
-	configMapReader   outbound.ConfigMapReader
-	config            *Config
+	clusterReader outbound.ClusterReader
+	natsSysClient outbound.NatsSysClient
+	config        *Config
 }
 
 func NewClusterManager(
-	natsClusterReader outbound.NatsClusterReader,
+	clusterReader outbound.ClusterReader,
 	natsSysClient outbound.NatsSysClient,
-	secretReader outbound.SecretReader,
-	configMapReader outbound.ConfigMapReader,
 	config *Config,
 ) (*ClusterManager, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
-	if config.OperatorNatsCluster != nil {
-		opClusterRef := domain.NewNamespacedName(
-			config.OperatorNatsCluster.ClusterRef.Namespace,
-			config.OperatorNatsCluster.ClusterRef.Name,
-		)
-		if err := opClusterRef.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid operator cluster reference: %v", err)
-		}
+	if err := config.validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
 	impl := &ClusterManager{
-		natsClusterReader: natsClusterReader,
-		natsSysClient:     natsSysClient,
-		secretReader:      secretReader,
-		configMapReader:   configMapReader,
-		config:            config,
+		clusterReader: clusterReader,
+		natsSysClient: natsSysClient,
+		config:        config,
 	}
 	if err := impl.validate(); err != nil {
 		return nil, fmt.Errorf("invalid ClusterManager: %w", err)
@@ -91,17 +43,11 @@ func NewClusterManager(
 }
 
 func (r *ClusterManager) validate() error {
-	if r.natsClusterReader == nil {
-		return fmt.Errorf("natsClusterReader is required")
+	if r.clusterReader == nil {
+		return fmt.Errorf("clusterReader is required")
 	}
 	if r.natsSysClient == nil {
 		return fmt.Errorf("natsSysClient is required")
-	}
-	if r.secretReader == nil {
-		return fmt.Errorf("secretReader is required")
-	}
-	if r.configMapReader == nil {
-		return fmt.Errorf("configMapReader is required")
 	}
 	if r.config == nil {
 		return fmt.Errorf("config is required")
@@ -109,18 +55,9 @@ func (r *ClusterManager) validate() error {
 	return nil
 }
 
-func (r *ClusterManager) Validate(ctx context.Context, state *v1alpha1.NatsCluster) error {
-	if state == nil {
-		return fmt.Errorf("NatsCluster is required")
-	}
-
-	if err := domain.NewNamespacedName(state.Namespace, state.Name).Validate(); err != nil {
-		return fmt.Errorf("invalid NatsCluster namespaced name: %w", err)
-	}
-
-	target, err := r.resolveTargetFromCluster(ctx, state)
-	if err != nil {
-		return err
+func (r *ClusterManager) Validate(ctx context.Context, target nauth.ClusterTarget) error {
+	if err := target.Validate(); err != nil {
+		return fmt.Errorf("invalid cluster target: %w", err)
 	}
 
 	sysConn, err := r.natsSysClient.Connect(target.NatsURL, target.SystemAdminCreds)
@@ -132,179 +69,62 @@ func (r *ClusterManager) Validate(ctx context.Context, state *v1alpha1.NatsClust
 	if err := sysConn.VerifySystemAccountAccess(); err != nil {
 		return fmt.Errorf("verify NATS System Account access: %w", err)
 	}
-
 	return nil
 }
 
-func (r *ClusterManager) GetClusterTarget(ctx context.Context, accountClusterRef *v1alpha1.NatsClusterRef) (*clusterTarget, error) {
-	var result *clusterTarget
-	var err error
-	if accountClusterRef != nil {
-		acClusterRef := domain.NewNamespacedName(accountClusterRef.Namespace, accountClusterRef.Name)
-		if err = acClusterRef.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid account cluster reference: %v", err)
-		}
-		err = r.validateAccountClusterRef(acClusterRef)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cluster reference: %v", err)
-		}
-		result, err = r.resolveTarget(ctx, acClusterRef)
-	} else if opClusterRef := r.operatorClusterRef(); opClusterRef != nil {
-		result, err = r.resolveTarget(ctx, *opClusterRef)
-	} else {
-		return nil, fmt.Errorf("no cluster reference provided and no operator cluster configured")
-	}
+func (r *ClusterManager) GetClusterTarget(ctx context.Context, accountClusterRef *nauth.ClusterRef) (*nauth.ClusterTarget, error) {
+	opClusterRef, opClusterRequired := r.opClusterConfig()
+	clusterRef, err := getEffectiveClusterRef(accountClusterRef, opClusterRef, opClusterRequired)
 	if err != nil {
-		return nil, fmt.Errorf("resolve cluster target: %w", err)
+		return nil, err
 	}
-	if err = result.validate(); err != nil {
+	result, err := r.clusterReader.GetTarget(ctx, *clusterRef)
+
+	if err != nil {
+		return nil, fmt.Errorf("resolve cluster target %q: %w", *clusterRef, err)
+	}
+	if err = result.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid cluster target: %w", err)
 	}
 	return result, nil
 }
 
-func (r *ClusterManager) resolveTarget(ctx context.Context, clusterRef domain.NamespacedName) (*clusterTarget, error) {
-	cluster, err := r.natsClusterReader.Get(ctx, clusterRef)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve NATS cluster %s: %w", clusterRef, err)
+func (r *ClusterManager) opClusterConfig() (clusterRef *nauth.ClusterRef, required bool) {
+	if r.config == nil {
+		return nil, false
 	}
-
-	target, err := r.resolveTargetFromCluster(ctx, cluster)
-	if err != nil {
-		return nil, err
+	cluster := r.config.OperatorNatsCluster
+	if cluster == nil {
+		return nil, false
 	}
-
-	return target, nil
+	clusterRef = &cluster.ClusterRef
+	required = !cluster.Optional
+	return
 }
 
-func (r *ClusterManager) resolveTargetFromCluster(ctx context.Context, cluster *v1alpha1.NatsCluster) (*clusterTarget, error) {
-	clusterRef := domain.NewNamespacedName(cluster.GetNamespace(), cluster.GetName())
-	natsURL, err := r.resolveNatsURL(ctx, cluster)
-	if err != nil {
-		return nil, fmt.Errorf("resolve NATS URL for NatsCluster %s: %w", clusterRef, err)
-	}
-	sysAdminCreds, err := r.resolveSysAdminCreds(ctx, cluster)
-	if err != nil {
-		return nil, fmt.Errorf("resolve system account user creds for NatsCluster %s: %w", clusterRef, err)
-	}
-	opSigningKey, err := r.resolveOperatorSigningKey(ctx, cluster)
-	if err != nil {
-		return nil, fmt.Errorf("resolve operator signing key for NatsCluster %s: %w", clusterRef, err)
-	}
-	target, err := newClusterTarget(natsURL, *sysAdminCreds, opSigningKey)
-	if err != nil {
-		return nil, fmt.Errorf("create cluster target for NatsCluster %s: %w", clusterRef, err)
-	}
-	return target, nil
-}
-
-func (r *ClusterManager) resolveSysAdminCreds(ctx context.Context, cluster *v1alpha1.NatsCluster) (*domain.NatsUserCreds, error) {
-	secretKeyRef := cluster.Spec.SystemAccountUserCredsSecretRef
-	secretRef := domain.NewNamespacedName(cluster.GetNamespace(), secretKeyRef.Name)
-	creds, err := r.resolveSecret(ctx, secretRef, secretKeyRef.Key)
-	if err != nil {
-		return nil, err
-	}
-	userCreds, err := domain.NewNatsUserCreds(creds)
-	if err != nil {
-		return nil, fmt.Errorf("invalid user creds: %w", err)
-	}
-	return userCreds, nil
-}
-
-func (r *ClusterManager) resolveOperatorSigningKey(ctx context.Context, cluster *v1alpha1.NatsCluster) (domain.NatsOperatorSigningKey, error) {
-	secretKeyRef := cluster.Spec.OperatorSigningKeySecretRef
-	secretRef := domain.NewNamespacedName(cluster.GetNamespace(), secretKeyRef.Name)
-	keyData, err := r.resolveSecret(ctx, secretRef, secretKeyRef.Key)
-	if err != nil {
-		return nil, err
-	}
-	opSigningKey, err := nkeys.FromSeed(keyData)
-	if err != nil {
-		return nil, fmt.Errorf("invalid operator signing key: %w", err)
-	}
-	return opSigningKey, nil
-}
-
-func (r *ClusterManager) resolveSecret(ctx context.Context, namespacedName domain.NamespacedName, key string) ([]byte, error) {
-	secretData, found, err := r.secretReader.Get(ctx, namespacedName)
-	if err != nil {
-		return nil, fmt.Errorf("resolve secret %s: %w", namespacedName, err)
-	}
-	if !found {
-		return nil, fmt.Errorf("secret %s not found", namespacedName)
-	}
-
-	if key == "" {
-		key = k8s.DefaultSecretKeyName
-	}
-
-	value, ok := secretData[key]
-	if !ok {
-		return nil, fmt.Errorf("secret %s does not contain key %q", namespacedName, key)
-	}
-
-	return []byte(value), nil
-}
-
-func (r *ClusterManager) resolveNatsURL(ctx context.Context, cluster *v1alpha1.NatsCluster) (string, error) {
-	if cluster.Spec.URL != "" {
-		return cluster.Spec.URL, nil
-	}
-
-	if cluster.Spec.URLFrom != nil {
-		urlFromRef := cluster.Spec.URLFrom
-		resourceRef := domain.NewNamespacedName(urlFromRef.Namespace, urlFromRef.Name)
-		if resourceRef.Namespace == "" {
-			resourceRef.Namespace = cluster.GetNamespace()
+func getEffectiveClusterRef(accClusterRef *nauth.ClusterRef, opClusterRef *nauth.ClusterRef, opClusterRequired bool) (*nauth.ClusterRef, error) {
+	if accClusterRef != nil {
+		if err := accClusterRef.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid account cluster ref: %w", err)
 		}
-
-		switch urlFromRef.Kind {
-		case v1alpha1.URLFromKindConfigMap:
-			data, err := r.configMapReader.Get(ctx, resourceRef)
-			if err != nil {
-				return "", fmt.Errorf("get ConfigMap %s: %w", resourceRef, err)
+		if opClusterRef != nil && opClusterRequired {
+			if err := opClusterRef.Validate(); err != nil {
+				return nil, fmt.Errorf("invalid operator cluster ref: %w", err)
 			}
-			if natsURL, ok := data[urlFromRef.Key]; ok {
-				return natsURL, nil
+			if *opClusterRef != *accClusterRef {
+				return nil, fmt.Errorf("account cluster reference %s does not match required operator cluster %s", *accClusterRef, *opClusterRef)
 			}
-			return "", fmt.Errorf("configMap %s has no key %q", resourceRef, urlFromRef.Key)
-		case v1alpha1.URLFromKindSecret:
-			data, found, err := r.secretReader.Get(ctx, resourceRef)
-			if err != nil {
-				return "", fmt.Errorf("get Secret %s: %w", resourceRef, err)
-			}
-			if !found {
-				return "", fmt.Errorf("secret %s not found", resourceRef)
-			}
-			if natsURL, ok := data[urlFromRef.Key]; ok {
-				return natsURL, nil
-			}
-			return "", fmt.Errorf("secret %s has no key %q", resourceRef, urlFromRef.Key)
-		default:
-			return "", fmt.Errorf("unsupported urlFrom.kind %q", urlFromRef.Kind)
 		}
+		return accClusterRef, nil
 	}
-
-	return "", fmt.Errorf("neither url nor urlFrom is set")
-}
-
-func (r *ClusterManager) validateAccountClusterRef(accountClusterRef domain.NamespacedName) error {
-	opClusterRef := r.operatorClusterRef()
-	if opClusterRef != nil && !r.config.OperatorNatsCluster.Optional && !opClusterRef.Equals(accountClusterRef) {
-		return fmt.Errorf("account cluster reference %s does not match required operator cluster %s", accountClusterRef, opClusterRef)
+	if opClusterRef != nil {
+		if err := opClusterRef.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid operator cluster ref: %w", err)
+		}
+		return opClusterRef, nil
 	}
-
-	return nil
-}
-
-func (r *ClusterManager) operatorClusterRef() *domain.NamespacedName {
-	if r.config == nil || r.config.OperatorNatsCluster == nil {
-		return nil
-	}
-	result := domain.NewNamespacedName(r.config.OperatorNatsCluster.ClusterRef.Namespace, r.config.OperatorNatsCluster.ClusterRef.Name)
-	return &result
+	return nil, fmt.Errorf("no cluster reference provided and no operator cluster configured")
 }
 
 var _ clusterTargetResolver = (*ClusterManager)(nil)
-var _ inbound.NatsClusterManager = (*ClusterManager)(nil)
+var _ inbound.ClusterManager = (*ClusterManager)(nil)

--- a/internal/core/cluster_test.go
+++ b/internal/core/cluster_test.go
@@ -5,73 +5,46 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/adapter/outbound/k8s" // TODO: [#185] Core must not depend on adapter code
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ClusterTestSuite struct {
 	suite.Suite
-	ctx                     context.Context
-	natsClusterResolverMock *NatsClusterReaderMock
-	natsSysClientMock       *NatsSysClientMock
-	natsSysConnMock         *NatsSysConnectionMock
-	secretClientMock        *SecretClientMock
-	configMapResolverMock   *ConfigMapReaderMock
+	ctx               context.Context
+	clusterReaderMock *ClusterReaderMock
+	natsSysClientMock *NatsSysClientMock
+	natsSysConnMock   *NatsSysConnectionMock
 }
 
 func (t *ClusterTestSuite) SetupTest() {
 	t.ctx = context.Background()
-	t.natsClusterResolverMock = NewNatsClusterReaderMock()
+	t.clusterReaderMock = NewClusterReaderMock()
 	t.natsSysClientMock = NewNatsSysClientMock()
 	t.natsSysConnMock = NewNatsSysConnectionMock()
-	t.secretClientMock = NewSecretClientMock()
-	t.configMapResolverMock = NewConfigMapReaderMock()
 }
 
 func (t *ClusterTestSuite) TearDownTest() {
-	t.natsClusterResolverMock.AssertExpectations(t.T())
+	t.clusterReaderMock.AssertExpectations(t.T())
 	t.natsSysClientMock.AssertExpectations(t.T())
 	t.natsSysConnMock.AssertExpectations(t.T())
-	t.secretClientMock.AssertExpectations(t.T())
-	t.configMapResolverMock.AssertExpectations(t.T())
 }
 
 func TestClusterManager_TestSuite(t *testing.T) {
 	suite.Run(t, new(ClusterTestSuite))
 }
 
-func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenOperatorClusterRef() {
+func (t *ClusterTestSuite) Test_ResolveClusterTarget_ShouldSucceed_WhenOperatorClusterRef() {
 	// Given
-	opClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "my-namespace",
-		Name:      "my-cluster",
-	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats")
+	opClusterRef := nauth.ClusterRef("my-namespace/my-cluster")
+	unitUnderTest := t.newUnitUnderTest(&opClusterRef, false, "nats")
 
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-	t.natsClusterResolverMock.mockGetNatsCluster(t.ctx, domain.NewNamespacedName("my-namespace", "my-cluster"),
-		&v1alpha1.NatsCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "my-namespace",
-				Name:      "my-cluster",
-			},
-			Spec: v1alpha1.NatsClusterSpec{
-				URL:                             "nats://my-cluster:4222",
-				OperatorSigningKeySecretRef:     v1alpha1.SecretKeyReference{Name: "op-sign-secret"},
-				SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{Name: "sau-creds"},
-			},
-		})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "op-sign-secret"),
-		map[string]string{k8s.DefaultSecretKeyName: string(opSignSeed)})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
+	opClusterTarget := t.generateClusterTarget()
+	t.clusterReaderMock.mockGetTarget(t.ctx, "my-namespace/my-cluster", &opClusterTarget)
 
 	// When
 	result, err := unitUnderTest.GetClusterTarget(t.ctx, nil)
@@ -79,174 +52,88 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenOperatorClust
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
-		NatsURL:            "nats://my-cluster:4222",
-		SystemAdminCreds:   sauCreds,
-		OperatorSigningKey: opSignKey,
-	}, result)
+	require.Equal(t.T(), &opClusterTarget, result)
 }
 
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountClusterRef() {
 	// Given´
 	unitUnderTest := t.newUnitUnderTest(nil, false, "nats")
 
-	acClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "ac-namespace",
-		Name:      "ac-cluster",
-	}
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-	t.natsClusterResolverMock.mockGetNatsCluster(t.ctx, domain.NewNamespacedName("ac-namespace", "ac-cluster"),
-		&v1alpha1.NatsCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "ac-namespace",
-				Name:      "ac-cluster",
-			},
-			Spec: v1alpha1.NatsClusterSpec{
-				URL:                             "nats://ac-cluster:4222",
-				OperatorSigningKeySecretRef:     v1alpha1.SecretKeyReference{Name: "op-sign-secret"},
-				SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{Name: "sau-creds"},
-			},
-		})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("ac-namespace", "op-sign-secret"),
-		map[string]string{k8s.DefaultSecretKeyName: string(opSignSeed)})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("ac-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
+	acClusterRef, err := nauth.NewClusterRef("ac-namespace/ac-cluster")
+	require.NoError(t.T(), err)
+	acClusterTarget := t.generateClusterTarget()
+	t.clusterReaderMock.mockGetTarget(t.ctx, "ac-namespace/ac-cluster", &acClusterTarget)
 
 	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, acClusterRef)
+	result, err := unitUnderTest.GetClusterTarget(t.ctx, &acClusterRef)
 
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
-		NatsURL:            "nats://ac-cluster:4222",
-		SystemAdminCreds:   sauCreds,
-		OperatorSigningKey: opSignKey,
-	}, result)
+	require.Equal(t.T(), acClusterTarget, *result)
 }
 
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountClusterRefSameAsNonOptionalOperatorClusterRef() {
 	// Given
-	clusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "my-namespace",
-		Name:      "my-cluster",
-	}
-	unitUnderTest := t.newUnitUnderTest(clusterRef, false, "nats")
+	clusterRef := nauth.ClusterRef("my-namespace/my-cluster")
+	clusterTarget := t.generateClusterTarget()
+	t.clusterReaderMock.mockGetTarget(t.ctx, "my-namespace/my-cluster", &clusterTarget).Once()
 
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-	t.natsClusterResolverMock.mockGetNatsCluster(t.ctx, domain.NewNamespacedName("my-namespace", "my-cluster"),
-		&v1alpha1.NatsCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "my-namespace",
-				Name:      "my-cluster",
-			},
-			Spec: v1alpha1.NatsClusterSpec{
-				URL:                             "nats://my-cluster:4222",
-				OperatorSigningKeySecretRef:     v1alpha1.SecretKeyReference{Name: "op-sign-secret"},
-				SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{Name: "sau-creds"},
-			},
-		})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "op-sign-secret"),
-		map[string]string{k8s.DefaultSecretKeyName: string(opSignSeed)})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
+	unitUnderTest := t.newUnitUnderTest(&clusterRef, false, "nats")
 
 	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, clusterRef)
+	result, err := unitUnderTest.GetClusterTarget(t.ctx, &clusterRef)
 
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
-		NatsURL:            "nats://my-cluster:4222",
-		SystemAdminCreds:   sauCreds,
-		OperatorSigningKey: opSignKey,
-	}, result)
+	require.Equal(t.T(), &clusterTarget, result)
 }
 
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldSucceed_WhenAccountClusterRefDifferentFromOptionalOperatorClusterRef() {
 	// Given
-	opClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "op-namespace",
-		Name:      "op-cluster",
-	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, true, "nats")
+	opClusterRef := nauth.ClusterRef("op-namespace/op-cluster")
+	unitUnderTest := t.newUnitUnderTest(&opClusterRef, true, "nats")
 
-	acClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "ac-namespace",
-		Name:      "ac-cluster",
-	}
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-	t.natsClusterResolverMock.mockGetNatsCluster(t.ctx, domain.NewNamespacedName("ac-namespace", "ac-cluster"),
-		&v1alpha1.NatsCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "ac-namespace",
-				Name:      "ac-cluster",
-			},
-			Spec: v1alpha1.NatsClusterSpec{
-				URL:                             "nats://ac-cluster:4222",
-				OperatorSigningKeySecretRef:     v1alpha1.SecretKeyReference{Name: "op-sign-secret"},
-				SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{Name: "sau-creds"},
-			},
-		})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("ac-namespace", "op-sign-secret"),
-		map[string]string{k8s.DefaultSecretKeyName: string(opSignSeed)})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("ac-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
+	acClusterRef := nauth.ClusterRef("ac-namespace/ac-cluster")
+	acClusterTarget := t.generateClusterTarget()
+	t.clusterReaderMock.mockGetTarget(t.ctx, acClusterRef, &acClusterTarget)
 
 	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, acClusterRef)
+	result, err := unitUnderTest.GetClusterTarget(t.ctx, &acClusterRef)
 
 	// Then
 	require.NoError(t.T(), err)
 	require.NotNil(t.T(), result)
-	require.Equal(t.T(), &clusterTarget{
-		NatsURL:            "nats://ac-cluster:4222",
-		SystemAdminCreds:   sauCreds,
-		OperatorSigningKey: opSignKey,
-	}, result)
+	require.Equal(t.T(), &acClusterTarget, result)
 }
 
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenAccountClusterRefDifferentFromNonOptionalOperatorClusterRef() {
 	// Given
-	opClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "op-namespace",
-		Name:      "op-cluster",
-	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats")
-
-	acClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "ac-namespace",
-		Name:      "ac-cluster",
-	}
+	opClusterRef := nauth.ClusterRef("op-namespace/op-cluster")
+	unitUnderTest := t.newUnitUnderTest(&opClusterRef, false, "nats")
+	acClusterRef := nauth.ClusterRef("ac-namespace/ac-cluster")
 
 	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, acClusterRef)
+	result, err := unitUnderTest.GetClusterTarget(t.ctx, &acClusterRef)
 
 	// Then
-	require.ErrorContains(t.T(), err, "invalid cluster reference: account cluster reference ac-namespace/ac-cluster does not match required operator cluster op-namespace/op-cluster")
+	require.ErrorContains(t.T(), err, "account cluster reference ac-namespace/ac-cluster does not match required operator cluster op-namespace/op-cluster")
 	require.Nil(t.T(), result)
 }
 
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenOperatorClusterNotFound() {
 	// Given
-	opClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "my-namespace",
-		Name:      "my-cluster",
-	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, false, "nats")
-
-	t.natsClusterResolverMock.mockGetNatsClusterError(t.ctx, domain.NewNamespacedName("my-namespace", "my-cluster"),
-		fmt.Errorf("the root cause"))
+	opClusterRef := nauth.ClusterRef("my-namespace/my-cluster")
+	unitUnderTest := t.newUnitUnderTest(&opClusterRef, false, "nats")
+	acClusterRef := nauth.ClusterRef("my-namespace/my-cluster")
+	t.clusterReaderMock.mockGetTargetError(t.ctx, acClusterRef, fmt.Errorf("fake not found"))
 
 	// When
 	result, err := unitUnderTest.GetClusterTarget(t.ctx, nil)
 
 	// Then
-	require.ErrorContains(t.T(), err, "resolve cluster target: failed to resolve NATS cluster my-namespace/my-cluster: the root cause")
+	require.ErrorContains(t.T(), err, "resolve cluster target \"my-namespace/my-cluster\": fake not found")
 	require.Nil(t.T(), result)
 }
 
@@ -264,24 +151,16 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenNeitherAccountNo
 
 func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenAccountClusterNotFound() {
 	// Given
-	opClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "op-namespace",
-		Name:      "op-cluster",
-	}
-	unitUnderTest := t.newUnitUnderTest(opClusterRef, true, "nats")
-
-	acClusterRef := &v1alpha1.NatsClusterRef{
-		Namespace: "ac-namespace",
-		Name:      "ac-cluster",
-	}
-	t.natsClusterResolverMock.mockGetNatsClusterError(t.ctx, domain.NewNamespacedName("ac-namespace", "ac-cluster"),
-		fmt.Errorf("the root cause"))
+	opClusterRef := nauth.ClusterRef("op-namespace/op-cluster")
+	unitUnderTest := t.newUnitUnderTest(&opClusterRef, true, "nats")
+	acClusterRef := nauth.ClusterRef("ac-namespace/ac-cluster")
+	t.clusterReaderMock.mockGetTargetError(t.ctx, acClusterRef, fmt.Errorf("fake not found"))
 
 	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, acClusterRef)
+	result, err := unitUnderTest.GetClusterTarget(t.ctx, &acClusterRef)
 
 	// Then
-	require.ErrorContains(t.T(), err, "resolve cluster target: failed to resolve NATS cluster ac-namespace/ac-cluster: the root cause")
+	require.ErrorContains(t.T(), err, "resolve cluster target \"ac-namespace/ac-cluster\": fake not found")
 	require.Nil(t.T(), result)
 }
 
@@ -289,175 +168,28 @@ func (t *ClusterTestSuite) Test_GetClusterTarget_ShouldFail_WhenAccountClusterRe
 	// Given
 	unitUnderTest := t.newUnitUnderTestWithDefaults()
 
-	acClusterRef := &v1alpha1.NatsClusterRef{
-		Name: "ac-cluster",
-	}
+	acClusterRef := nauth.ClusterRef("ac-cluster")
 
 	// When
-	result, err := unitUnderTest.GetClusterTarget(t.ctx, acClusterRef)
+	result, err := unitUnderTest.GetClusterTarget(t.ctx, &acClusterRef)
 
 	// Then
-	require.ErrorContains(t.T(), err, "invalid account cluster reference: namespace required")
+	require.ErrorContains(t.T(), err, "invalid account cluster ref:")
+	require.ErrorContains(t.T(), err, "invalid cluster ref \"ac-cluster\" (expected NamespacedName):")
+	require.ErrorContains(t.T(), err, "invalid Namespaced Name format \"ac-cluster\": expected namespace/name")
 	require.Nil(t.T(), result)
-}
-
-func (t *ClusterTestSuite) Test_resolveNatsURL_ShouldSucceed_FromConfigMap() {
-	// Given
-	unitUnderTest := t.newUnitUnderTestWithDefaults()
-
-	t.configMapResolverMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "my-config"),
-		map[string]string{"theNatsURL": "nats://custom-nats:4222"})
-
-	// When
-	result, err := unitUnderTest.resolveNatsURL(t.ctx, &v1alpha1.NatsCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "my-namespace",
-			Name:      "my-cluster",
-		},
-		Spec: v1alpha1.NatsClusterSpec{
-			URLFrom: &v1alpha1.URLFromReference{
-				Kind: v1alpha1.URLFromKindConfigMap,
-				Name: "my-config",
-				Key:  "theNatsURL",
-			},
-		},
-	})
-
-	// Then
-	require.NoError(t.T(), err)
-	require.Equal(t.T(), "nats://custom-nats:4222", result)
-}
-
-func (t *ClusterTestSuite) Test_resolveNatsURL_ShouldSucceed_FromConfigMapWithExplicitNamespace() {
-	// Given
-	unitUnderTest := t.newUnitUnderTestWithDefaults()
-
-	t.configMapResolverMock.mockGet(t.ctx, domain.NewNamespacedName("config-namespace", "my-config"),
-		map[string]string{"theNatsURL": "nats://custom-nats:4222"})
-
-	// When
-	result, err := unitUnderTest.resolveNatsURL(t.ctx, &v1alpha1.NatsCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "my-namespace",
-			Name:      "my-cluster",
-		},
-		Spec: v1alpha1.NatsClusterSpec{
-			URLFrom: &v1alpha1.URLFromReference{
-				Kind:      v1alpha1.URLFromKindConfigMap,
-				Namespace: "config-namespace",
-				Name:      "my-config",
-				Key:       "theNatsURL",
-			},
-		},
-	})
-
-	// Then
-	require.NoError(t.T(), err)
-	require.Equal(t.T(), "nats://custom-nats:4222", result)
-}
-
-func (t *ClusterTestSuite) Test_resolveNatsURL_ShouldSucceed_FromSecret() {
-	// Given
-	unitUnderTest := t.newUnitUnderTestWithDefaults()
-
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "my-secret"),
-		map[string]string{"theNatsURL": "nats://custom-nats:4222"})
-
-	// When
-	result, err := unitUnderTest.resolveNatsURL(t.ctx, &v1alpha1.NatsCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "my-namespace",
-			Name:      "my-cluster",
-		},
-		Spec: v1alpha1.NatsClusterSpec{
-			URLFrom: &v1alpha1.URLFromReference{
-				Kind: v1alpha1.URLFromKindSecret,
-				Name: "my-secret",
-				Key:  "theNatsURL",
-			},
-		},
-	})
-
-	// Then
-	require.NoError(t.T(), err)
-	require.Equal(t.T(), "nats://custom-nats:4222", result)
-}
-
-func (t *ClusterTestSuite) Test_resolveNatsURL_ShouldSucceed_FromSecretWithExplicitNamespace() {
-	// Given
-	unitUnderTest := t.newUnitUnderTestWithDefaults()
-
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("config-namespace", "my-secret"),
-		map[string]string{"theNatsURL": "nats://custom-nats:4222"})
-
-	// When
-	result, err := unitUnderTest.resolveNatsURL(t.ctx, &v1alpha1.NatsCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "my-namespace",
-			Name:      "my-cluster",
-		},
-		Spec: v1alpha1.NatsClusterSpec{
-			URLFrom: &v1alpha1.URLFromReference{
-				Kind:      v1alpha1.URLFromKindSecret,
-				Namespace: "config-namespace",
-				Name:      "my-secret",
-				Key:       "theNatsURL",
-			},
-		},
-	})
-
-	// Then
-	require.NoError(t.T(), err)
-	require.Equal(t.T(), "nats://custom-nats:4222", result)
-}
-
-func (t *ClusterTestSuite) Test_resolveNatsURL_ShouldFail_WhenNoNatsURLReferenceProvided() {
-	// Given
-	unitUnderTest := t.newUnitUnderTestWithDefaults()
-
-	// When
-	result, err := unitUnderTest.resolveNatsURL(t.ctx, &v1alpha1.NatsCluster{})
-
-	// Then
-	require.ErrorContains(t.T(), err, "neither url nor urlFrom is set")
-	require.Empty(t.T(), result)
-}
-
-func (t *ClusterTestSuite) Test_resolveNatsURL_ShouldFail_WhenUnsupportedFromKindProvided() {
-	// Given
-	unitUnderTest := t.newUnitUnderTestWithDefaults()
-
-	// When
-	result, err := unitUnderTest.resolveNatsURL(t.ctx, &v1alpha1.NatsCluster{
-		Spec: v1alpha1.NatsClusterSpec{
-			URLFrom: &v1alpha1.URLFromReference{
-				Kind: "NotSoKind",
-			},
-		},
-	})
-
-	// Then
-	require.ErrorContains(t.T(), err, "unsupported urlFrom.kind \"NotSoKind\"")
-	require.Empty(t.T(), result)
 }
 
 func (t *ClusterTestSuite) Test_Validate_ShouldSucceed() {
 	// Given
 	unitUnderTest := t.newUnitUnderTestWithDefaults()
-	cluster := t.newNatsCluster("my-namespace", "my-cluster", "nats://my-cluster:4222")
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "op-sign-secret"),
-		map[string]string{k8s.DefaultSecretKeyName: string(opSignSeed)})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
-	t.natsSysClientMock.mockConnect("nats://my-cluster:4222", sauCreds, t.natsSysConnMock)
+	clusterTarget := t.generateClusterTarget()
+	t.natsSysClientMock.mockConnect(clusterTarget.NatsURL, clusterTarget.SystemAdminCreds, t.natsSysConnMock)
 	t.natsSysConnMock.mockVerifySystemAccountAccess()
 	t.natsSysConnMock.mockDisconnect()
 
 	// When
-	err := unitUnderTest.Validate(t.ctx, cluster)
+	err := unitUnderTest.Validate(t.ctx, clusterTarget)
 
 	// Then
 	t.NoError(err)
@@ -466,64 +198,37 @@ func (t *ClusterTestSuite) Test_Validate_ShouldSucceed() {
 func (t *ClusterTestSuite) Test_Validate_ShouldFail_WhenOperatorSigningKeySecretMissing() {
 	// Given
 	unitUnderTest := t.newUnitUnderTestWithDefaults()
-	cluster := t.newNatsCluster("my-namespace", "my-cluster", "nats://my-cluster:4222")
-	_, sauCreds := t.generateSecrets()
-
-	t.secretClientMock.mockGetError(domain.NewNamespacedName("my-namespace", "op-sign-secret"), fmt.Errorf("the root cause"))
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
+	clusterTarget := t.generateClusterTarget()
+	clusterTarget.OperatorSigningKey = nil
 
 	// When
-	err := unitUnderTest.Validate(t.ctx, cluster)
+	err := unitUnderTest.Validate(t.ctx, clusterTarget)
 
 	// Then
-	t.ErrorContains(err, "resolve operator signing key for NatsCluster my-namespace/my-cluster:")
-	t.ErrorContains(err, "resolve secret my-namespace/op-sign-secret: the root cause")
+	t.ErrorContains(err, "invalid cluster target: operator signing key is required")
 }
 
 func (t *ClusterTestSuite) Test_Validate_ShouldFail_WhenSystemAccountUserCredsSecretMissing() {
 	// Given
 	unitUnderTest := t.newUnitUnderTestWithDefaults()
-	cluster := t.newNatsCluster("my-namespace", "my-cluster", "nats://my-cluster:4222")
-	t.secretClientMock.mockGetError(domain.NewNamespacedName("my-namespace", "sau-creds"), fmt.Errorf("the root cause"))
+	clusterTarget := t.generateClusterTarget()
+	clusterTarget.SystemAdminCreds = domain.NatsUserCreds{}
 
 	// When
-	err := unitUnderTest.Validate(t.ctx, cluster)
+	err := unitUnderTest.Validate(t.ctx, clusterTarget)
 
 	// Then
-	t.ErrorContains(err, "resolve system account user creds for NatsCluster my-namespace/my-cluster:")
-	t.ErrorContains(err, "resolve secret my-namespace/sau-creds: the root cause")
-}
-
-func (t *ClusterTestSuite) Test_Validate_ShouldFail_WhenNatsURLCannotBeResolved() {
-	// Given
-	unitUnderTest := t.newUnitUnderTestWithDefaults()
-	cluster := t.newNatsClusterFromConfigMap("my-namespace", "my-cluster", "my-config", "theNatsURL")
-	t.configMapResolverMock.mockGetError(t.ctx, domain.NewNamespacedName("my-namespace", "my-config"), fmt.Errorf("the root cause"))
-
-	// When
-	err := unitUnderTest.Validate(t.ctx, cluster)
-
-	// Then
-	t.ErrorContains(err, "resolve NATS URL for NatsCluster my-namespace/my-cluster:")
-	t.ErrorContains(err, "get ConfigMap my-namespace/my-config: the root cause")
+	t.ErrorContains(err, "invalid cluster target: invalid system admin credentials: credentials cannot be empty")
 }
 
 func (t *ClusterTestSuite) Test_Validate_ShouldFail_WhenNatsConnectionFails() {
 	// Given
 	unitUnderTest := t.newUnitUnderTestWithDefaults()
-	cluster := t.newNatsCluster("my-namespace", "my-cluster", "nats://my-cluster:4222")
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "op-sign-secret"),
-		map[string]string{k8s.DefaultSecretKeyName: string(opSignSeed)})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
-	t.natsSysClientMock.mockConnectError("nats://my-cluster:4222", sauCreds, fmt.Errorf("authentication failed"))
+	clusterTarget := t.generateClusterTarget()
+	t.natsSysClientMock.mockConnectError(clusterTarget.NatsURL, clusterTarget.SystemAdminCreds, fmt.Errorf("authentication failed"))
 
 	// When
-	err := unitUnderTest.Validate(t.ctx, cluster)
+	err := unitUnderTest.Validate(t.ctx, clusterTarget)
 
 	// Then
 	t.ErrorContains(err, "connect to NATS cluster using System Account User Credentials: authentication failed")
@@ -532,20 +237,13 @@ func (t *ClusterTestSuite) Test_Validate_ShouldFail_WhenNatsConnectionFails() {
 func (t *ClusterTestSuite) Test_Validate_ShouldFail_WhenVerifySystemAccountAccessFails() {
 	// Given
 	unitUnderTest := t.newUnitUnderTestWithDefaults()
-	cluster := t.newNatsCluster("my-namespace", "my-cluster", "nats://my-cluster:4222")
-	opSignKey, sauCreds := t.generateSecrets()
-	opSignSeed, _ := opSignKey.Seed()
-
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "op-sign-secret"),
-		map[string]string{k8s.DefaultSecretKeyName: string(opSignSeed)})
-	t.secretClientMock.mockGet(t.ctx, domain.NewNamespacedName("my-namespace", "sau-creds"),
-		map[string]string{k8s.DefaultSecretKeyName: string(sauCreds.Creds)})
-	t.natsSysClientMock.mockConnect("nats://my-cluster:4222", sauCreds, t.natsSysConnMock)
+	clusterTarget := t.generateClusterTarget()
+	t.natsSysClientMock.mockConnect(clusterTarget.NatsURL, clusterTarget.SystemAdminCreds, t.natsSysConnMock)
 	t.natsSysConnMock.mockVerifySystemAccountAccessError(fmt.Errorf("permission denied"))
 	t.natsSysConnMock.mockDisconnect()
 
 	// When
-	err := unitUnderTest.Validate(t.ctx, cluster)
+	err := unitUnderTest.Validate(t.ctx, clusterTarget)
 
 	// Then
 	t.ErrorContains(err, "verify NATS System Account access: permission denied")
@@ -555,7 +253,7 @@ func (t *ClusterTestSuite) newUnitUnderTestWithDefaults() *ClusterManager {
 	return t.newUnitUnderTest(nil, false, "")
 }
 
-func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *v1alpha1.NatsClusterRef, opClusterOptional bool, opNamespace domain.Namespace) *ClusterManager {
+func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *nauth.ClusterRef, opClusterOptional bool, opNamespace domain.Namespace) *ClusterManager {
 	var operatorNatsCluster *OperatorNatsCluster
 	var err error
 	if opClusterRef != nil {
@@ -573,10 +271,8 @@ func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *v1alpha1.NatsClusterRe
 	}
 
 	u, err := NewClusterManager(
-		t.natsClusterResolverMock,
+		t.clusterReaderMock,
 		t.natsSysClientMock,
-		t.secretClientMock,
-		t.configMapResolverMock,
 		config,
 	)
 	if err != nil {
@@ -587,39 +283,7 @@ func (t *ClusterTestSuite) newUnitUnderTest(opClusterRef *v1alpha1.NatsClusterRe
 	return u
 }
 
-func (t *ClusterTestSuite) newNatsCluster(namespace, name, natsURL string) *v1alpha1.NatsCluster {
-	return &v1alpha1.NatsCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: v1alpha1.NatsClusterSpec{
-			URL:                             natsURL,
-			OperatorSigningKeySecretRef:     v1alpha1.SecretKeyReference{Name: "op-sign-secret"},
-			SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{Name: "sau-creds"},
-		},
-	}
-}
-
-func (t *ClusterTestSuite) newNatsClusterFromConfigMap(namespace, name, configMapName, key string) *v1alpha1.NatsCluster {
-	return &v1alpha1.NatsCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: v1alpha1.NatsClusterSpec{
-			URLFrom: &v1alpha1.URLFromReference{
-				Kind: v1alpha1.URLFromKindConfigMap,
-				Name: configMapName,
-				Key:  key,
-			},
-			OperatorSigningKeySecretRef:     v1alpha1.SecretKeyReference{Name: "op-sign-secret"},
-			SystemAccountUserCredsSecretRef: v1alpha1.SecretKeyReference{Name: "sau-creds"},
-		},
-	}
-}
-
-func (t *ClusterTestSuite) generateSecrets() (domain.NatsOperatorSigningKey, domain.NatsUserCreds) {
+func (t *ClusterTestSuite) generateClusterTarget() nauth.ClusterTarget {
 	opSign, _ := nkeys.CreateOperator()
 
 	acKey, _ := nkeys.CreateAccount()
@@ -645,5 +309,9 @@ func (t *ClusterTestSuite) generateSecrets() (domain.NatsOperatorSigningKey, dom
 		t.Failf("failed to create NatsUserCreds from SAU creds", "error: %v", err)
 	}
 
-	return opSign, *sauNatsUserCreds
+	return nauth.ClusterTarget{
+		NatsURL:            "nats://my-cluster:4222",
+		OperatorSigningKey: opSign,
+		SystemAdminCreds:   *sauNatsUserCreds,
+	}
 }

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -2,11 +2,9 @@ package core
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
-	k8sval "k8s.io/apimachinery/pkg/api/validation"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 )
 
 type Config struct {
@@ -42,19 +40,17 @@ func (c *Config) validate() error {
 }
 
 type OperatorNatsCluster struct {
-	ClusterRef v1alpha1.NatsClusterRef
+	ClusterRef nauth.ClusterRef
 	// Optional controls account-level overrides when ClusterRef is configured.
 	// false (default) means account-level cluster refs must not deviate.
 	Optional bool
 }
 
-func NewOperatorNatsCluster(clusterRef v1alpha1.NatsClusterRef, optional bool) (*OperatorNatsCluster, error) {
+func NewOperatorNatsCluster(clusterRef nauth.ClusterRef, optional bool) (*OperatorNatsCluster, error) {
+
 	cluster := &OperatorNatsCluster{
-		ClusterRef: v1alpha1.NatsClusterRef{
-			Namespace: clusterRef.Namespace,
-			Name:      clusterRef.Name,
-		},
-		Optional: optional,
+		ClusterRef: clusterRef,
+		Optional:   optional,
 	}
 	if err := cluster.validate(); err != nil {
 		return nil, err
@@ -63,25 +59,5 @@ func NewOperatorNatsCluster(clusterRef v1alpha1.NatsClusterRef, optional bool) (
 }
 
 func (c *OperatorNatsCluster) validate() error {
-	namespace := c.ClusterRef.Namespace
-	namespaceTrimmed := strings.TrimSpace(namespace)
-	name := c.ClusterRef.Name
-	nameTrimmed := strings.TrimSpace(name)
-
-	if namespaceTrimmed == "" || nameTrimmed == "" {
-		return fmt.Errorf("both namespace and name must be provided for operator NATS cluster reference")
-	}
-	if namespace != namespaceTrimmed || name != nameTrimmed {
-		return fmt.Errorf("namespace and name in operator NATS cluster reference must not have leading or trailing whitespace")
-	}
-	if errs := k8sval.ValidateNamespaceName(namespace, false); len(errs) > 0 {
-		return fmt.Errorf("invalid namespace %q in operator NATS cluster reference: %s", namespace, strings.Join(errs, ", "))
-	}
-	if errs := k8sval.NameIsDNSSubdomain(name, false); len(errs) > 0 {
-		return fmt.Errorf("invalid name %q in operator NATS cluster reference: %s", name, strings.Join(errs, ", "))
-	}
-
-	c.ClusterRef.Namespace = namespace
-	c.ClusterRef.Name = name
-	return nil
+	return c.ClusterRef.Validate()
 }

--- a/internal/core/config_blackbox_test.go
+++ b/internal/core/config_blackbox_test.go
@@ -4,27 +4,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/core"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 )
 
 func TestNewOperatorNatsCluster(t *testing.T) {
 	t.Run("should_succeed", func(t *testing.T) {
-		cluster, err := core.NewOperatorNatsCluster(v1alpha1.NatsClusterRef{
-			Namespace: "operator-system",
-			Name:      "nats-main",
-		}, true)
+		cluster, err := core.NewOperatorNatsCluster("operator-system/nats-main", true)
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
 		if cluster == nil {
 			t.Fatalf("expected non-nil cluster")
-		}
-		if cluster.ClusterRef.Namespace != "operator-system" {
-			t.Fatalf("expected namespace, got %q", cluster.ClusterRef.Namespace)
-		}
-		if cluster.ClusterRef.Name != "nats-main" {
-			t.Fatalf("expected name, got %q", cluster.ClusterRef.Name)
 		}
 		if !cluster.Optional {
 			t.Fatalf("expected optional=true")
@@ -33,32 +24,23 @@ func TestNewOperatorNatsCluster(t *testing.T) {
 
 	testCases := []struct {
 		testName      string
-		ref           v1alpha1.NatsClusterRef
+		ref           nauth.ClusterRef
 		expectedError string
 	}{
 		{
-			testName: "should_fail_when_namespace_or_name_is_missing",
-			ref: v1alpha1.NatsClusterRef{
-				Namespace: "",
-				Name:      "nats-main",
-			},
-			expectedError: "both namespace and name must be provided",
+			testName:      "should_fail_when_namespace_or_name_is_missing",
+			ref:           "nats-main",
+			expectedError: "invalid Namespaced Name format \"nats-main\": expected namespace/name",
 		},
 		{
-			testName: "should_fail_when_namespace_is_invalid",
-			ref: v1alpha1.NatsClusterRef{
-				Namespace: "invalid_namespace",
-				Name:      "nats-main",
-			},
-			expectedError: "invalid namespace",
+			testName:      "should_fail_when_namespace_is_invalid",
+			ref:           "invalid_namespace/nats-main",
+			expectedError: "namespace invalid \"invalid_namespace\"",
 		},
 		{
-			testName: "should_fail_when_name_is_invalid",
-			ref: v1alpha1.NatsClusterRef{
-				Namespace: "operator-system",
-				Name:      "NATS_MAIN",
-			},
-			expectedError: "invalid name",
+			testName:      "should_fail_when_name_is_invalid",
+			ref:           "operator-system/NATS_MAIN",
+			expectedError: "name invalid \"NATS_MAIN\"",
 		},
 	}
 
@@ -94,10 +76,7 @@ func TestNewConfig(t *testing.T) {
 
 	t.Run("should_fail_when_operator_cluster_is_invalid_even_if_constructed_directly", func(t *testing.T) {
 		config, err := core.NewConfig(&core.OperatorNatsCluster{
-			ClusterRef: v1alpha1.NatsClusterRef{
-				Namespace: "invalid_namespace",
-				Name:      "nats-main",
-			},
+			ClusterRef: "invalid_namespace/nats-main",
 		}, "")
 		if err == nil {
 			t.Fatalf("expected error, got success with config=%+v", config)

--- a/internal/core/mocks_test.go
+++ b/internal/core/mocks_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/adapter/outbound/k8s" // TODO: [#185] Core must not depend on adapter code
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"github.com/nats-io/jwt/v2"
 	"github.com/stretchr/testify/mock"
@@ -57,10 +58,6 @@ func (s *SecretClientMock) mockGet(ctx context.Context, namespacedName domain.Na
 
 func (s *SecretClientMock) mockGetNotFound(namespacedName domain.NamespacedName) {
 	s.On("Get", mock.Anything, namespacedName).Return(nil, false, nil)
-}
-
-func (s *SecretClientMock) mockGetError(namespacedName domain.NamespacedName, err error) {
-	s.On("Get", mock.Anything, namespacedName).Return(nil, false, err)
 }
 
 func (s *SecretClientMock) GetByLabels(ctx context.Context, namespace domain.Namespace, labels map[string]string) (*corev1.SecretList, error) {
@@ -384,54 +381,28 @@ var _ outbound.AccountReader = &AccountReaderMock{}
 /* ****************************************************
 * NatsCluster Resolver
 *****************************************************/
-type NatsClusterReaderMock struct {
+type ClusterReaderMock struct {
 	mock.Mock
 }
 
-func NewNatsClusterReaderMock() *NatsClusterReaderMock {
-	return &NatsClusterReaderMock{}
+func NewClusterReaderMock() *ClusterReaderMock {
+	return &ClusterReaderMock{}
 }
 
-func (m *NatsClusterReaderMock) Get(ctx context.Context, clusterRef domain.NamespacedName) (*v1alpha1.NatsCluster, error) {
+func (m *ClusterReaderMock) GetTarget(ctx context.Context, clusterRef nauth.ClusterRef) (*nauth.ClusterTarget, error) {
 	args := m.Called(ctx, clusterRef)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*v1alpha1.NatsCluster), args.Error(1)
+	return args.Get(0).(*nauth.ClusterTarget), args.Error(1)
 }
 
-func (m *NatsClusterReaderMock) mockGetNatsCluster(ctx context.Context, clusterRef domain.NamespacedName, result *v1alpha1.NatsCluster) {
-	m.On("Get", ctx, clusterRef).Return(result, nil)
+func (m *ClusterReaderMock) mockGetTarget(ctx context.Context, clusterRef nauth.ClusterRef, result *nauth.ClusterTarget) *mock.Call {
+	return m.On("GetTarget", ctx, clusterRef).Return(result, nil)
 }
 
-func (m *NatsClusterReaderMock) mockGetNatsClusterError(ctx context.Context, clusterRef domain.NamespacedName, err error) {
-	m.On("Get", ctx, clusterRef).Return(nil, err)
+func (m *ClusterReaderMock) mockGetTargetError(ctx context.Context, clusterRef nauth.ClusterRef, err error) {
+	m.On("GetTarget", ctx, clusterRef).Return(nil, err)
 }
 
-var _ outbound.NatsClusterReader = (*NatsClusterReaderMock)(nil)
-
-/* ****************************************************
-* outbound.ConfigMapReader Mock
-*****************************************************/
-type ConfigMapReaderMock struct {
-	mock.Mock
-}
-
-func NewConfigMapReaderMock() *ConfigMapReaderMock {
-	return &ConfigMapReaderMock{}
-}
-
-func (m *ConfigMapReaderMock) Get(ctx context.Context, namespacedName domain.NamespacedName) (map[string]string, error) {
-	args := m.Called(ctx, namespacedName)
-	return args.Get(0).(map[string]string), args.Error(1)
-}
-
-func (m *ConfigMapReaderMock) mockGet(ctx context.Context, namespacedName domain.NamespacedName, result map[string]string) {
-	m.On("Get", ctx, namespacedName).Return(result, nil)
-}
-
-func (m *ConfigMapReaderMock) mockGetError(ctx context.Context, namespacedName domain.NamespacedName, err error) {
-	m.On("Get", ctx, namespacedName).Return(map[string]string{}, err)
-}
-
-var _ outbound.ConfigMapReader = (*ConfigMapReaderMock)(nil)
+var _ outbound.ClusterReader = (*ClusterReaderMock)(nil)

--- a/internal/domain/k8s.go
+++ b/internal/domain/k8s.go
@@ -37,6 +37,18 @@ func NewNamespacedName(namespace, name string) NamespacedName {
 	return r
 }
 
+func ParseNamespacedName(value string) (NamespacedName, error) {
+	parts := strings.SplitN(value, "/", 2)
+	if len(parts) != 2 {
+		return NamespacedName{}, fmt.Errorf("invalid Namespaced Name format %q: expected namespace/name", value)
+	}
+	result := NewNamespacedName(parts[0], parts[1])
+	if err := result.Validate(); err != nil {
+		return NamespacedName{}, fmt.Errorf("invalid Namespaced Name %q: %w", value, err)
+	}
+	return result, nil
+}
+
 func (n NamespacedName) GetNamespace() Namespace {
 	return Namespace(n.Namespace)
 }

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AccountResources struct {
-	Account      v1alpha1.Account `json:"account,omitempty"` // TODO: Migrate to domain model
+	Account      v1alpha1.Account `json:"account,omitempty"` // TODO: [#11] Migrate from API- to domain model
 	ExportGroups ExportGroups     `json:"exportGroups,omitempty"`
 }
 

--- a/internal/domain/nauth/cluster.go
+++ b/internal/domain/nauth/cluster.go
@@ -1,0 +1,78 @@
+package nauth
+
+import (
+	"fmt"
+
+	"github.com/WirelessCar/nauth/internal/domain"
+)
+
+type ClusterTarget struct {
+	NatsURL            string
+	SystemAdminCreds   domain.NatsUserCreds
+	OperatorSigningKey domain.NatsOperatorSigningKey
+}
+
+func NewClusterTarget(natsURL string, systemAdminCreds domain.NatsUserCreds, operatorSigningKey domain.NatsOperatorSigningKey) (*ClusterTarget, error) {
+	target := &ClusterTarget{
+		NatsURL:            natsURL,
+		SystemAdminCreds:   systemAdminCreds,
+		OperatorSigningKey: operatorSigningKey,
+	}
+	if err := target.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid cluster target: %w", err)
+	}
+	return target, nil
+}
+
+func (c *ClusterTarget) Validate() error {
+	if c.NatsURL == "" {
+		return fmt.Errorf("URL is required")
+	}
+	if err := c.SystemAdminCreds.Validate(); err != nil {
+		return fmt.Errorf("invalid system admin credentials: %w", err)
+	}
+	if c.OperatorSigningKey == nil {
+		return fmt.Errorf("operator signing key is required")
+	}
+	return nil
+}
+
+type ClusterRefType int64
+
+const (
+	ClusterRefTypeUnknown ClusterRefType = iota
+	ClusterRefTypeNamespacedName
+)
+
+type ClusterRef string
+
+func NewClusterRef(value string) (ClusterRef, error) {
+	result := ClusterRef(value)
+	if err := result.Validate(); err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+func (r ClusterRef) GetType() ClusterRefType {
+	if _, err := r.AsNamespacedName(); err == nil {
+		return ClusterRefTypeNamespacedName
+	}
+	return ClusterRefTypeUnknown
+}
+
+func (r ClusterRef) Validate() error {
+	// For now, we only support NamespacedName format, so validation is just checking if it can be parsed as such.
+	if _, err := r.AsNamespacedName(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r ClusterRef) AsNamespacedName() (*domain.NamespacedName, error) {
+	result, err := domain.ParseNamespacedName(string(r))
+	if err != nil {
+		return nil, fmt.Errorf("invalid cluster ref %q (expected NamespacedName): %w", r, err)
+	}
+	return &result, nil
+}

--- a/internal/ports/inbound/nauth.go
+++ b/internal/ports/inbound/nauth.go
@@ -9,8 +9,8 @@ import (
 
 type AccountManager interface {
 	CreateOrUpdate(ctx context.Context, accountResources nauth.AccountResources) (*nauth.AccountResult, error)
-	Import(ctx context.Context, state *v1alpha1.Account) (*nauth.AccountResult, error)
-	Delete(ctx context.Context, desired *v1alpha1.Account) error
+	Import(ctx context.Context, state *v1alpha1.Account) (*nauth.AccountResult, error) // TODO: [#11] Migrate from API- to domain model
+	Delete(ctx context.Context, desired *v1alpha1.Account) error                       // TODO: [#11] Migrate from API- to domain model
 }
 
 type AccountExportManager interface {
@@ -26,6 +26,6 @@ type UserManager interface {
 	Delete(ctx context.Context, desired *v1alpha1.User) error
 }
 
-type NatsClusterManager interface {
-	Validate(ctx context.Context, state *v1alpha1.NatsCluster) error
+type ClusterManager interface {
+	Validate(ctx context.Context, target nauth.ClusterTarget) error
 }

--- a/internal/ports/outbound/k8s.go
+++ b/internal/ports/outbound/k8s.go
@@ -3,7 +3,6 @@ package outbound
 import (
 	"context"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,14 +23,4 @@ type SecretClient interface {
 	Delete(ctx context.Context, secretRef domain.NamespacedName) error
 	DeleteByLabels(ctx context.Context, namespace domain.Namespace, labels map[string]string) error
 	Label(ctx context.Context, secretRef domain.NamespacedName, labels map[string]string) error
-}
-
-// AccountReader reads NAuth Account resources
-// TODO: [#228] Remove outbound.AccountReader as an outbound port
-type AccountReader interface {
-	Get(ctx context.Context, accountRef domain.NamespacedName) (account *v1alpha1.Account, err error)
-}
-
-type NatsClusterReader interface {
-	Get(ctx context.Context, clusterRef domain.NamespacedName) (*v1alpha1.NatsCluster, error)
 }

--- a/internal/ports/outbound/nauth.go
+++ b/internal/ports/outbound/nauth.go
@@ -1,0 +1,19 @@
+package outbound
+
+import (
+	"context"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
+)
+
+type ClusterReader interface {
+	GetTarget(ctx context.Context, clusterRef nauth.ClusterRef) (*nauth.ClusterTarget, error)
+}
+
+// AccountReader reads NAuth Account resources
+// TODO: [#228] Remove outbound.AccountReader as an outbound port
+type AccountReader interface {
+	Get(ctx context.Context, accountRef domain.NamespacedName) (account *v1alpha1.Account, err error)
+}


### PR DESCRIPTION
Break the core cluster flow away from `v1alpha1.NatsCluster` and `v1alpha1.NatsClusterRef` by introducing domain-level `nauth.ClusterRef` and `nauth.ClusterTarget` models.

Move Kubernetes-specific NatsCluster resolution into the outbound k8s adapter, so core validation only receives a resolved cluster target and account flows only pass domain cluster references. This keeps API conversion at the boundary and removes direct NatsCluster resource handling from core.

Issue: #11
