### PR TITLE
refactor(core): pass account references through domain model

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -138,7 +138,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		if controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
 			if managementPolicy != v1alpha1.AccountManagementPolicyObserve {
-				if err := r.manager.Delete(ctx, natsAccount); err != nil {
+				if err := r.manager.Delete(ctx, toAccountReference(natsAccount)); err != nil {
 					return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to delete account: %w", err))
 				}
 			}
@@ -181,7 +181,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var adoptions *v1alpha1.AccountAdoptions
 	if managementPolicy == v1alpha1.AccountManagementPolicyObserve {
 		var err error
-		result, err = r.manager.Import(ctx, natsAccount)
+		result, err = r.manager.Import(ctx, toAccountReference(natsAccount))
 		if err != nil {
 			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to import the observed account: %w", err))
 		}
@@ -227,6 +227,27 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return r.reporter.status(ctx, natsAccount)
+}
+
+func toAccountReference(state *v1alpha1.Account) nauth.AccountReference {
+	natsClusterRef := state.Spec.NatsClusterRef
+	var clusterRef *nauth.ClusterRef
+	if natsClusterRef != nil {
+		namespacedName := domain.NewNamespacedName(natsClusterRef.Namespace, natsClusterRef.Name)
+		if namespacedName.Namespace == "" {
+			namespacedName.Namespace = state.Namespace
+		}
+		ref := nauth.ClusterRef(namespacedName.String())
+		clusterRef = &ref
+	}
+	return nauth.AccountReference{
+		AccountRef: domain.NamespacedName{
+			Name:      state.Name,
+			Namespace: state.Namespace,
+		},
+		AccountID:      nauth.AccountID(state.GetLabel(v1alpha1.AccountLabelAccountID)),
+		NatsClusterRef: clusterRef,
+	}
 }
 
 func (r *AccountReconciler) collectAccountResources(ctx context.Context, account *v1alpha1.Account, accountID string) (nauth.AccountResources, accountAdoptionRefs, error) {

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -560,8 +560,8 @@ func (o *AccountManagerMock) mockCreateOrUpdateError(ctx interface{}, resources 
 	return call
 }
 
-func (o *AccountManagerMock) Import(ctx context.Context, state *v1alpha1.Account) (*nauth.AccountResult, error) {
-	args := o.Called(ctx, state)
+func (o *AccountManagerMock) Import(ctx context.Context, reference nauth.AccountReference) (*nauth.AccountResult, error) {
+	args := o.Called(ctx, reference)
 	if args.Error(1) != nil {
 		return nil, args.Error(1)
 	}
@@ -571,8 +571,8 @@ func (o *AccountManagerMock) Import(ctx context.Context, state *v1alpha1.Account
 	return args.Get(0).(*nauth.AccountResult), nil
 }
 
-func (o *AccountManagerMock) Delete(ctx context.Context, state *v1alpha1.Account) error {
-	args := o.Called(ctx, state)
+func (o *AccountManagerMock) Delete(ctx context.Context, reference nauth.AccountReference) error {
+	args := o.Called(ctx, reference)
 	return args.Error(0)
 }
 

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -245,20 +245,20 @@ func signAccountJWT(claims *jwt.AccountClaims, operatorSigningKey nkeys.KeyPair)
 	return claims.Encode(operatorSigningKey)
 }
 
-func (a *AccountManager) Import(ctx context.Context, state *v1alpha1.Account) (*nauth.AccountResult, error) {
-	accountRef := domain.NewNamespacedName(state.GetNamespace(), state.GetName())
+func (a *AccountManager) Import(ctx context.Context, reference nauth.AccountReference) (*nauth.AccountResult, error) {
+	accountRef := reference.AccountRef
 	if err := accountRef.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid account reference %q: %w", accountRef, err)
 	}
 
-	cluster, err := a.resolveClusterTarget(ctx, state)
+	cluster, err := a.clusterTargetResolver.GetClusterTarget(ctx, reference.NatsClusterRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve cluster target: %w", err)
 	}
 
-	accountID := state.GetLabel(v1alpha1.AccountLabelAccountID)
+	accountID := string(reference.AccountID)
 	if accountID == "" {
-		return nil, fmt.Errorf("account ID is missing for account %s during import", state.GetName())
+		return nil, fmt.Errorf("account ID is missing for account %s during import", accountRef)
 	}
 
 	secrets, found, err := a.secretManager.GetSecrets(ctx, accountRef, accountID)
@@ -308,13 +308,12 @@ func (a *AccountManager) Import(ctx context.Context, state *v1alpha1.Account) (*
 	}, nil
 }
 
-func (a *AccountManager) Delete(ctx context.Context, state *v1alpha1.Account) error {
-	accountRef := domain.NewNamespacedName(state.GetNamespace(), state.GetName())
-	if err := accountRef.Validate(); err != nil {
-		return fmt.Errorf("invalid account reference %q: %w", accountRef, err)
+func (a *AccountManager) Delete(ctx context.Context, reference nauth.AccountReference) error {
+	if err := reference.AccountRef.Validate(); err != nil {
+		return fmt.Errorf("invalid account reference: %w", err)
 	}
 
-	cluster, err := a.resolveClusterTarget(ctx, state)
+	cluster, err := a.clusterTargetResolver.GetClusterTarget(ctx, reference.NatsClusterRef)
 	if err != nil {
 		return fmt.Errorf("failed to resolve cluster target: %w", err)
 	}
@@ -324,12 +323,12 @@ func (a *AccountManager) Delete(ctx context.Context, state *v1alpha1.Account) er
 		return fmt.Errorf("failed to get operator signing public key: %w", err)
 	}
 
-	accountID := state.GetLabel(v1alpha1.AccountLabelAccountID)
+	accountID := string(reference.AccountID)
 	if accountID == "" {
-		return fmt.Errorf("account ID is missing for account %s", accountRef)
+		return fmt.Errorf("account ID is missing for account %s", reference.AccountRef)
 	}
 
-	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, accountRef, accountID)
+	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, reference.AccountRef, accountID)
 	if err != nil {
 		return fmt.Errorf("failed to get secrets for account: %w", err)
 	}
@@ -366,7 +365,7 @@ func (a *AccountManager) Delete(ctx context.Context, state *v1alpha1.Account) er
 		return fmt.Errorf("failed to delete account JWT in NATS: %w", err)
 	}
 
-	err = a.secretManager.DeleteAll(ctx, accountRef, accountID)
+	err = a.secretManager.DeleteAll(ctx, reference.AccountRef, accountID)
 	if err != nil {
 		return fmt.Errorf("failed to delete account secrets: %w", err)
 	}

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -672,14 +672,9 @@ func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {
 	t.natsSysConnMock.mockDisconnect()
 
 	// When
-	result, err := t.unitUnderTest.Import(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
-			},
-		},
+	result, err := t.unitUnderTest.Import(t.ctx, nauth.AccountReference{
+		AccountRef: domain.NewNamespacedName("account-namespace", "account-name"),
+		AccountID:  nauth.AccountID(accountID),
 	})
 
 	// Then
@@ -724,14 +719,9 @@ func (t *AccountManagerTestSuite) Test_Delete_ShouldSucceed() {
 	t.secretManagerMock.mockDeleteAll(t.ctx, accountRef, accountID).Once()
 
 	// When
-	err := t.unitUnderTest.Delete(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
-			},
-		},
+	err := t.unitUnderTest.Delete(t.ctx, nauth.AccountReference{
+		AccountRef: domain.NewNamespacedName("account-namespace", "account-name"),
+		AccountID:  nauth.AccountID(accountID),
 	})
 
 	// Then
@@ -770,14 +760,9 @@ func (t *AccountManagerTestSuite) Test_Delete_ShouldSucceed_WhenAccountSecretsAr
 	t.secretManagerMock.mockDeleteAll(t.ctx, accountRef, accountID).Once()
 
 	// When
-	err := t.unitUnderTest.Delete(t.ctx, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
-			},
-		},
+	err := t.unitUnderTest.Delete(t.ctx, nauth.AccountReference{
+		AccountRef: domain.NewNamespacedName("account-namespace", "account-name"),
+		AccountID:  nauth.AccountID(accountID),
 	})
 
 	// Then

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -5,11 +5,18 @@ import (
 	"time"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain"
 )
 
 type AccountResources struct {
 	Account      v1alpha1.Account `json:"account,omitempty"` // TODO: [#11] Migrate from API- to domain model
 	ExportGroups ExportGroups     `json:"exportGroups,omitempty"`
+}
+
+type AccountReference struct {
+	AccountRef     domain.NamespacedName
+	AccountID      AccountID
+	NatsClusterRef *ClusterRef
 }
 
 type AccountResult struct {

--- a/internal/ports/inbound/nauth.go
+++ b/internal/ports/inbound/nauth.go
@@ -9,8 +9,8 @@ import (
 
 type AccountManager interface {
 	CreateOrUpdate(ctx context.Context, accountResources nauth.AccountResources) (*nauth.AccountResult, error)
-	Import(ctx context.Context, state *v1alpha1.Account) (*nauth.AccountResult, error) // TODO: [#11] Migrate from API- to domain model
-	Delete(ctx context.Context, desired *v1alpha1.Account) error                       // TODO: [#11] Migrate from API- to domain model
+	Import(ctx context.Context, reference nauth.AccountReference) (*nauth.AccountResult, error) // TODO: [#11] Migrate from API- to domain model
+	Delete(ctx context.Context, reference nauth.AccountReference) error                         // TODO: [#11] Migrate from API- to domain model
 }
 
 type AccountExportManager interface {


### PR DESCRIPTION
Introduce a domain AccountReference for Account import and delete operations.

Move Account CRD details, labels, and NatsClusterRef conversion to the controller boundary so core no longer needs v1alpha1.Account for these flows. Core now receives the resolved account identity and optional domain ClusterRef directly.

