### PR TITLE
test(e2e): improve KUTTL failure diagnostics

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -23,6 +23,7 @@ on:
       - 'charts/**'
       - 'cmd/**'
       - 'internal/**'
+      - 'test/**'
       - Dockerfile
       - go.*
 

--- a/test/e2e/account-deletion-jetstream/02-create-stream.yaml
+++ b/test/e2e/account-deletion-jetstream/02-create-stream.yaml
@@ -2,28 +2,37 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
+      log "prepare temporary account creds"
+      # Keep generated creds in a temp file so stdout from the helper can remain the creds payload.
       creds_file="$(mktemp)"
       trap 'rm -f "$creds_file"' EXIT
 
+      # Generate temporary creds for the account and verify they contain a user seed block.
       bash ../../script/create-temp-account-creds.sh "$NAMESPACE" example-account > "$creds_file"
       grep -q 'BEGIN USER NKEY SEED' "$creds_file" || { echo "temporary creds missing seed block"; sed -n '1,40p' "$creds_file"; exit 1; }
 
-      pod="$(kubectl get pods -n nats -o name | grep 'pod/nats-box' | head -1 | cut -d'/' -f2)"
+      log "copy temporary account creds into nats-box pod"
+      # Pick the nats-box pod because it has the nats CLI needed for JetStream API requests.
+      pod="$(kubectl get pods -n nats -o name | awk -F/ '/^pod\/nats-box/ {print $2; exit}')"
       test -n "$pod"
 
-      kubectl exec -i -n nats "$pod" -- sh -c "cat > /tmp/stream-writer.creds" < "$creds_file"
-      kubectl exec -n nats "$pod" -- sh -c "grep -q 'BEGIN USER NKEY SEED' /tmp/stream-writer.creds"
+      # Copy creds into the pod, then verify the remote file has the expected seed block.
+      run kubectl exec -i -n nats "$pod" -- sh -c "cat > /tmp/stream-writer.creds" < "$creds_file"
+      run kubectl exec -n nats "$pod" -- sh -c "grep -q 'BEGIN USER NKEY SEED' /tmp/stream-writer.creds"
 
       attempts=0
       while true; do
         attempts=$((attempts + 1))
 
+        log "send JetStream stream create request for ORDERS (attempt $attempts)"
+        # Capture stdout and stderr so failed nats requests print the actual server response.
         set +e
         response="$(
           kubectl exec -n nats "$pod" -- sh -lc \
-            "nats --server='nats://nats.nats.svc.cluster.local:4222' --creds /tmp/stream-writer.creds req '\$JS.API.STREAM.CREATE.ORDERS' '{\"name\":\"ORDERS\",\"subjects\":[\"orders.>\"]}'"
+            "nats --server='nats://nats.nats.svc.cluster.local:4222' --creds /tmp/stream-writer.creds req '\$JS.API.STREAM.CREATE.ORDERS' '{\"name\":\"ORDERS\",\"subjects\":[\"orders.>\"]}'" 2>&1
         )"
         status=$?
         set -e
@@ -51,4 +60,6 @@ commands:
         sleep 1
       done
 
-      kubectl exec -n nats "$pod" -- rm -f /tmp/stream-writer.creds
+      log "clean up temporary account creds from nats-box pod"
+      run kubectl exec -n nats "$pod" -- rm -f /tmp/stream-writer.creds
+      BASH

--- a/test/e2e/account-deletion-jetstream/03-account-deletion.yaml
+++ b/test/e2e/account-deletion-jetstream/03-account-deletion.yaml
@@ -2,6 +2,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
-      kubectl delete accounts.nauth.io example-account -n "$NAMESPACE" --wait=false
+      run kubectl delete accounts.nauth.io example-account -n "$NAMESPACE" --wait=false
+      BASH

--- a/test/e2e/account-deletion-jetstream/04-remove-stream.yaml
+++ b/test/e2e/account-deletion-jetstream/04-remove-stream.yaml
@@ -2,28 +2,37 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
+      log "prepare temporary account creds"
+      # Keep generated creds in a temp file so stdout from the helper can remain the creds payload.
       creds_file="$(mktemp)"
       trap 'rm -f "$creds_file"' EXIT
 
