### PR TITLE
refactor(core): prepare Account CreateOrUpdate domain request

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -16,8 +16,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const GroupNameInline = "inline"
-
 type AccountManager struct {
 	natsSysClient         outbound.NatsSysClient
 	natsAccClient         outbound.NatsAccountClient
@@ -81,19 +79,27 @@ func (a *AccountManager) validate() error {
 }
 
 func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources nauth.AccountResources) (*nauth.AccountResult, error) {
-	account := &resources.Account
-	accountRef := domain.NewNamespacedName(account.GetNamespace(), account.GetName())
-	if err := accountRef.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid account reference %q: %w", accountRef, err)
+	// TODO: [#11] Migrate to CreateOrUpdate with nauth.AccountRequest as input
+	request, err := tmpToAccountRequest(ctx, resources.Account, a.accountReader)
+	if err != nil {
+		return nil, err
+	}
+	request.ExportGroups = append(request.ExportGroups, resources.ExportGroups...)
+	return a.tmpCreateOrUpdate(ctx, *request)
+}
+
+func (a *AccountManager) tmpCreateOrUpdate(ctx context.Context, request nauth.AccountRequest) (*nauth.AccountResult, error) {
+	if err := request.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid account request: %w", err)
 	}
 
-	cluster, err := a.resolveClusterTarget(ctx, account)
+	cluster, err := a.clusterTargetResolver.GetClusterTarget(ctx, request.ClusterRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve cluster target: %w", err)
 	}
 
-	fixedAccountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
-	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, accountRef, fixedAccountID)
+	fixedAccountID := string(request.AccountID)
+	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, request.AccountRef, fixedAccountID)
 	if fixedAccountID != "" {
 		// Update
 		if !found {
@@ -132,12 +138,12 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources nauth.Acc
 			return nil, fmt.Errorf("failed to create account signing key pair: %w", err)
 		}
 
-		err = a.secretManager.ApplyRootSecret(ctx, accountRef, accountKeyPair)
+		err = a.secretManager.ApplyRootSecret(ctx, request.AccountRef, accountKeyPair)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply account root secret: %w", err)
 		}
 
-		err = a.secretManager.ApplySignSecret(ctx, accountRef, accountPublicKey, accountSigningKeyPair)
+		err = a.secretManager.ApplySignSecret(ctx, request.AccountRef, accountPublicKey, accountSigningKeyPair)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply account signing secret: %w", err)
 		}
@@ -153,26 +159,19 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources nauth.Acc
 		return nil, fmt.Errorf("failed to get operator signing public key: %w", err)
 	}
 
-	accountIDReader := cachedAccountIDReader(ctx, a.accountReader)
-	claimsBuilder := newAccountClaimsBuilder(accountPublicKey, account.Spec.JetStreamEnabled).
-		displayName(getDisplayName(account)).
-		signingKey(accountSigningPublicKey)
-	if err = applySpec(accountIDReader, claimsBuilder, account.Spec); err != nil {
-		return nil, fmt.Errorf("failed to prepare account claims: %w", err)
-	}
+	claimsBuilder := newAccountClaimsBuilder(accountPublicKey, request.JetStreamEnabled).
+		displayName(getDisplayName(request)).
+		signingKey(accountSigningPublicKey).
+		accountLimits(request.AccountLimits).
+		jetStreamLimits(request.JetStreamLimits).
+		natsLimits(request.NatsLimits)
 	adoptions := nauth.NewAccountAdoptions()
-	for _, exp := range resources.ExportGroups {
-		adoptionResult := nauth.AdoptionResult{Ref: exp.Ref}
-		err = claimsBuilder.addExportGroup(*exp)
-		if err != nil {
-			adoptionResult.Failure = nauth.AdoptionFailureConflict
-			adoptionResult.Message = err.Error()
-		}
-		if err = adoptions.Exports.Add(adoptionResult); err != nil {
-			return nil, fmt.Errorf("failed to add adoption result for export group %q: %w", exp.Ref, err)
-		}
+	if err = adoptExportGroups(request.ExportGroups, claimsBuilder, adoptions); err != nil {
+		return nil, fmt.Errorf("failed to adopt export groups: %w", err)
 	}
-
+	if err = adoptImportGroups(request.ImportGroups, claimsBuilder, adoptions); err != nil {
+		return nil, fmt.Errorf("failed to adopt import groups: %w", err)
+	}
 	natsClaims, err := claimsBuilder.build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build NATS account claims: %w", err)
@@ -189,7 +188,7 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources nauth.Acc
 	}
 
 	log := logf.FromContext(ctx)