+      # Generate temporary creds for the deleted account and verify they contain a user seed block.
       bash ../../script/create-temp-account-creds.sh "$NAMESPACE" example-account > "$creds_file"
       grep -q 'BEGIN USER NKEY SEED' "$creds_file" || { echo "temporary creds missing seed block"; sed -n '1,40p' "$creds_file"; exit 1; }
 
-      pod="$(kubectl get pods -n nats -o name | grep 'pod/nats-box' | head -1 | cut -d'/' -f2)"
+      log "copy temporary account creds into nats-box pod"
+      # Pick the nats-box pod because it has the nats CLI needed for JetStream API requests.
+      pod="$(kubectl get pods -n nats -o name | awk -F/ '/^pod\/nats-box/ {print $2; exit}')"
       test -n "$pod"
 
-      kubectl exec -i -n nats "$pod" -- sh -c "cat > /tmp/stream-writer.creds" < "$creds_file"
-      kubectl exec -n nats "$pod" -- sh -c "grep -q 'BEGIN USER NKEY SEED' /tmp/stream-writer.creds"
+      # Copy creds into the pod, then verify the remote file has the expected seed block.
+      run kubectl exec -i -n nats "$pod" -- sh -c "cat > /tmp/stream-writer.creds" < "$creds_file"
+      run kubectl exec -n nats "$pod" -- sh -c "grep -q 'BEGIN USER NKEY SEED' /tmp/stream-writer.creds"
 
       attempts=0
       while true; do
         attempts=$((attempts + 1))
 
+        log "send JetStream stream delete request for ORDERS (attempt $attempts)"
+        # Capture stdout and stderr so failed nats requests print the actual server response.
         set +e
         response="$(
           kubectl exec -n nats "$pod" -- sh -lc \
-            "nats --server='nats://nats.nats.svc.cluster.local:4222' --creds /tmp/stream-writer.creds req '\$JS.API.STREAM.DELETE.ORDERS' ''"
+            "nats --server='nats://nats.nats.svc.cluster.local:4222' --creds /tmp/stream-writer.creds req '\$JS.API.STREAM.DELETE.ORDERS' ''" 2>&1
         )"
         status=$?
         set -e
@@ -51,4 +60,6 @@ commands:
         sleep 1
       done
 
-      kubectl exec -n nats "$pod" -- rm -f /tmp/stream-writer.creds
+      log "clean up temporary account creds from nats-box pod"
+      run kubectl exec -n nats "$pod" -- rm -f /tmp/stream-writer.creds
+      BASH

--- a/test/e2e/account-update/01-assert.yaml
+++ b/test/e2e/account-update/01-assert.yaml
@@ -27,9 +27,13 @@ assertAll:
   - celExpr: matches(example_account.metadata.labels["account.nauth.io/id"], "^A.{55}$")
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
+      log "persist account id before update"
+      # Store the original account id on the resource so the next step can assert it was preserved.
       before_id="$(kubectl get accounts.nauth.io example-account -n "$NAMESPACE" -o jsonpath='{.metadata.labels.account\.nauth\.io/id}')"
       test -n "$before_id"
 
-      kubectl annotate accounts.nauth.io example-account -n "$NAMESPACE" --overwrite "test.nauth.io/id-before=$before_id"
+      run kubectl annotate accounts.nauth.io example-account -n "$NAMESPACE" --overwrite "test.nauth.io/id-before=$before_id"
+      BASH

--- a/test/e2e/basic-test/00-assert-operator-secrets.yaml
+++ b/test/e2e/basic-test/00-assert-operator-secrets.yaml
@@ -32,16 +32,21 @@ kind: TestAssert
 timeout: 20
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
+      log "validate operator NatsCluster secrets and references"
+      # Read the expected secret data fields to ensure the operator bootstrap secrets are populated.
       op_sign="$(kubectl get secret -n nats operator-op-sign -o jsonpath='{.data.default}')"
       test -n "$op_sign"
 
       sys_creds="$(kubectl get secret -n nats operator-sau-creds -o jsonpath='{.data.default}')"
       test -n "$sys_creds"
 
+      # Verify the NatsCluster points at the same operator bootstrap secrets.
       ref="$(kubectl get natscluster.nauth.io local-nats -n nats -o jsonpath='{.spec.operatorSigningKeySecretRef.name}')"
       test "$ref" = "operator-op-sign"
 
       ref="$(kubectl get natscluster.nauth.io local-nats -n nats -o jsonpath='{.spec.systemAccountUserCredsSecretRef.name}')"
       test "$ref" = "operator-sau-creds"
+      BASH

--- a/test/e2e/basic-test/01-assert-account.yaml
+++ b/test/e2e/basic-test/01-assert-account.yaml
@@ -50,16 +50,19 @@ assertAll:
   - celExpr: matches(example_account.status.claims.signingKeys[0].key, "^A.{55}$")
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
-      # read account id from account
+      log "validate account id and generated account secrets"
+      # Read account id from account metadata; generated secrets are labelled with this id.
       aid="$(kubectl get accounts.nauth.io example-account -n "$NAMESPACE" -o jsonpath='{.metadata.labels.account\.nauth\.io/id}')"
       test -n "$aid"
 
-      # verify account root secret exists
+      # Verify account root seed secret exists for the resolved account id.
       sec="$(kubectl get secret -n "$NAMESPACE" -l account.nauth.io/id="$aid",nauth.io/secret-type=account-root -o jsonpath='{.items[0].data.default}')"
       test -n "$sec"
 
-      # verify account sign secret exists
+      # Verify account signing seed secret exists for the resolved account id.
       sec="$(kubectl get secret -n "$NAMESPACE" -l account.nauth.io/id="$aid",nauth.io/secret-type=account-sign -o jsonpath='{.items[0].data.default}')"
       test -n "$sec"
+      BASH

--- a/test/e2e/basic-test/02-assert-user.yaml
+++ b/test/e2e/basic-test/02-assert-user.yaml
@@ -51,24 +51,31 @@ assertAll:
   - celExpr: example_user.metadata.labels["user.nauth.io/signed-by"] == example_account.status.claims.signingKeys[0].key
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
+      log "validate user id and generated user creds secret"
+      # Read user id from user metadata to verify the controller assigned an NATS user nkey.
       uid="$(kubectl get users.nauth.io example-user -n "$NAMESPACE" -o jsonpath='{.metadata.labels.user\.nauth\.io/id}')"
       test -n "$uid"
 
       secret_name="example-user-nats-user-creds"
 
-      # fetch secret once and verify all fields
+      # Fetch the generated creds secret once and inspect its labels and owner reference locally.
       secret_json="$(kubectl get secret "$secret_name" -n "$NAMESPACE" -o json)"
 
+      # Verify the secret contains encoded user creds.
       creds="$(printf '%s' "$secret_json" | jq -r '.data["user.creds"]')"
       test -n "$creds"
 
+      # Verify labels identify this as a managed user creds secret.
       secret_type="$(printf '%s' "$secret_json" | jq -r '.metadata.labels["nauth.io/secret-type"]')"
       test "$secret_type" = "user-creds"
 
       managed="$(printf '%s' "$secret_json" | jq -r '.metadata.labels["nauth.io/managed"]')"
       test "$managed" = "true"
 
+      # Verify the creds secret is owned by the User resource.
       owner_name="$(printf '%s' "$secret_json" | jq -r '.metadata.ownerReferences[0].name')"
       test "$owner_name" = "example-user"
+      BASH

--- a/test/e2e/cluster-ref-test/02-assert.yaml
+++ b/test/e2e/cluster-ref-test/02-assert.yaml
@@ -41,31 +41,32 @@ assertAll:
   - celExpr: matches(account.metadata.labels["account.nauth.io/id"], "^A.{55}$")
 commands:
   - script: |
-      set -eu
+      bash <<'BASH'
+      source ../../script/e2e-debug.sh
 
-      # Verify NO secrets with legacy labels exist in this namespace
+      log "validate cluster-ref account uses NatsCluster secrets"
+      # The cluster-ref path must not create legacy operator secret copies in the account namespace.
       legacy_count=$(kubectl get secret -n cluster-ref-test -l nauth.io/secret-type=operator-sign -o json | jq '.items | length')
       if [ "$legacy_count" != "0" ]; then
         echo "ERROR: Found secrets with legacy operator-sign label in cluster-ref-test namespace"
         exit 1
       fi
 