-	prevClaimsHash := account.Status.ClaimsHash
+	prevClaimsHash := request.ClaimsHash
 	if prevClaimsHash == "" || prevClaimsHash != claimsHash {
 		sysConn, err := a.natsSysClient.Connect(cluster.NatsURL, cluster.SystemAdminCreds)
 		if err != nil {
@@ -215,23 +214,38 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources nauth.Acc
 	}, nil
 }
 
-func applySpec(accountIDReader resolveAccountIDFn, builder *accountClaimsBuilder, spec v1alpha1.AccountSpec) error {
-	builder.
-		accountLimits(toNAuthAccountLimits(spec.AccountLimits)).
-		jetStreamLimits(toNAuthJetStreamLimits(spec.JetStreamLimits)).
-		natsLimits(toNAuthNatsLimits(spec.NatsLimits))
-
-	inlineExportGroup := toInlineExportGroup(spec.Exports)
-	if err := builder.addExportGroup(inlineExportGroup); err != nil {
-		return fmt.Errorf("failed to add inline exports: %w", err)
+func adoptExportGroups(groups nauth.ExportGroups, claimsBuilder *accountClaimsBuilder, adoptions *nauth.AccountAdoptions) error {
+	for _, exp := range groups {
+		adoptionResult := nauth.AdoptionResult{Ref: exp.Ref}
+		err := claimsBuilder.addExportGroup(*exp)
+		if err != nil {
+			if exp.Required {
+				return fmt.Errorf("failed to include required export group %q: %w", exp.Ref, err)
+			}
+			adoptionResult.Failure = nauth.AdoptionFailureConflict
+			adoptionResult.Message = err.Error()
+		}
+		if err = adoptions.Exports.Add(adoptionResult); err != nil {
+			return fmt.Errorf("failed to add adoption result for export group %q: %w", exp.Ref, err)
+		}
 	}
+	return nil
+}
 
-	inlineImportGroup, inlineImportsErr := toInlineImportGroup(accountIDReader, spec.Imports)
-	if inlineImportsErr != nil {
-		return fmt.Errorf("failed to convert inline imports to domain model: %w", inlineImportsErr)
-	}
-	if err := builder.addImportGroup(inlineImportGroup); err != nil {
-		return fmt.Errorf("failed to add inline imports: %w", err)
+func adoptImportGroups(groups nauth.ImportGroups, claimsBuilder *accountClaimsBuilder, adoptions *nauth.AccountAdoptions) error {
+	for _, imp := range groups {
+		adoptionResult := nauth.AdoptionResult{Ref: imp.Ref}
+		err := claimsBuilder.addImportGroup(*imp)
+		if err != nil {
+			if imp.Required {
+				return fmt.Errorf("failed to include required import group %q: %w", imp.Ref, err)
+			}
+			adoptionResult.Failure = nauth.AdoptionFailureConflict
+			adoptionResult.Message = err.Error()
+		}
+		if err = adoptions.Imports.Add(adoptionResult); err != nil {
+			return fmt.Errorf("failed to add adoption result for import group %q: %w", imp.Ref, err)
+		}
 	}
 	return nil
 }
@@ -470,177 +484,11 @@ func (a *AccountManager) SignUserJWT(ctx context.Context, accountRef domain.Name
 	}, nil
 }
 
-// TODO: [#11] Migrate from API- to domain model
-func (a *AccountManager) resolveClusterTarget(ctx context.Context, account *v1alpha1.Account) (*nauth.ClusterTarget, error) {
-	var optAccClusterRef *nauth.ClusterRef
-	natsClusterRef := account.Spec.NatsClusterRef
-	if natsClusterRef != nil {
-		namespace := natsClusterRef.Namespace
-		if namespace == "" {
-			namespace = account.GetNamespace()
-		}
-		namespacedName := domain.NewNamespacedName(namespace, natsClusterRef.Name)
-		clusterRef, err := nauth.NewClusterRef(namespacedName.String())
-		if err != nil {
-			return nil, fmt.Errorf("invalid account NatsClusterRef %q: %w", namespacedName, err)
-		}
-		optAccClusterRef = &clusterRef
+func getDisplayName(request nauth.AccountRequest) string {
+	if request.DisplayName != "" {
+		return request.DisplayName
 	}
-
-	return a.clusterTargetResolver.GetClusterTarget(ctx, optAccClusterRef)
-}
-
-func getDisplayName(account *v1alpha1.Account) string {
-	if account.Spec.DisplayName != "" {
-		return account.Spec.DisplayName
-	}
-	return fmt.Sprintf("%s/%s", account.GetNamespace(), account.GetName())
-}
-
-type resolveAccountIDFn func(accountRef domain.NamespacedName) (accountID string, err error)
-
-func cachedAccountIDReader(ctx context.Context, accountReader outbound.AccountReader) resolveAccountIDFn {
-	cache := make(map[domain.NamespacedName]string)
-	return func(accountRef domain.NamespacedName) (string, error) {
-		accountID := ""
-		var cached bool
-		if accountID, cached = cache[accountRef]; !cached {
-			account, err := accountReader.Get(ctx, accountRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve account ID: %w", err)
-			}
-			accountID = account.GetLabel(v1alpha1.AccountLabelAccountID)
-			cache[accountRef] = accountID
-		}
-		if accountID == "" {
-			return "", fmt.Errorf("account ID label %s is missing for account %q", v1alpha1.AccountLabelAccountID, accountRef)
-		}
-		return accountID, nil
-	}
-}
-
-func toNAuthAccountLimits(source *v1alpha1.AccountLimits) *nauth.AccountLimits {
-	if source == nil {
-		return nil
-	}
-	return &nauth.AccountLimits{
-		Imports:         source.Imports,
-		Exports:         source.Exports,
-		WildcardExports: source.WildcardExports,
-		Conn:            source.Conn,
-		LeafNodeConn:    source.LeafNodeConn,
-	}
-}
-
-func toNAuthJetStreamLimits(source *v1alpha1.JetStreamLimits) *nauth.JetStreamLimits {
-	if source == nil {
-		return nil
-	}
-	return &nauth.JetStreamLimits{
-		MemoryStorage:        source.MemoryStorage,
-		DiskStorage:          source.DiskStorage,
-		Streams:              source.Streams,
-		Consumer:             source.Consumer,
-		MaxAckPending:        source.MaxAckPending,
-		MemoryMaxStreamBytes: source.MemoryMaxStreamBytes,
-		DiskMaxStreamBytes:   source.DiskMaxStreamBytes,
-		MaxBytesRequired:     source.MaxBytesRequired,
-	}
-}
-
-func toNAuthNatsLimits(source *v1alpha1.NatsLimits) *nauth.NatsLimits {
-	if source == nil {
-		return nil
-	}
-	return &nauth.NatsLimits{
-		Subs:    source.Subs,
-		Data:    source.Data,
-		Payload: source.Payload,
-	}
-}
-
-func toInlineImportGroup(reader resolveAccountIDFn, sources v1alpha1.Imports) (nauth.ImportGroup, error) {
-	result := nauth.ImportGroup{
-		Name: GroupNameInline,
-	}
-	for _, source := range sources {
-		accountRef := domain.NewNamespacedName(source.AccountRef.Namespace, source.AccountRef.Name)
-		var err error
-		accountID, err := reader(accountRef)
-		if err != nil {
-			return result, fmt.Errorf("failed to resolve account ID for inline import %s: %w", accountRef, err)
-		}
-		if accountID == "" {
-			return result, fmt.Errorf("account ID is missing for inline import %s", accountRef)
-		}
-		result.Imports = append(result.Imports, &nauth.Import{
-			AccountID:    nauth.AccountID(accountID),
-			Name:         source.Name,
-			Subject:      nauth.Subject(source.Subject),
-			LocalSubject: nauth.Subject(source.LocalSubject),
-			Type:         toNAuthExportTypeFromAPI(source.Type),
-			Share:        source.Share,
-			AllowTrace:   source.AllowTrace,
-		})
-	}
-	return result, nil
-}
-
-func toInlineExportGroup(sources v1alpha1.Exports) nauth.ExportGroup {
-	result := nauth.ExportGroup{
-		Name: GroupNameInline,
-	}
-	for _, source := range sources {
-		result.Exports = append(result.Exports, &nauth.Export{
-			Name:                 source.Name,
-			Subject:              nauth.Subject(source.Subject),
-			Type:                 toNAuthExportTypeFromAPI(source.Type),
-			TokenReq:             source.TokenReq,
-			Revocations:          nauth.RevocationList(source.Revocations),
-			ResponseType:         toNAuthResponseTypeFromAPI(source.ResponseType),
-			ResponseThreshold:    source.ResponseThreshold,
-			Latency:              toNAuthServiceLatencyFromAPI(source.Latency),
-			AccountTokenPosition: source.AccountTokenPosition,
-			Advertise:            source.Advertise,
-			AllowTrace:           source.AllowTrace,
-		})
-	}
-	return result
-}
-
-func toNAuthResponseTypeFromAPI(source v1alpha1.ResponseType) nauth.ResponseType {
-	switch source {
-	case v1alpha1.ResponseTypeSingleton:
-		return nauth.ResponseTypeSingleton
-	case v1alpha1.ResponseTypeStream:
-		return nauth.ResponseTypeStream
-	case v1alpha1.ResponseTypeChunked:
-		return nauth.ResponseTypeChunked
-	default:
-		return ""
-	}
-}
-
-func toNAuthServiceLatencyFromAPI(source *v1alpha1.ServiceLatency) *nauth.ServiceLatency {
-	if source == nil {
-		return nil
-	}
-
-	return &nauth.ServiceLatency{
-		Sampling: nauth.SamplingRate(source.Sampling),
-		Results:  nauth.Subject(source.Results),
-	}
-}
-
-func toNAuthExportTypeFromAPI(exportType v1alpha1.ExportType) nauth.ExportType {
-	switch exportType {
-	case v1alpha1.Stream:
-		return nauth.ExportTypeStream
-	case v1alpha1.Service:
-		return nauth.ExportTypeService
-	default:
-		return nauth.ExportTypeUnknown
-	}
+	return request.AccountRef.String()
 }
 
 var _ inbound.AccountManager = (*AccountManager)(nil)

--- a/internal/core/account_claims.go
+++ b/internal/core/account_claims.go
@@ -112,7 +112,12 @@ func (b *accountClaimsBuilder) jetStreamLimits(limits *nauth.JetStreamLimits) *a
 }
 
 func (b *accountClaimsBuilder) addImportGroup(group nauth.ImportGroup) error {
-	result := jwt.Imports(mergeJWTItems(b.claim.Imports, toJWTImports(group.Imports), true))
+	imports := toJWTImports(group.Imports)
+	if err := validateJWTImports(b.claim.Subject, imports); err != nil {
+		return err
+	}
+
+	result := jwt.Imports(mergeJWTItems(b.claim.Imports, imports, true))
 	err := validateJWTImports(b.claim.Subject, result)
 	if err != nil {
 		return err
@@ -122,7 +127,12 @@ func (b *accountClaimsBuilder) addImportGroup(group nauth.ImportGroup) error {
 }
 
 func (b *accountClaimsBuilder) addExportGroup(group nauth.ExportGroup) error {
-	result := jwt.Exports(mergeJWTItems(b.claim.Exports, toJWTExports(group.Exports), true))
+	exports := toJWTExports(group.Exports)
+	if err := validateJWTExports(exports); err != nil {
+		return err
+	}
+
+	result := jwt.Exports(mergeJWTItems(b.claim.Exports, exports, true))
 	err := validateJWTExports(result)
 	if err != nil {
 		return err

--- a/internal/core/account_claims_test.go
+++ b/internal/core/account_claims_test.go
@@ -52,11 +52,11 @@ func Test_AccountClaims(t *testing.T) {
 					jetStreamLimits(spec.JetStreamLimits).
 					natsLimits(spec.NatsLimits)
 				require.NoError(t, builder.addExportGroup(nauth.ExportGroup{
-					Name:    GroupNameInline,
+					Name:    tmpGroupNameInline,
 					Exports: spec.Exports,
 				}))
 				require.NoError(t, builder.addImportGroup(nauth.ImportGroup{
-					Name:    GroupNameInline,
+					Name:    tmpGroupNameInline,
 					Imports: spec.Imports,
 				}))
 				builder.signingKey(testClaimsSigningKey01)

--- a/internal/core/account_converter_tmp.go
+++ b/internal/core/account_converter_tmp.go
@@ -1,0 +1,231 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
+	"github.com/WirelessCar/nauth/internal/ports/outbound"
+)
+
+// TODO: [#11] Move conversions to controller layer
+
+const tmpGroupNameInline = "inline"
+
+type tmpResolveAccountIDFn func(accountRef domain.NamespacedName) (accountID string, err error)
+
+func tmpToAccountRequest(ctx context.Context, state v1alpha1.Account, accountReader outbound.AccountReader) (*nauth.AccountRequest, error) {
+	accountID := nauth.AccountID(state.GetLabel(v1alpha1.AccountLabelAccountID))
+	accountRef := domain.NewNamespacedName(state.Namespace, state.Name)
+
+	accountIDResolver := tmpCachedAccountIDReader(ctx, accountReader)
+
+	clusterRef, err := tmpToClusterRef(state.Spec.NatsClusterRef, state.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var exportGroups nauth.ExportGroups
+	inlineExportGroup := tmpToNAuthExportGroup(tmpGroupNameInline, true, state.Spec.Exports)
+	if inlineExportGroup != nil {
+		exportGroups = nauth.ExportGroups{inlineExportGroup}
+	}
+
+	var importGroups nauth.ImportGroups
+	inlineImportGroup, err := tmpToNAuthImportGroup(tmpGroupNameInline, true, state.Spec.Imports, accountIDResolver)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert inline imports: %w", err)
+	}
+	if inlineImportGroup != nil {
+		importGroups = nauth.ImportGroups{inlineImportGroup}
+	}
+
+	result := nauth.AccountRequest{
+		AccountRef:       accountRef,
+		AccountID:        accountID,
+		ClaimsHash:       state.Status.ClaimsHash,
+		DisplayName:      state.Spec.DisplayName,
+		ClusterRef:       clusterRef,
+		AccountLimits:    tmpToNAuthAccountLimits(state.Spec.AccountLimits),
+		JetStreamEnabled: state.Spec.JetStreamEnabled,
+		JetStreamLimits:  tmpToNAuthJetStreamLimits(state.Spec.JetStreamLimits),
+		NatsLimits:       tmpToNAuthNatsLimits(state.Spec.NatsLimits),
+		ExportGroups:     exportGroups,
+		ImportGroups:     importGroups,
+	}
+	return &result, nil
+}
+
+func tmpCachedAccountIDReader(ctx context.Context, accountReader outbound.AccountReader) tmpResolveAccountIDFn {
+	cache := make(map[domain.NamespacedName]string)
+	return func(accountRef domain.NamespacedName) (string, error) {
+		accountID := ""
+		var cached bool
+		if accountID, cached = cache[accountRef]; !cached {
+			account, err := accountReader.Get(ctx, accountRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve account ID: %w", err)
+			}
+			accountID = account.GetLabel(v1alpha1.AccountLabelAccountID)
+			cache[accountRef] = accountID
+		}
+		if accountID == "" {
+			return "", fmt.Errorf("account ID label %s is missing for account %q", v1alpha1.AccountLabelAccountID, accountRef)
+		}
+		return accountID, nil
+	}
+}
+
+func tmpToNAuthAccountLimits(source *v1alpha1.AccountLimits) *nauth.AccountLimits {
+	if source == nil {
+		return nil
+	}
+	return &nauth.AccountLimits{
+		Imports:         source.Imports,
+		Exports:         source.Exports,
+		WildcardExports: source.WildcardExports,
+		Conn:            source.Conn,
+		LeafNodeConn:    source.LeafNodeConn,
+	}
+}
+
+func tmpToNAuthJetStreamLimits(source *v1alpha1.JetStreamLimits) *nauth.JetStreamLimits {
+	if source == nil {
+		return nil
+	}
+	return &nauth.JetStreamLimits{
+		MemoryStorage:        source.MemoryStorage,
+		DiskStorage:          source.DiskStorage,
+		Streams:              source.Streams,
+		Consumer:             source.Consumer,
+		MaxAckPending:        source.MaxAckPending,
+		MemoryMaxStreamBytes: source.MemoryMaxStreamBytes,
+		DiskMaxStreamBytes:   source.DiskMaxStreamBytes,
+		MaxBytesRequired:     source.MaxBytesRequired,
+	}
+}
+
+func tmpToNAuthNatsLimits(source *v1alpha1.NatsLimits) *nauth.NatsLimits {
+	if source == nil {
+		return nil
+	}
+	return &nauth.NatsLimits{
+		Subs:    source.Subs,
+		Data:    source.Data,
+		Payload: source.Payload,
+	}
+}
+
+func tmpToClusterRef(source *v1alpha1.NatsClusterRef, defaultNamespace string) (*nauth.ClusterRef, error) {
+	if source == nil {
+		return nil, nil
+	}
+	namespacedName := domain.NewNamespacedName(source.Namespace, source.Name)
+	if namespacedName.Namespace == "" {
+		namespacedName.Namespace = defaultNamespace
+	}
+	if err := namespacedName.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid NatsClusterRef: %w", err)
+	}
+	result, err := nauth.NewClusterRef(namespacedName.String())
+	if err != nil {
+		return nil, fmt.Errorf("invalid NatsClusterRef: %w", err)
+	}
+
+	return &result, nil
+}
+
+func tmpToNAuthExportGroup(groupRef nauth.Ref, required bool, sources v1alpha1.Exports) *nauth.ExportGroup {
+	if len(sources) == 0 {
+		return nil
+	}
+	result := nauth.ExportGroup{
+		Ref:      groupRef,
+		Required: required,
+	}
+	for _, source := range sources {
+		result.Exports = append(result.Exports, &nauth.Export{
+			Name:                 source.Name,
+			Subject:              nauth.Subject(source.Subject),
+			Type:                 tmpToNAuthExportType(source.Type),
+			TokenReq:             source.TokenReq,
+			Revocations:          nauth.RevocationList(source.Revocations),
+			ResponseType:         tmpToNAuthResponseType(source.ResponseType),
+			ResponseThreshold:    source.ResponseThreshold,
+			Latency:              tmpToNAuthServiceLatency(source.Latency),
+			AccountTokenPosition: source.AccountTokenPosition,
+			Advertise:            source.Advertise,
+			AllowTrace:           source.AllowTrace,
+		})
+	}
+	return &result
+}
+
+func tmpToNAuthImportGroup(groupRef nauth.Ref, required bool, sources v1alpha1.Imports, reader tmpResolveAccountIDFn) (*nauth.ImportGroup, error) {
+	if len(sources) == 0 {
+		return nil, nil
+	}
+
+	result := nauth.ImportGroup{
+		Ref:      groupRef,
+		Required: required,
+	}
+	for _, source := range sources {
+		accountRef := domain.NewNamespacedName(source.AccountRef.Namespace, source.AccountRef.Name)
+		var err error
+		accountID, err := reader(accountRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve account ID for inline import %s: %w", accountRef, err)
+		}
+		if accountID == "" {
+			return nil, fmt.Errorf("account ID is missing for inline import %s", accountRef)
+		}
+		result.Imports = append(result.Imports, &nauth.Import{
+			AccountID:    nauth.AccountID(accountID),
+			Name:         source.Name,
+			Subject:      nauth.Subject(source.Subject),
+			LocalSubject: nauth.Subject(source.LocalSubject),
+			Type:         tmpToNAuthExportType(source.Type),
+			Share:        source.Share,
+			AllowTrace:   source.AllowTrace,
+		})
+	}
+	return &result, nil
+}
+
+func tmpToNAuthResponseType(source v1alpha1.ResponseType) nauth.ResponseType {
+	switch source {
+	case v1alpha1.ResponseTypeSingleton:
+		return nauth.ResponseTypeSingleton
+	case v1alpha1.ResponseTypeStream:
+		return nauth.ResponseTypeStream
+	case v1alpha1.ResponseTypeChunked:
+		return nauth.ResponseTypeChunked
+	default:
+		return ""
+	}
+}
+
+func tmpToNAuthServiceLatency(source *v1alpha1.ServiceLatency) *nauth.ServiceLatency {
+	if source == nil {
+		return nil
+	}
+
+	return &nauth.ServiceLatency{
+		Sampling: nauth.SamplingRate(source.Sampling),
+		Results:  nauth.Subject(source.Results),
+	}
+}
+
+func tmpToNAuthExportType(exportType v1alpha1.ExportType) nauth.ExportType {
+	switch exportType {
+	case v1alpha1.Stream:
+		return nauth.ExportTypeStream
+	case v1alpha1.Service:
+		return nauth.ExportTypeService
+	default:
+		return nauth.ExportTypeUnknown
+	}
+}

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -641,7 +641,7 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountClaimsAreInv
 
 	// Then
 	t.Nil(result)
-	t.ErrorContains(err, "failed to add inline imports")
+	t.ErrorContains(err, "failed to include required import group")
 	t.ErrorContains(err, "overlapping subject namespace for \"foo\" and \"foo\"")
 }
 

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsConflict.approved.yaml
@@ -6,6 +6,8 @@ Adoptions:
       failure: Conflict
       message: stream export subject "foo.*" already exports "foo.*"
     aac5f3ce-7ed4-4981-b346-5dfcf778e585: {}
+    inline: {}
+  imports: {}
 Claims:
   displayName: account-namespace/account-name
   exports:

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsInvalid.approved.yaml
@@ -6,6 +6,8 @@ Adoptions:
       failure: Conflict
       message: subject "invalid subject" cannot have spaces
     aac5f3ce-7ed4-4981-b346-5dfcf778e585: {}
+    inline: {}
+  imports: {}
 Claims:
   displayName: account-namespace/account-name
   exports:

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMerge.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMerge.approved.yaml
@@ -3,6 +3,8 @@ AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
 Adoptions:
   exports:
     aac5f3ce-7ed4-4981-b346-5dfcf778e585: {}
+    inline: {}
+  imports: {}
 Claims:
   displayName: account-namespace/account-name
   exports:

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMixed.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsMixed.approved.yaml
@@ -3,6 +3,8 @@ AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
 Adoptions:
   exports:
     2cecbfcb-e92d-4bc9-bf4d-67d82737e707: {}
+    inline: {}
+  imports: {}
 Claims:
   displayName: account-namespace/account-name
   exports:

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsOnly.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.ExportsOnly.approved.yaml
@@ -4,6 +4,7 @@ Adoptions:
   exports:
     2cecbfcb-e92d-4bc9-bf4d-67d82737e707: {}
     aac5f3ce-7ed4-4981-b346-5dfcf778e585: {}
+  imports: {}
 Claims:
   displayName: account-namespace/account-name
   exports:

--- a/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.InlineOnly.approved.yaml
+++ b/internal/core/approvals/account_test.TestAccountManager_TestSuite.Test_CreateOrUpdate_ShouldSucceed_Adoptions.InlineOnly.approved.yaml
@@ -1,7 +1,9 @@
 AccountID: ABVIZMZGIFNQNOEMNHPGQLSL5NW7SUMTPBWT3HD65DQDNDKOU4XGBTL4
 AccountSignedBy: ODSQ3FLLTVD4O3K4BAXXOFPURAFMOSNPB74DBTLPDD5NAXSBOIC6M3M5
 Adoptions:
-  exports: {}
+  exports:
+    inline: {}
+  imports: {}
 Claims:
   accountLimits:
     conn: 100

--- a/internal/domain/nauth/account.go
+++ b/internal/domain/nauth/account.go
@@ -13,6 +13,55 @@ type AccountResources struct {
 	ExportGroups ExportGroups     `json:"exportGroups,omitempty"`
 }
 
+type AccountRequest struct {
+	AccountRef       domain.NamespacedName `json:"accountRef,omitempty"`
+	AccountID        AccountID             `json:"accountId,omitempty"`
+	ClaimsHash       string                `json:"claimsHash,omitempty"`
+	DisplayName      string                `json:"displayName,omitempty"`
+	ClusterRef       *ClusterRef           `json:"clusterRef,omitempty"`
+	AccountLimits    *AccountLimits        `json:"accountLimits,omitempty"`
+	JetStreamEnabled *bool                 `json:"jetStreamEnabled,omitempty"`
+	JetStreamLimits  *JetStreamLimits      `json:"jetStreamLimits,omitempty"`
+	NatsLimits       *NatsLimits           `json:"natsLimits,omitempty"`
+	ExportGroups     ExportGroups          `json:"exportGroups,omitempty"`
+	ImportGroups     ImportGroups          `json:"importGroups,omitempty"`
+}
+
+func (r AccountRequest) Validate() error {
+	if err := r.AccountRef.Validate(); err != nil {
+		return fmt.Errorf("invalid account reference: %w", err)
+	}
+
+	if r.ClusterRef != nil {
+		if err := r.ClusterRef.Validate(); err != nil {
+			return fmt.Errorf("invalid cluster reference: %w", err)
+		}
+	}
+
+	exportGroupNames := make(map[Ref]struct{})
+	for _, exportGroup := range r.ExportGroups {
+		if exportGroup.Ref == "" {
+			return fmt.Errorf("export group ref is required")
+		}
+		if _, exists := exportGroupNames[exportGroup.Ref]; exists {
+			return fmt.Errorf("duplicate export group ref: %q", exportGroup.Ref)
+		}
+		exportGroupNames[exportGroup.Ref] = struct{}{}
+	}
+
+	importGroupNames := make(map[Ref]struct{})
+	for _, importGroup := range r.ImportGroups {
+		if importGroup.Ref == "" {
+			return fmt.Errorf("import group ref is required")
+		}
+		if _, exists := importGroupNames[importGroup.Ref]; exists {
+			return fmt.Errorf("duplicate import group ref: %q", importGroup.Ref)
+		}
+		importGroupNames[importGroup.Ref] = struct{}{}
+	}
+	return nil
+}
+
 type AccountReference struct {
 	AccountRef     domain.NamespacedName
 	AccountID      AccountID
@@ -87,9 +136,13 @@ type SigningKey struct {
 	// TODO: [#140] Add signing key scope
 }
 
+type ImportGroups []*ImportGroup
+
 type ImportGroup struct {
-	Name    string  `json:"name,omitempty"`
-	Imports Imports `json:"imports,omitempty"`
+	Ref      Ref     `json:"ref"`
+	Required bool    `json:"required,omitempty"`
+	Name     string  `json:"name,omitempty"`
+	Imports  Imports `json:"imports,omitempty"`
 }
 
 type Imports []*Import
@@ -107,9 +160,10 @@ type Import struct {
 type ExportGroups []*ExportGroup
 
 type ExportGroup struct {
-	Ref     Ref     `json:"ref"`
-	Name    string  `json:"name,omitempty"`
-	Exports Exports `json:"exports"`
+	Ref      Ref     `json:"ref"`
+	Required bool    `json:"required,omitempty"`
+	Name     string  `json:"name,omitempty"`
+	Exports  Exports `json:"exports"`
 }
 
 type Exports []*Export
@@ -157,11 +211,13 @@ type AccountClaims struct {
 
 type AccountAdoptions struct {
 	Exports *AdoptionResults `json:"exports,omitempty"`
+	Imports *AdoptionResults `json:"imports,omitempty"`
 }
 
 func NewAccountAdoptions() *AccountAdoptions {
 	return &AccountAdoptions{
 		Exports: &AdoptionResults{},
+		Imports: &AdoptionResults{},
 	}
 }
 


### PR DESCRIPTION
Introduce AccountRequest as the domain input for Account reconciliation and move Account spec data into import and export groups before claim building.

Mark inline import/export groups as required so CreateOrUpdate fails fast when they cannot be applied, while leaving optional groups available for future adoption reporting. Keep the API-to-domain conversion in a temporary core adapter to avoid touching the controller while parallel controller work is in progress.

Issue: #11