+      # The system account creds should also be referenced through NatsCluster, not copied.
       legacy_count=$(kubectl get secret -n cluster-ref-test -l nauth.io/secret-type=system-account-user-creds -o json | jq '.items | length')
       if [ "$legacy_count" != "0" ]; then
         echo "ERROR: Found secrets with legacy system-account-user-creds label in cluster-ref-test namespace"
         exit 1
       fi
 
-      echo "SUCCESS: No legacy labeled secrets found - NatsCluster approach is being used"
-
-      # Read account id from account
+      # Read account id from account metadata; generated secrets are labelled with this id.
       aid="$(kubectl get accounts.nauth.io cluster-ref-account -n cluster-ref-test -o jsonpath='{.metadata.labels.account\.nauth\.io/id}')"
       test -n "$aid"
 
-      # Verify account root secret exists
+      # Verify the controller generated account root and signing secrets for the account.
       sec="$(kubectl get secret -n cluster-ref-test -l account.nauth.io/id="$aid",nauth.io/secret-type=account-root -o jsonpath='{.items[0].data.default}')"
       test -n "$sec"
 
-      # Verify account sign secret exists
       sec="$(kubectl get secret -n cluster-ref-test -l account.nauth.io/id="$aid",nauth.io/secret-type=account-sign -o jsonpath='{.items[0].data.default}')"
       test -n "$sec"
+      BASH

--- a/test/script/create-temp-account-creds.sh
+++ b/test/script/create-temp-account-creds.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/e2e-debug.sh"
 
 if [ "$#" -ne 2 ]; then
   echo "usage: $0 <namespace> <account-name>" >&2
@@ -9,20 +11,24 @@ fi
 
 NAMESPACE="$1"
 ACCOUNT_NAME="$2"
-SCRIPT_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
 
+log "resolve account signing material for $NAMESPACE/$ACCOUNT_NAME"
+# Read account id from account metadata; generated account secrets are labelled with this id.
 ACCOUNT_ID="$(kubectl get accounts.nauth.io "$ACCOUNT_NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.labels.account\.nauth\.io/id}')"
 if [ -z "$ACCOUNT_ID" ]; then
   echo "failed to resolve account id for $NAMESPACE/$ACCOUNT_NAME" >&2
   exit 2
 fi
 
+# Resolve the account root seed secret so the helper can mint temporary user creds.
 ROOT_SEED_B64="$(kubectl get secret -n "$NAMESPACE" -l account.nauth.io/id="$ACCOUNT_ID",nauth.io/secret-type=account-root -o jsonpath='{.items[0].data.default}')"
 if [ -z "$ROOT_SEED_B64" ]; then
   echo "failed to resolve account root seed secret for $NAMESPACE/$ACCOUNT_NAME" >&2
   exit 3
 fi
 
+# Decode to a shell variable only; never log the root seed.
 ROOT_SEED="$(printf '%s' "$ROOT_SEED_B64" | base64 -d)"
 
+log "generate temporary account creds for $NAMESPACE/$ACCOUNT_NAME"
 go run "$SCRIPT_DIR/create-temp-account-creds.go" "$ACCOUNT_ID" "$ROOT_SEED"

--- a/test/script/e2e-debug.sh
+++ b/test/script/e2e-debug.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+_e2e_debug_err() {
+  local status=$?
+  local line="${BASH_LINENO[0]:-${LINENO}}"
+  local cmd="${BASH_COMMAND}"
+  echo "e2e-debug: ERROR line ${line}: ${cmd} exited with ${status}" >&2
+  exit "$status"
+}
+
+trap _e2e_debug_err ERR
+
+log() {
+  echo "e2e-debug: $*" >&2
+}
+
+run() {
+  printf 'e2e-debug: running:' >&2
+  printf ' %q' "$@" >&2
+  printf '\n' >&2
+  "$@"
+}

--- a/test/script/nats-jwt-upload.sh
+++ b/test/script/nats-jwt-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: nats-jwt-upload.sh <jwt-file> [nats-cluster-name] [nats-cluster-namespace]
 # Example: ./nats-jwt-upload.sh /tmp/account.jwt local-nats nats
 #
@@ -6,6 +6,8 @@
 # a NatsCluster resource.
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/e2e-debug.sh"
 
 if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
   echo "[$0] Usage: $0 <jwt-file> [nats-cluster-name] [nats-cluster-namespace]" >&2
@@ -16,22 +18,29 @@ JWT_FILE="$1"
 NATS_CLUSTER_NAME="${2:-local-nats}"
 NATS_CLUSTER_NAMESPACE="${3:-nats}"
 
+log "validate JWT upload inputs"
 if [ ! -f "$JWT_FILE" ]; then
   echo "[$0] ERROR: JWT file not found: $JWT_FILE" >&2
-  echo "[$0] Absolute path would be: $(realpath "$JWT_FILE" 2>&1 || echo 'cannot resolve')" >&2
+  echo "[$0] Absolute path would be: $(cd "$(dirname "$JWT_FILE")" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$(basename "$JWT_FILE")" || echo 'cannot resolve')" >&2
   exit 2
 fi
 
+# Keep a short filename for unique remote temp paths in the nats-box pod.
 JWT_FILENAME=$(basename "$JWT_FILE")
 
+# Fail before resolving credentials if the target NatsCluster does not exist.
 if ! kubectl get natsclusters.nauth.io "$NATS_CLUSTER_NAME" -n "$NATS_CLUSTER_NAMESPACE" >/dev/null 2>&1; then
   echo "[$0] ERROR: NatsCluster $NATS_CLUSTER_NAMESPACE/$NATS_CLUSTER_NAME not found" >&2
   exit 3
 fi
 
+log "resolve NATS URL from NatsCluster $NATS_CLUSTER_NAMESPACE/$NATS_CLUSTER_NAME"
+# Prefer a direct spec.url value.
 NATS_URL="$(kubectl get natsclusters.nauth.io "$NATS_CLUSTER_NAME" -n "$NATS_CLUSTER_NAMESPACE" -o jsonpath='{.spec.url}')"
 
 if [ -z "$NATS_URL" ]; then
+  log "resolve NATS URL from spec.urlFrom"
+  # Fall back to spec.urlFrom, which can point to a ConfigMap or Secret key.
   URL_FROM_KIND="$(kubectl get natsclusters.nauth.io "$NATS_CLUSTER_NAME" -n "$NATS_CLUSTER_NAMESPACE" -o jsonpath='{.spec.urlFrom.kind}')"
   URL_FROM_NAME="$(kubectl get natsclusters.nauth.io "$NATS_CLUSTER_NAME" -n "$NATS_CLUSTER_NAMESPACE" -o jsonpath='{.spec.urlFrom.name}')"
   URL_FROM_KEY="$(kubectl get natsclusters.nauth.io "$NATS_CLUSTER_NAME" -n "$NATS_CLUSTER_NAMESPACE" -o jsonpath='{.spec.urlFrom.key}')"
@@ -43,9 +52,11 @@ if [ -z "$NATS_URL" ]; then
 
   case "$URL_FROM_KIND" in
     ConfigMap|configmap)
+      # ConfigMap values are stored as plain data.
       NATS_URL="$(kubectl get configmap "$URL_FROM_NAME" -n "$URL_FROM_NAMESPACE" -o "go-template={{ index .data \"$URL_FROM_KEY\" }}" 2>/dev/null || true)"
       ;;
     Secret|secret)
+      # Secret values are base64 encoded by Kubernetes.
       URL_B64="$(kubectl get secret "$URL_FROM_NAME" -n "$URL_FROM_NAMESPACE" -o "go-template={{ index .data \"$URL_FROM_KEY\" }}" 2>/dev/null || true)"
       if [ -n "$URL_B64" ] && [ "$URL_B64" != "<no value>" ]; then
         NATS_URL="$(printf '%s' "$URL_B64" | base64 -d)"
@@ -65,6 +76,8 @@ if [ -z "$NATS_URL" ]; then
   exit 4
 fi
 
+log "resolve system account credentials"
+# Read the Secret reference that contains system account user creds for account JWT upload.
 CREDS_SECRET="$(kubectl get natsclusters.nauth.io "$NATS_CLUSTER_NAME" -n "$NATS_CLUSTER_NAMESPACE" -o jsonpath='{.spec.systemAccountUserCredsSecretRef.name}')"
 CREDS_KEY="$(kubectl get natsclusters.nauth.io "$NATS_CLUSTER_NAME" -n "$NATS_CLUSTER_NAMESPACE" -o jsonpath='{.spec.systemAccountUserCredsSecretRef.key}')"
 
@@ -77,17 +90,22 @@ if [ -z "$CREDS_KEY" ]; then
   CREDS_KEY="default"
 fi
 
+# Extract the referenced creds key without logging the secret contents.
 CREDS_B64="$(kubectl get secret "$CREDS_SECRET" -n "$NATS_CLUSTER_NAMESPACE" -o "go-template={{ index .data \"$CREDS_KEY\" }}" 2>/dev/null || true)"
 if [ -z "$CREDS_B64" ] || [ "$CREDS_B64" = "<no value>" ]; then
   echo "[$0] ERROR: Secret $NATS_CLUSTER_NAMESPACE/$CREDS_SECRET does not contain key '$CREDS_KEY'" >&2
   exit 5
 fi
 
+log "prepare temporary system account creds file"
 CREDS_FILE=$(mktemp)
 trap 'rm -f "$CREDS_FILE"' EXIT
+# Decode creds to a temp file for kubectl cp; keep secret material out of logs.
 printf '%s' "$CREDS_B64" | base64 -d > "$CREDS_FILE"
 
-EXEC_POD=$(kubectl get pods -n "$NATS_CLUSTER_NAMESPACE" --field-selector=status.phase=Running -o name 2>&1 | grep "pod/nats-box" | head -1 | cut -d'/' -f2)
+log "resolve nats-box pod"
+# Pick the nats-box pod because it has the nats CLI needed for system account requests.
+EXEC_POD=$(kubectl get pods -n "$NATS_CLUSTER_NAMESPACE" --field-selector=status.phase=Running -o name | awk -F/ '/^pod\/nats-box/ {print $2; exit}')
 
 if [ -z "$EXEC_POD" ]; then
   echo "[$0] ERROR: nats-box pod not found in namespace $NATS_CLUSTER_NAMESPACE" >&2
@@ -97,18 +115,23 @@ if [ -z "$EXEC_POD" ]; then
   exit 6
 fi
 
+log "copy upload files into nats-box pod"
+# Use unique remote paths so repeated KUTTL retries do not collide.
 REMOTE_CREDS_PATH="/tmp/nauth-upload-creds-$$-${JWT_FILENAME%.jwt}.default"
 kubectl cp "$CREDS_FILE" "$NATS_CLUSTER_NAMESPACE/$EXEC_POD:$REMOTE_CREDS_PATH" 2>&1 | grep -v "tar:" || true
 
 REMOTE_JWT_PATH="/tmp/nauth-upload-$$-${JWT_FILENAME%.jwt}.jwt"
 kubectl cp "$JWT_FILE" "$NATS_CLUSTER_NAMESPACE/$EXEC_POD:$REMOTE_JWT_PATH" 2>&1 | grep -v "tar:" || true
 
+log "upload account JWT through NATS system account"
+# Send the account JWT to the NATS system account claims update subject.
 set +e
 RESPONSE=$(kubectl exec -i -n "$NATS_CLUSTER_NAMESPACE" "$EXEC_POD" -- sh -c \
   "nats req --creds='$REMOTE_CREDS_PATH' --server='$NATS_URL' '\$SYS.REQ.CLAIMS.UPDATE' \"\$(cat '$REMOTE_JWT_PATH')\"" 2>&1)
 NATS_EXIT_CODE=$?
 set -e
 
+log "remove remote upload files from nats-box pod"
 kubectl exec -n "$NATS_CLUSTER_NAMESPACE" "$EXEC_POD" -- rm -f "$REMOTE_CREDS_PATH" "$REMOTE_JWT_PATH" 2>/dev/null || true
 
 if [ $NATS_EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
Add a shared e2e debug helper for focused block-level logging and ERR traps across KUTTL shell scripts.

Wrap inline e2e commands in bash, log key execution blocks, capture NATS request stderr, and use a safer nats-box pod lookup. Add comments around cryptic jsonpath, jq, and secret handling commands while keeping CI logs readable.

Also make helper scripts more portable by using env bash and avoiding realpath.

Co-authored-by: OpenAI Codex <codex@openai.com>
Signed-off-by: Thobias Karlsson <thobias.karlsson@gmail.com>
