### PR TITLE
refactor(domain): use account ID reader with typed errors

### DIFF
--- a/internal/adapter/inbound/controller/user_test.go
+++ b/internal/adapter/inbound/controller/user_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
-	"github.com/WirelessCar/nauth/internal/adapter/outbound/k8s"
+	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	k8err "k8s.io/apimachinery/pkg/api/errors"
@@ -95,14 +95,14 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingOrUpd
 
 func (t *UserControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdateFailsBecauseNoAccountExists() {
 	// Given
-	t.userManagerMock.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(k8s.ErrNoAccountFound).Once()
+	errAccountNotFound := domain.ErrAccountNotFound()
+	t.userManagerMock.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(errAccountNotFound).Once()
 
 	// When
 	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.userNamespacedName})
 
 	// Then
-	t.Error(err)
-	t.Equal(k8s.ErrNoAccountFound, err)
+	t.ErrorIs(err, errAccountNotFound)
 
 	user := &v1alpha1.User{}
 	err = k8sClient.Get(t.ctx, t.userNamespacedName, user)
@@ -114,7 +114,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdateFa
 	}
 
 	t.Len(t.fakeRecorder.Events, 1)
-	t.Contains(<-t.fakeRecorder.Events, k8s.ErrNoAccountFound.Error())
+	t.Contains(<-t.fakeRecorder.Events, errAccountNotFound.Error())
 }
 
 func (t *UserControllerTestSuite) Test_Reconcile_ShouldDeleteUserMarkedForDeletion() {

--- a/internal/adapter/inbound/controller/user_test.go
+++ b/internal/adapter/inbound/controller/user_test.go
@@ -95,7 +95,7 @@ func (t *UserControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingOrUpd
 
 func (t *UserControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdateFailsBecauseNoAccountExists() {
 	// Given
-	errAccountNotFound := domain.ErrAccountNotFound()
+	errAccountNotFound := domain.ErrAccountNotFound
 	t.userManagerMock.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(errAccountNotFound).Once()
 
 	// When

--- a/internal/adapter/outbound/k8s/account.go
+++ b/internal/adapter/outbound/k8s/account.go
@@ -30,7 +30,7 @@ func (a *AccountClient) Get(ctx context.Context, accountRef domain.NamespacedNam
 	}
 
 	if !isReady(account) {
-		return nil, domain.ErrAccountNotReady()
+		return nil, domain.ErrAccountNotReady
 	}
 	return account, nil
 }
@@ -43,23 +43,23 @@ func (a *AccountClient) GetAccountID(ctx context.Context, accountRef domain.Name
 
 	accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
 	if accountID == "" {
-		return "", domain.ErrAccountNotReady()
+		return "", domain.ErrAccountNotReady
 	}
 	return nauth.AccountID(accountID), nil
 }
 
-func (a *AccountClient) get(ctx context.Context, accountRef domain.NamespacedName) (*v1alpha1.Account, domain.NAuthError) {
+func (a *AccountClient) get(ctx context.Context, accountRef domain.NamespacedName) (*v1alpha1.Account, error) {
 	if err := accountRef.Validate(); err != nil {
-		return nil, domain.ErrBadRequest(fmt.Errorf("invalid reference %q: %w", accountRef, err))
+		return nil, domain.ErrBadRequest.WithCause(fmt.Errorf("invalid reference %q: %w", accountRef, err))
 	}
 	key := client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}
 
 	account := &v1alpha1.Account{}
 	if err := a.client.Get(ctx, key, account); err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			return nil, domain.ErrAccountNotFound()
+			return nil, domain.ErrAccountNotFound
 		}
-		return nil, domain.ErrUnknownError(fmt.Errorf("failed to get account %q: %w", accountRef, err))
+		return nil, domain.ErrUnknownError.WithCause(fmt.Errorf("failed to get account %q: %w", accountRef, err))
 	}
 	return account, nil
 }

--- a/internal/adapter/outbound/k8s/account.go
+++ b/internal/adapter/outbound/k8s/account.go
@@ -2,14 +2,13 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/outbound"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type AccountClient struct {
@@ -17,34 +16,52 @@ type AccountClient struct {
 }
 
 func NewAccountClient(client client.Client) *AccountClient {
-	ag := &AccountClient{
+	return &AccountClient{
 		client: client,
 	}
-
-	return ag
 }
 
 // Get the referenced Account
 // Requires the account to be reconciled and ready
-func (a *AccountClient) Get(ctx context.Context, accountRef domain.NamespacedName) (account *v1alpha1.Account, err error) {
-	log := logf.FromContext(ctx)
-	if err = accountRef.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid account reference %q: %w", accountRef, err)
-	}
-	key := client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}
-
-	account = &v1alpha1.Account{}
-	err = a.client.Get(ctx, key, account)
+func (a *AccountClient) Get(ctx context.Context, accountRef domain.NamespacedName) (*v1alpha1.Account, error) {
+	account, err := a.get(ctx, accountRef)
 	if err != nil {
 		return nil, err
 	}
 
 	if !isReady(account) {
-		log.Error(err, "account is not ready", "accountRef", accountRef)
-		return nil, errors.Join(ErrAccountNotReady, err)
+		return nil, domain.ErrAccountNotReady()
+	}
+	return account, nil
+}
+
+func (a *AccountClient) GetAccountID(ctx context.Context, accountRef domain.NamespacedName) (nauth.AccountID, error) {
+	account, err := a.Get(ctx, accountRef)
+	if err != nil {
+		return "", err
 	}
 
-	return account, err
+	accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
+	if accountID == "" {
+		return "", domain.ErrAccountNotReady()
+	}
+	return nauth.AccountID(accountID), nil
+}
+
+func (a *AccountClient) get(ctx context.Context, accountRef domain.NamespacedName) (*v1alpha1.Account, domain.NAuthError) {
+	if err := accountRef.Validate(); err != nil {
+		return nil, domain.ErrBadRequest(fmt.Errorf("invalid reference %q: %w", accountRef, err))
+	}
+	key := client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}
+
+	account := &v1alpha1.Account{}
+	if err := a.client.Get(ctx, key, account); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, domain.ErrAccountNotFound()
+		}
+		return nil, domain.ErrUnknownError(fmt.Errorf("failed to get account %q: %w", accountRef, err))
+	}
+	return account, nil
 }
 
 func isReady(account *v1alpha1.Account) bool {
@@ -53,3 +70,4 @@ func isReady(account *v1alpha1.Account) bool {
 
 // Compile-time assertion that implementation satisfies the ports interface
 var _ outbound.AccountReader = (*AccountClient)(nil)
+var _ outbound.AccountIDReader = (*AccountClient)(nil)

--- a/internal/adapter/outbound/k8s/account_test.go
+++ b/internal/adapter/outbound/k8s/account_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
+	"github.com/WirelessCar/nauth/internal/domain/nauth"
+	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/suite"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type AccountClientTestSuite struct {
@@ -26,69 +26,125 @@ func TestAccountClient_TestSuite(t *testing.T) {
 
 func (t *AccountClientTestSuite) SetupTest() {
 	t.ctx = context.Background()
-	t.accountRef = domain.NewNamespacedName(testNamespace, sanitizeTestName(t.T().Name()))
+	t.accountRef = domain.NewNamespacedName(scopedTestName("ns", t.T().Name()), sanitizeTestName(t.T().Name()))
 	t.Require().NoError(t.accountRef.Validate())
+
 	t.unitUnderTest = NewAccountClient(k8sClient)
-	t.Require().NoError(cleanAccount(t.ctx, t.accountRef))
-	t.Require().NoError(createAccount(t.ctx, t.accountRef))
-}
 
-func (t *AccountClientTestSuite) TearDownTest() {
-	t.Require().NoError(cleanAccount(t.ctx, t.accountRef))
-}
-
-func (t *AccountClientTestSuite) Test_Get_ShouldFail_WhenAccountIsNotReady() {
-	fetchedAccount, err := t.unitUnderTest.Get(t.ctx, t.accountRef)
-
-	t.Error(err)
-	t.Nil(fetchedAccount)
+	t.Require().NoError(ensureNamespace(t.ctx, t.accountRef.Namespace))
 }
 
 func (t *AccountClientTestSuite) Test_Get_ShouldSucceed_WhenAccountIsReady() {
-	t.Require().NoError(accountIsReady(t.ctx, t.accountRef))
-
-	fetchedAccount, err := t.unitUnderTest.Get(t.ctx, t.accountRef)
-
-	t.NoError(err)
-	t.NotNil(fetchedAccount)
-	t.Equal(t.accountRef.Name, fetchedAccount.Name)
-}
-
-func createAccount(ctx context.Context, accountRef domain.NamespacedName) error {
-	account := &v1alpha1.Account{
+	// Given
+	accountID := t.newAccountID()
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.Account{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      accountRef.Name,
-			Namespace: accountRef.Namespace,
+			Name:      t.accountRef.Name,
+			Namespace: t.accountRef.Namespace,
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): accountID,
+			},
 		},
-	}
+	}))
 
-	return k8sClient.Create(ctx, account)
+	// When
+	result, err := t.unitUnderTest.Get(t.ctx, t.accountRef)
+
+	t.Require().NoError(err)
+	t.Require().NotNil(result)
+	t.Equal(t.accountRef.Name, result.Name)
+	t.Equal(accountID, result.GetLabel(v1alpha1.AccountLabelAccountID))
 }
 
-func accountIsReady(ctx context.Context, accountRef domain.NamespacedName) error {
-	key := client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}
-	account := &v1alpha1.Account{}
+func (t *AccountClientTestSuite) Test_Get_ShouldFail_WhenAccountIsNotReady() {
+	// Given
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.accountRef.Name,
+			Namespace: t.accountRef.Namespace,
+		},
+	}))
 
-	err := k8sClient.Get(ctx, key, account)
-	if err != nil {
-		return err
-	}
+	// When
+	result, err := t.unitUnderTest.Get(t.ctx, t.accountRef)
 
-	account.SetLabel(v1alpha1.AccountLabelAccountID, "account-id")
-
-	return k8sClient.Update(ctx, account)
+	// Then
+	t.ErrorIs(err, domain.ErrAccountNotReady())
+	t.Nil(result)
 }
 
-func cleanAccount(ctx context.Context, accountRef domain.NamespacedName) error {
-	account := &v1alpha1.Account{}
+func (t *AccountClientTestSuite) Test_Get_ShouldFail_WhenAccountIsNotFound() {
+	// When
+	result, err := t.unitUnderTest.Get(t.ctx, t.accountRef)
 
-	key := client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}
-	if err := k8sClient.Get(ctx, key, account); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
+	// Then
+	t.Nil(result)
+	t.ErrorIs(err, domain.ErrAccountNotFound())
+}
 
-	return k8sClient.Delete(ctx, account)
+func (t *AccountClientTestSuite) Test_GetAccountID_ShouldSucceed() {
+	// Given
+	accountID := t.newAccountID()
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.accountRef.Name,
+			Namespace: t.accountRef.Namespace,
+			Labels: map[string]string{
+				string(v1alpha1.AccountLabelAccountID): accountID,
+			},
+		},
+	}))
+
+	// When
+	result, err := t.unitUnderTest.GetAccountID(t.ctx, t.accountRef)
+
+	// Then
+	t.NoError(err)
+	t.Equal(nauth.AccountID(accountID), result)
+}
+
+func (t *AccountClientTestSuite) Test_GetAccountID_ShouldFail_WhenAccountIsNotReady() {
+	// Given
+	t.Require().NoError(k8sClient.Create(t.ctx, &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.accountRef.Name,
+			Namespace: t.accountRef.Namespace,
+		},
+	}))
+
+	// When
+	result, err := t.unitUnderTest.GetAccountID(t.ctx, t.accountRef)
+
+	// Then
+	t.ErrorIs(err, domain.ErrAccountNotReady())
+	t.Empty(result)
+}
+
+func (t *AccountClientTestSuite) Test_GetAccountID_ShouldFail_WhenAccountIsNotFound() {
+	// When
+	result, err := t.unitUnderTest.GetAccountID(t.ctx, t.accountRef)
+
+	// Then
+	t.ErrorIs(err, domain.ErrAccountNotFound())
+	t.Empty(result)
+}
+
+func (t *AccountClientTestSuite) Test_GetAccountID_ShouldFail_WhenAccountReferenceIsInvalid() {
+	// Given
+	accountRef := domain.NewNamespacedName("", "asdf")
+
+	// When
+	result, err := t.unitUnderTest.GetAccountID(t.ctx, accountRef)
+
+	// Then
+	t.ErrorIs(err, domain.ErrBadRequest(nil))
+	t.Empty(result)
+}
+
+// Helpers
+
+func (t *AccountClientTestSuite) newAccountID() string {
+	account, _ := nkeys.CreateAccount()
+	publicKey, _ := account.PublicKey()
+	return publicKey
 }

--- a/internal/adapter/outbound/k8s/account_test.go
+++ b/internal/adapter/outbound/k8s/account_test.go
@@ -69,7 +69,7 @@ func (t *AccountClientTestSuite) Test_Get_ShouldFail_WhenAccountIsNotReady() {
 	result, err := t.unitUnderTest.Get(t.ctx, t.accountRef)
 
 	// Then
-	t.ErrorIs(err, domain.ErrAccountNotReady())
+	t.ErrorIs(err, domain.ErrAccountNotReady)
 	t.Nil(result)
 }
 
@@ -79,7 +79,7 @@ func (t *AccountClientTestSuite) Test_Get_ShouldFail_WhenAccountIsNotFound() {
 
 	// Then
 	t.Nil(result)
-	t.ErrorIs(err, domain.ErrAccountNotFound())
+	t.ErrorIs(err, domain.ErrAccountNotFound)
 }
 
 func (t *AccountClientTestSuite) Test_GetAccountID_ShouldSucceed() {
@@ -116,7 +116,7 @@ func (t *AccountClientTestSuite) Test_GetAccountID_ShouldFail_WhenAccountIsNotRe
 	result, err := t.unitUnderTest.GetAccountID(t.ctx, t.accountRef)
 
 	// Then
-	t.ErrorIs(err, domain.ErrAccountNotReady())
+	t.ErrorIs(err, domain.ErrAccountNotReady)
 	t.Empty(result)
 }
 
@@ -125,7 +125,7 @@ func (t *AccountClientTestSuite) Test_GetAccountID_ShouldFail_WhenAccountIsNotFo
 	result, err := t.unitUnderTest.GetAccountID(t.ctx, t.accountRef)
 
 	// Then
-	t.ErrorIs(err, domain.ErrAccountNotFound())
+	t.ErrorIs(err, domain.ErrAccountNotFound)
 	t.Empty(result)
 }
 
@@ -137,7 +137,7 @@ func (t *AccountClientTestSuite) Test_GetAccountID_ShouldFail_WhenAccountReferen
 	result, err := t.unitUnderTest.GetAccountID(t.ctx, accountRef)
 
 	// Then
-	t.ErrorIs(err, domain.ErrBadRequest(nil))
+	t.ErrorIs(err, domain.ErrBadRequest)
 	t.Empty(result)
 }
 

--- a/internal/adapter/outbound/k8s/configmap.go
+++ b/internal/adapter/outbound/k8s/configmap.go
@@ -41,15 +41,15 @@ func NewConfigMapClient(c client.Client) *ConfigMapClient {
 // Keys from both Data and BinaryData are included.
 func (c *ConfigMapClient) Get(ctx context.Context, configMapRef domain.NamespacedName) (map[string]string, error) {
 	if err := configMapRef.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid ConfigMap reference %q: %w", configMapRef, err)
+		return nil, domain.ErrBadRequest(fmt.Errorf("invalid ConfigMap reference %q: %w", configMapRef, err))
 	}
 	cm := &v1.ConfigMap{}
 	key := client.ObjectKey{Namespace: configMapRef.Namespace, Name: configMapRef.Name}
 	if err := c.client.Get(ctx, key, cm); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, ErrNotFound
+			return nil, domain.ErrConfigMapNotFound()
 		}
-		return nil, fmt.Errorf("failed to get ConfigMap %s: %w", configMapRef, err)
+		return nil, domain.ErrUnknownError(fmt.Errorf("failed to get ConfigMap %s: %w", configMapRef, err))
 	}
 	result := make(map[string]string)
 	for k, v := range cm.Data {

--- a/internal/adapter/outbound/k8s/configmap.go
+++ b/internal/adapter/outbound/k8s/configmap.go
@@ -41,15 +41,15 @@ func NewConfigMapClient(c client.Client) *ConfigMapClient {
 // Keys from both Data and BinaryData are included.
 func (c *ConfigMapClient) Get(ctx context.Context, configMapRef domain.NamespacedName) (map[string]string, error) {
 	if err := configMapRef.Validate(); err != nil {
-		return nil, domain.ErrBadRequest(fmt.Errorf("invalid ConfigMap reference %q: %w", configMapRef, err))
+		return nil, domain.ErrBadRequest.WithCause(fmt.Errorf("invalid ConfigMap reference %q: %w", configMapRef, err))
 	}
 	cm := &v1.ConfigMap{}
 	key := client.ObjectKey{Namespace: configMapRef.Namespace, Name: configMapRef.Name}
 	if err := c.client.Get(ctx, key, cm); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, domain.ErrConfigMapNotFound()
+			return nil, domain.ErrConfigMapNotFound
 		}
-		return nil, domain.ErrUnknownError(fmt.Errorf("failed to get ConfigMap %s: %w", configMapRef, err))
+		return nil, domain.ErrUnknownError.WithCause(fmt.Errorf("failed to get ConfigMap %s: %w", configMapRef, err))
 	}
 	result := make(map[string]string)
 	for k, v := range cm.Data {

--- a/internal/adapter/outbound/k8s/configmap_test.go
+++ b/internal/adapter/outbound/k8s/configmap_test.go
@@ -42,7 +42,7 @@ func (t *ConfigMapClientTestSuite) Test_Get_ShouldFail_WhenConfigMapDoesNotExist
 
 	result, err := t.unitUnderTest.Get(t.ctx, nonExistingConfigMapRef)
 
-	t.ErrorIs(err, domain.ErrConfigMapNotFound())
+	t.ErrorIs(err, domain.ErrConfigMapNotFound)
 	t.Nil(result)
 }
 

--- a/internal/adapter/outbound/k8s/configmap_test.go
+++ b/internal/adapter/outbound/k8s/configmap_test.go
@@ -42,9 +42,8 @@ func (t *ConfigMapClientTestSuite) Test_Get_ShouldFail_WhenConfigMapDoesNotExist
 
 	result, err := t.unitUnderTest.Get(t.ctx, nonExistingConfigMapRef)
 
-	t.Error(err)
+	t.ErrorIs(err, domain.ErrConfigMapNotFound())
 	t.Nil(result)
-	t.Equal(ErrNotFound, err)
 }
 
 func (t *ConfigMapClientTestSuite) Test_Get_ShouldSucceed_WhenConfigMapContainsData() {

--- a/internal/adapter/outbound/k8s/errors.go
+++ b/internal/adapter/outbound/k8s/errors.go
@@ -1,9 +1,0 @@
-package k8s
-
-import "errors"
-
-var (
-	ErrNoAccountFound  = errors.New("no account found")
-	ErrAccountNotReady = errors.New("account is not ready")
-	ErrNotFound        = errors.New("not found")
-)

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/domain/nauth"
 	"github.com/WirelessCar/nauth/internal/ports/inbound"
@@ -19,7 +18,7 @@ import (
 type AccountManager struct {
 	natsSysClient         outbound.NatsSysClient
 	natsAccClient         outbound.NatsAccountClient
-	accountReader         outbound.AccountReader
+	accountIDReader       outbound.AccountIDReader
 	clusterTargetResolver clusterTargetResolver
 	secretManager         secretManager
 }
@@ -27,7 +26,7 @@ type AccountManager struct {
 func NewAccountManager(
 	natsSysClient outbound.NatsSysClient,
 	natsAccClient outbound.NatsAccountClient,
-	accountReader outbound.AccountReader,
+	accountIDReader outbound.AccountIDReader,
 	secretClient outbound.SecretClient,
 	clusterManager *ClusterManager,
 ) (*AccountManager, error) {
@@ -35,20 +34,20 @@ func NewAccountManager(
 	if err != nil {
 		return nil, err
 	}
-	return newAccountManager(natsSysClient, natsAccClient, accountReader, clusterManager, sm)
+	return newAccountManager(natsSysClient, natsAccClient, accountIDReader, clusterManager, sm)
 }
 
 func newAccountManager(
 	natsSysClient outbound.NatsSysClient,
 	natsAccClient outbound.NatsAccountClient,
-	accountReader outbound.AccountReader,
+	accountIDReader outbound.AccountIDReader,
 	clusterTargetResolver clusterTargetResolver,
 	secretManager secretManager,
 ) (*AccountManager, error) {
 	m := &AccountManager{
 		natsSysClient:         natsSysClient,
 		natsAccClient:         natsAccClient,
-		accountReader:         accountReader,
+		accountIDReader:       accountIDReader,
 		clusterTargetResolver: clusterTargetResolver,
 		secretManager:         secretManager,
 	}
@@ -62,8 +61,8 @@ func (a *AccountManager) validate() error {
 	if a.clusterTargetResolver == nil {
 		return errors.New("clusterTargetResolver is required")
 	}
-	if a.accountReader == nil {
-		return errors.New("accountReader is required")
+	if a.accountIDReader == nil {
+		return errors.New("accountIDReader is required")
 	}
 	if a.secretManager == nil {
 		return errors.New("secretManager is required")
@@ -80,7 +79,7 @@ func (a *AccountManager) validate() error {
 
 func (a *AccountManager) CreateOrUpdate(ctx context.Context, resources nauth.AccountResources) (*nauth.AccountResult, error) {
 	// TODO: [#11] Migrate to CreateOrUpdate with nauth.AccountRequest as input
-	request, err := tmpToAccountRequest(ctx, resources.Account, a.accountReader)
+	request, err := tmpToAccountRequest(ctx, resources.Account, a.accountIDReader)
 	if err != nil {
 		return nil, err
 	}
@@ -446,26 +445,22 @@ func (a *AccountManager) SignUserJWT(ctx context.Context, accountRef domain.Name
 	if err := accountRef.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid account reference %q: %w", accountRef, err)
 	}
-	account, err := a.accountReader.Get(ctx, accountRef)
+	accountID, err := a.accountIDReader.GetAccountID(ctx, accountRef)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get account for user JWT signing: %w", err)
+		return nil, fmt.Errorf("failed to lookup Account ID for %q during user JWT signing: %w", accountRef, err)
 	}
-	accountID := account.GetLabel(v1alpha1.AccountLabelAccountID)
-	if accountID == "" {
-		return nil, fmt.Errorf("account ID is missing for account %s during user JWT signing", accountRef)
-	}
-	if claims.IssuerAccount != "" && claims.IssuerAccount != accountID {
+	if claims.IssuerAccount != "" && claims.IssuerAccount != string(accountID) {
 		return nil, fmt.Errorf("claims issuer account ID %s does not match %s bound to account %q during user JWT signing", claims.IssuerAccount, accountID, accountRef)
 	}
 	if claims.IssuerAccount == "" {
-		claims.IssuerAccount = accountID
+		claims.IssuerAccount = string(accountID)
 	}
 	claimsVal := &jwt.ValidationResults{}
 	claims.Validate(claimsVal)
 	if errs := claimsVal.Errors(); len(errs) > 0 {
 		return nil, fmt.Errorf("claims validation failed during user JWT signing: %v", claimsVal.Errors())
 	}
-	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, accountRef, accountID)
+	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, accountRef, string(accountID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get account secrets for user JWT signing: %w", err)
 	}
@@ -482,7 +477,7 @@ func (a *AccountManager) SignUserJWT(ctx context.Context, accountRef domain.Name
 	}
 	return &SignedUserJWT{
 		UserJWT:   userJWT,
-		AccountID: accountID,
+		AccountID: string(accountID),
 		SignedBy:  signPubKey,
 	}, nil
 }

--- a/internal/core/account_converter_tmp.go
+++ b/internal/core/account_converter_tmp.go
@@ -14,13 +14,13 @@ import (
 
 const tmpGroupNameInline = "inline"
 
-type tmpResolveAccountIDFn func(accountRef domain.NamespacedName) (accountID string, err error)
+type tmpResolveAccountIDFn func(accountRef domain.NamespacedName) (accountID nauth.AccountID, err error)
 
-func tmpToAccountRequest(ctx context.Context, state v1alpha1.Account, accountReader outbound.AccountReader) (*nauth.AccountRequest, error) {
+func tmpToAccountRequest(ctx context.Context, state v1alpha1.Account, accountIDReader outbound.AccountIDReader) (*nauth.AccountRequest, error) {
 	accountID := nauth.AccountID(state.GetLabel(v1alpha1.AccountLabelAccountID))
 	accountRef := domain.NewNamespacedName(state.Namespace, state.Name)
 
-	accountIDResolver := tmpCachedAccountIDReader(ctx, accountReader)
+	accountIDResolver := tmpCachedAccountIDReader(ctx, accountIDReader)
 
 	clusterRef, err := tmpToClusterRef(state.Spec.NatsClusterRef, state.Namespace)
 	if err != nil {
@@ -58,17 +58,17 @@ func tmpToAccountRequest(ctx context.Context, state v1alpha1.Account, accountRea
 	return &result, nil
 }
 
-func tmpCachedAccountIDReader(ctx context.Context, accountReader outbound.AccountReader) tmpResolveAccountIDFn {
-	cache := make(map[domain.NamespacedName]string)
-	return func(accountRef domain.NamespacedName) (string, error) {
-		accountID := ""
+func tmpCachedAccountIDReader(ctx context.Context, accountIDReader outbound.AccountIDReader) tmpResolveAccountIDFn {
+	cache := make(map[domain.NamespacedName]nauth.AccountID)
+	return func(accountRef domain.NamespacedName) (nauth.AccountID, error) {
+		var accountID nauth.AccountID
 		var cached bool
 		if accountID, cached = cache[accountRef]; !cached {
-			account, err := accountReader.Get(ctx, accountRef)
+			var err error
+			accountID, err = accountIDReader.GetAccountID(ctx, accountRef)
 			if err != nil {
 				return "", fmt.Errorf("failed to resolve account ID: %w", err)
 			}
-			accountID = account.GetLabel(v1alpha1.AccountLabelAccountID)
 			cache[accountRef] = accountID
 		}
 		if accountID == "" {
@@ -183,7 +183,7 @@ func tmpToNAuthImportGroup(groupRef nauth.Ref, required bool, sources v1alpha1.I
 			return nil, fmt.Errorf("account ID is missing for inline import %s", accountRef)
 		}
 		result.Imports = append(result.Imports, &nauth.Import{
-			AccountID:    nauth.AccountID(accountID),
+			AccountID:    accountID,
 			Name:         source.Name,
 			Subject:      nauth.Subject(source.Subject),
 			LocalSubject: nauth.Subject(source.LocalSubject),

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -830,7 +830,7 @@ func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldFailWhenAccountIsNotRea
 	// Given
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
 
-	t.accountIDReaderMock.mockGetAccountIDError(t.ctx, accountRef, domain.ErrAccountNotReady()).Once()
+	t.accountIDReaderMock.mockGetAccountIDError(t.ctx, accountRef, domain.ErrAccountNotReady).Once()
 
 	userKey, _ := nkeys.CreateUser()
 	userKeyPublic, _ := userKey.PublicKey()

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -28,7 +28,7 @@ type AccountManagerTestSuite struct {
 	clusterRef    nauth.ClusterRef
 	clusterTarget nauth.ClusterTarget
 
-	accountReaderMock         *AccountReaderMock
+	accountIDReaderMock       *AccountIDReaderMock
 	natsSysClientMock         *NatsSysClientMock
 	natsSysConnMock           *NatsSysConnectionMock
 	natsAccClientMock         *NatsAccountClientMock
@@ -57,7 +57,7 @@ func (t *AccountManagerTestSuite) SetupTest() {
 
 	t.clusterTargetResolverMock = newClusterTargetResolverMock()
 	t.secretManagerMock = newSecretManagerMock()
-	t.accountReaderMock = NewAccountReaderMock()
+	t.accountIDReaderMock = NewAccountIDReaderMock()
 	t.natsSysClientMock = NewNatsSysClientMock()
 	t.natsSysConnMock = NewNatsSysConnectionMock()
 	t.natsAccClientMock = NewNatsAccountClientMock()
@@ -67,7 +67,7 @@ func (t *AccountManagerTestSuite) SetupTest() {
 	t.unitUnderTest, err = newAccountManager(
 		t.natsSysClientMock,
 		t.natsAccClientMock,
-		t.accountReaderMock,
+		t.accountIDReaderMock,
 		t.clusterTargetResolverMock,
 		t.secretManagerMock,
 	)
@@ -86,7 +86,7 @@ func (t *AccountManagerTestSuite) assertAndResetAllMock() {
 func (t *AccountManagerTestSuite) assertAllMocks() {
 	t.clusterTargetResolverMock.AssertExpectations(t.T())
 	t.secretManagerMock.AssertExpectations(t.T())
-	t.accountReaderMock.AssertExpectations(t.T())
+	t.accountIDReaderMock.AssertExpectations(t.T())
 	t.natsSysClientMock.AssertExpectations(t.T())
 	t.natsSysConnMock.AssertExpectations(t.T())
 	t.natsAccClientMock.AssertExpectations(t.T())
@@ -96,7 +96,7 @@ func (t *AccountManagerTestSuite) assertAllMocks() {
 func (t *AccountManagerTestSuite) resetAllMocks() {
 	t.clusterTargetResolverMock.Mock = mock.Mock{}
 	t.secretManagerMock.Mock = mock.Mock{}
-	t.accountReaderMock.Mock = mock.Mock{}
+	t.accountIDReaderMock.Mock = mock.Mock{}
 	t.natsSysClientMock.Mock = mock.Mock{}
 	t.natsSysConnMock.Mock = mock.Mock{}
 	t.natsAccClientMock.Mock = mock.Mock{}
@@ -594,15 +594,7 @@ func (t *AccountManagerTestSuite) Test_Update_ShouldFail_WhenAccountClaimsAreInv
 		Root: accountRootKey,
 		Sign: accountSignKey,
 	})
-	t.accountReaderMock.mockGet(t.ctx, importAccountRef, &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "import-namespace",
-			Name:      "import-account",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): importAccountID,
-			},
-		},
-	}).Once()
+	t.accountIDReaderMock.mockGetAccountID(t.ctx, importAccountRef, importAccountID).Once()
 
 	// When
 	result, err := t.unitUnderTest.CreateOrUpdate(t.ctx, nauth.AccountResources{
@@ -808,20 +800,11 @@ func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldSucceed() {
 	accountSignKey, _ := nkeys.CreateAccount()
 	accountSignKeyPublic, _ := accountSignKey.PublicKey()
 
-	account := &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
-			},
-		},
-	}
-	t.accountReaderMock.mockGet(t.ctx, accountRef, account)
+	t.accountIDReaderMock.mockGetAccountID(t.ctx, accountRef, accountID).Once()
 	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, accountID, &Secrets{
 		Root: accountRootKey,
 		Sign: accountSignKey,
-	})
+	}).Once()
 
 	userKey, _ := nkeys.CreateUser()
 	userKeyPublic, _ := userKey.PublicKey()
@@ -847,13 +830,7 @@ func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldFailWhenAccountIsNotRea
 	// Given
 	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
 
-	account := &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-		},
-	}
-	t.accountReaderMock.mockGet(t.ctx, accountRef, account)
+	t.accountIDReaderMock.mockGetAccountIDError(t.ctx, accountRef, domain.ErrAccountNotReady()).Once()
 
 	userKey, _ := nkeys.CreateUser()
 	userKeyPublic, _ := userKey.PublicKey()
@@ -864,7 +841,7 @@ func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldFailWhenAccountIsNotRea
 
 	// Then
 	t.Nil(result)
-	t.ErrorContains(err, "account ID is missing for account account-namespace/account-name during user JWT signing")
+	t.ErrorContains(err, "failed to lookup Account ID for \"account-namespace/account-name\" during user JWT signing: AccountNotReady")
 }
 
 func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldFailWhenClaimsIssuerAccountDoesNotMatchFoundAccountID() {
@@ -873,16 +850,7 @@ func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldFailWhenClaimsIssuerAcc
 	accountRootKey, _ := nkeys.CreateAccount()
 	accountID, _ := accountRootKey.PublicKey()
 
-	account := &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
-			},
-		},
-	}
-	t.accountReaderMock.mockGet(t.ctx, accountRef, account)
+	t.accountIDReaderMock.mockGetAccountID(t.ctx, accountRef, accountID).Once()
 
 	userKey, _ := nkeys.CreateUser()
 	userKeyPublic, _ := userKey.PublicKey()
@@ -904,16 +872,7 @@ func (t *AccountManagerTestSuite) Test_SignUserJWT_ShouldFailWhenClaimsValidatio
 	accountRootKey, _ := nkeys.CreateAccount()
 	accountID, _ := accountRootKey.PublicKey()
 
-	account := &v1alpha1.Account{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "account-namespace",
-			Name:      "account-name",
-			Labels: map[string]string{
-				string(v1alpha1.AccountLabelAccountID): accountID,
-			},
-		},
-	}
-	t.accountReaderMock.mockGet(t.ctx, accountRef, account)
+	t.accountIDReaderMock.mockGetAccountID(t.ctx, accountRef, accountID).Once()
 
 	userKey, _ := nkeys.CreateUser()
 	userKeyPublic, _ := userKey.PublicKey()
@@ -1042,8 +1001,8 @@ func (m *secretManagerMock) GetSecrets(ctx context.Context, accountRef domain.Na
 	return args.Get(0).(*Secrets), args.Bool(1), args.Error(2)
 }
 
-func (m *secretManagerMock) mockGetSecrets(ctx context.Context, accountRef domain.NamespacedName, accountID string, result *Secrets) {
-	m.On("GetSecrets", ctx, accountRef, accountID).Return(result, true, nil)
+func (m *secretManagerMock) mockGetSecrets(ctx context.Context, accountRef domain.NamespacedName, accountID string, result *Secrets) *mock.Call {
+	return m.On("GetSecrets", ctx, accountRef, accountID).Return(result, true, nil)
 }
 
 func (m *secretManagerMock) mockGetSecretsFoundError(ctx context.Context, accountRef domain.NamespacedName, accountID string, err error) {

--- a/internal/core/mocks_test.go
+++ b/internal/core/mocks_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/WirelessCar/nauth/api/v1alpha1"
 	"github.com/WirelessCar/nauth/internal/adapter/outbound/k8s" // TODO: [#185] Core must not depend on adapter code
 	"github.com/WirelessCar/nauth/internal/domain"
 	"github.com/WirelessCar/nauth/internal/domain/nauth"
@@ -355,28 +354,31 @@ func (n *NatsAccConnectionMock) mockListAccountStreams(result []string) *mock.Ca
 var _ outbound.NatsAccountConnection = (*NatsAccConnectionMock)(nil)
 
 /* ****************************************************
-* outbound.AccountReader Resolver
+* outbound.AccountIDReader mock
 *****************************************************/
 
-// TODO: [#228] Remove AccountReaderMock
-type AccountReaderMock struct {
+type AccountIDReaderMock struct {
 	mock.Mock
 }
 
-func NewAccountReaderMock() *AccountReaderMock {
-	return &AccountReaderMock{}
+func NewAccountIDReaderMock() *AccountIDReaderMock {
+	return &AccountIDReaderMock{}
 }
 
-func (a *AccountReaderMock) Get(ctx context.Context, accountRef domain.NamespacedName) (account *v1alpha1.Account, err error) {
+func (a *AccountIDReaderMock) GetAccountID(ctx context.Context, accountRef domain.NamespacedName) (nauth.AccountID, error) {
 	args := a.Called(ctx, accountRef)
-	return args.Get(0).(*v1alpha1.Account), args.Error(1)
+	return args.Get(0).(nauth.AccountID), args.Error(1)
 }
 
-func (a *AccountReaderMock) mockGet(ctx context.Context, accountRef domain.NamespacedName, result *v1alpha1.Account) *mock.Call {
-	return a.On("Get", ctx, accountRef).Return(result, nil)
+func (a *AccountIDReaderMock) mockGetAccountID(ctx context.Context, accountRef domain.NamespacedName, result string) *mock.Call {
+	return a.On("GetAccountID", ctx, accountRef).Return(nauth.AccountID(result), nil)
 }
 
-var _ outbound.AccountReader = &AccountReaderMock{}
+func (a *AccountIDReaderMock) mockGetAccountIDError(ctx context.Context, accountRef domain.NamespacedName, err error) *mock.Call {
+	return a.On("GetAccountID", ctx, accountRef).Return(nauth.AccountID(""), err)
+}
+
+var _ outbound.AccountIDReader = &AccountIDReaderMock{}
 
 /* ****************************************************
 * NatsCluster Resolver

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,0 +1,104 @@
+package domain
+
+import "errors"
+
+type ErrCode string
+
+const (
+	CodeUnknownError      ErrCode = "UnknownError"
+	CodeBadRequest        ErrCode = "BadRequest"
+	CodeConfigMapNotFound ErrCode = "ConfigMapNotFound"
+	CodeAccountNotFound   ErrCode = "AccountNotFound"
+	CodeAccountNotReady   ErrCode = "AccountNotReady"
+)
+
+func ErrBadRequest(cause error) NAuthError {
+	return Err(CodeBadRequest, cause)
+}
+
+func ErrConfigMapNotFound() NAuthError {
+	return Err(CodeConfigMapNotFound, nil)
+}
+
+func ErrAccountNotFound() NAuthError {
+	return Err(CodeAccountNotFound, nil)
+}
+
+func ErrAccountNotReady() NAuthError {
+	return Err(CodeAccountNotReady, nil)
+}
+
+func ErrUnknownError(cause error) NAuthError {
+	return Err(CodeUnknownError, cause)
+}
+
+func Err(code ErrCode, cause error) NAuthError {
+	return &nauthError{
+		code:  code,
+		cause: cause,
+	}
+}
+
+func CodeOf(err error) ErrCode {
+	if err == nil {
+		return ""
+	}
+
+	if domainErr, ok := errors.AsType[NAuthError](err); ok {
+		return domainErr.Code()
+	}
+	return CodeUnknownError
+}
+
+func HasCode(err error, code ErrCode) bool {
+	return CodeOf(err) == code
+}
+
+type NAuthError interface {
+	error
+	Code() ErrCode
+	Unwrap() error
+}
+
+type nauthError struct {
+	code  ErrCode
+	cause error
+}
+
+func (e *nauthError) Error() string {
+	code := e.Code()
+	if code == "" {
+		code = CodeUnknownError
+	}
+
+	result := string(code)
+	if e.cause != nil {
+		result += ": " + e.cause.Error()
+	}
+	return result
+}
+
+func (e *nauthError) Code() ErrCode {
+	if e.code == "" {
+		return CodeUnknownError
+	}
+	return e.code
+}
+
+func (e *nauthError) Unwrap() error {
+	return e.cause
+}
+
+func (e *nauthError) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+
+	if targetErr, ok := errors.AsType[NAuthError](target); ok {
+		return e.Code() == targetErr.Code()
+	}
+	return false
+}
+
+var _ error = &nauthError{}
+var _ NAuthError = &nauthError{}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,104 +1,37 @@
 package domain
 
-import "errors"
-
-type ErrCode string
-
-const (
-	CodeUnknownError      ErrCode = "UnknownError"
-	CodeBadRequest        ErrCode = "BadRequest"
-	CodeConfigMapNotFound ErrCode = "ConfigMapNotFound"
-	CodeAccountNotFound   ErrCode = "AccountNotFound"
-	CodeAccountNotReady   ErrCode = "AccountNotReady"
+import (
+	"errors"
+	"fmt"
 )
 
-func ErrBadRequest(cause error) NAuthError {
-	return Err(CodeBadRequest, cause)
+type Error string
+
+const (
+	ErrUnknownError      Error = "UnknownError"
+	ErrBadRequest        Error = "BadRequest"
+	ErrAccountNotFound   Error = "AccountNotFound"
+	ErrAccountNotReady   Error = "AccountNotReady"
+	ErrConfigMapNotFound Error = "ConfigMapNotFound"
+)
+
+func (e Error) Error() string {
+	return string(e)
 }
 
-func ErrConfigMapNotFound() NAuthError {
-	return Err(CodeConfigMapNotFound, nil)
+func (e Error) Is(target error) bool {
+	var targetErr Error
+	ok := errors.As(target, &targetErr)
+	return ok && e == targetErr
 }
 
-func ErrAccountNotFound() NAuthError {
-	return Err(CodeAccountNotFound, nil)
+func (e Error) WithCause(cause error) error {
+	return wrapError(e, cause)
 }
 
-func ErrAccountNotReady() NAuthError {
-	return Err(CodeAccountNotReady, nil)
-}
-
-func ErrUnknownError(cause error) NAuthError {
-	return Err(CodeUnknownError, cause)
-}
-
-func Err(code ErrCode, cause error) NAuthError {
-	return &nauthError{
-		code:  code,
-		cause: cause,
+func wrapError(err Error, cause error) error {
+	if cause == nil {
+		return err
 	}
+	return fmt.Errorf("%w: %w", err, cause)
 }
-
-func CodeOf(err error) ErrCode {
-	if err == nil {
-		return ""
-	}
-
-	if domainErr, ok := errors.AsType[NAuthError](err); ok {
-		return domainErr.Code()
-	}
-	return CodeUnknownError
-}
-
-func HasCode(err error, code ErrCode) bool {
-	return CodeOf(err) == code
-}
-
-type NAuthError interface {
-	error
-	Code() ErrCode
-	Unwrap() error
-}
-
-type nauthError struct {
-	code  ErrCode
-	cause error
-}
-
-func (e *nauthError) Error() string {
-	code := e.Code()
-	if code == "" {
-		code = CodeUnknownError
-	}
-
-	result := string(code)
-	if e.cause != nil {
-		result += ": " + e.cause.Error()
-	}
-	return result
-}
-
-func (e *nauthError) Code() ErrCode {
-	if e.code == "" {
-		return CodeUnknownError
-	}
-	return e.code
-}
-
-func (e *nauthError) Unwrap() error {
-	return e.cause
-}
-
-func (e *nauthError) Is(target error) bool {
-	if target == nil {
-		return false
-	}
-
-	if targetErr, ok := errors.AsType[NAuthError](target); ok {
-		return e.Code() == targetErr.Code()
-	}
-	return false
-}
-
-var _ error = &nauthError{}
-var _ NAuthError = &nauthError{}

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -2,79 +2,40 @@ package domain
 
 import (
 	"errors"
-	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestCodeOf(t *testing.T) {
-	t.Run("returns empty reason for nil", func(t *testing.T) {
-		if got := CodeOf(nil); got != "" {
-			t.Fatalf("expected empty reason, got %q", got)
-		}
-	})
+func Test_Error(t *testing.T) {
+	// When
+	err := ErrBadRequest
 
-	t.Run("returns domain error reason", func(t *testing.T) {
-		err := ErrAccountNotFound()
+	// Then
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBadRequest)
+	require.EqualError(t, err, "BadRequest")
+	require.Nil(t, errors.Unwrap(err))
 
-		if got := CodeOf(err); got != CodeAccountNotFound {
-			t.Fatalf("expected %q, got %q", CodeAccountNotFound, got)
-		}
-	})
-
-	t.Run("unwraps wrapped domain errors", func(t *testing.T) {
-		err := fmt.Errorf("lookup account: %w", ErrAccountNotReady())
-
-		if got := CodeOf(err); got != CodeAccountNotReady {
-			t.Fatalf("expected %q, got %q", CodeAccountNotReady, got)
-		}
-	})
-
-	t.Run("classifies non-domain errors as unhandled", func(t *testing.T) {
-		err := errors.New("plain failure")
-
-		if got := CodeOf(err); got != CodeUnknownError {
-			t.Fatalf("expected %q, got %q", CodeUnknownError, got)
-		}
-	})
+	var domainErr Error
+	require.ErrorAs(t, err, &domainErr)
+	require.Equal(t, ErrBadRequest, domainErr)
 }
 
-func TestNAuthError(t *testing.T) {
-	cause := errors.New("invalid account reference")
-	err := ErrBadRequest(cause)
+func Test_Error_WithCause(t *testing.T) {
+	// Given
+	cause := errors.New("the cause")
 
-	if got := err.Code(); got != CodeBadRequest {
-		t.Fatalf("expected %q, got %q", CodeBadRequest, got)
-	}
-	if !errors.Is(err, cause) {
-		t.Fatalf("expected errors.Is to match wrapped cause")
-	}
-	if !errors.Is(err, ErrBadRequest(nil)) {
-		t.Fatalf("expected errors.Is to match domain error code")
-	}
+	// When
+	err := ErrBadRequest.WithCause(cause)
 
-	var domainErr NAuthError
-	if !errors.As(fmt.Errorf("wrapped: %w", err), &domainErr) {
-		t.Fatalf("expected errors.As to find NAuthError")
-	}
-	if got := domainErr.Code(); got != CodeBadRequest {
-		t.Fatalf("expected %q, got %q", CodeBadRequest, got)
-	}
-}
+	// Then
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBadRequest)
+	require.ErrorIs(t, err, cause)
+	require.EqualError(t, err, "BadRequest: the cause")
 
-func TestNAuthError_Is(t *testing.T) {
-	t.Run("matches same code", func(t *testing.T) {
-		err := fmt.Errorf("wrapped: %w", ErrAccountNotReady())
-
-		if !errors.Is(err, ErrAccountNotReady()) {
-			t.Fatalf("expected errors.Is to match same domain error code")
-		}
-	})
-
-	t.Run("does not match different code", func(t *testing.T) {
-		err := ErrAccountNotReady()
-
-		if errors.Is(err, ErrAccountNotFound()) {
-			t.Fatalf("expected errors.Is not to match a different domain error code")
-		}
-	})
+	var domainErr Error
+	require.ErrorAs(t, err, &domainErr)
+	require.Equal(t, ErrBadRequest, domainErr)
 }

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -1,0 +1,80 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestCodeOf(t *testing.T) {
+	t.Run("returns empty reason for nil", func(t *testing.T) {
+		if got := CodeOf(nil); got != "" {
+			t.Fatalf("expected empty reason, got %q", got)
+		}
+	})
+
+	t.Run("returns domain error reason", func(t *testing.T) {
+		err := ErrAccountNotFound()
+
+		if got := CodeOf(err); got != CodeAccountNotFound {
+			t.Fatalf("expected %q, got %q", CodeAccountNotFound, got)
+		}
+	})
+
+	t.Run("unwraps wrapped domain errors", func(t *testing.T) {
+		err := fmt.Errorf("lookup account: %w", ErrAccountNotReady())
+
+		if got := CodeOf(err); got != CodeAccountNotReady {
+			t.Fatalf("expected %q, got %q", CodeAccountNotReady, got)
+		}
+	})
+
+	t.Run("classifies non-domain errors as unhandled", func(t *testing.T) {
+		err := errors.New("plain failure")
+
+		if got := CodeOf(err); got != CodeUnknownError {
+			t.Fatalf("expected %q, got %q", CodeUnknownError, got)
+		}
+	})
+}
+
+func TestNAuthError(t *testing.T) {
+	cause := errors.New("invalid account reference")
+	err := ErrBadRequest(cause)
+
+	if got := err.Code(); got != CodeBadRequest {
+		t.Fatalf("expected %q, got %q", CodeBadRequest, got)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("expected errors.Is to match wrapped cause")
+	}
+	if !errors.Is(err, ErrBadRequest(nil)) {
+		t.Fatalf("expected errors.Is to match domain error code")
+	}
+
+	var domainErr NAuthError
+	if !errors.As(fmt.Errorf("wrapped: %w", err), &domainErr) {
+		t.Fatalf("expected errors.As to find NAuthError")
+	}
+	if got := domainErr.Code(); got != CodeBadRequest {
+		t.Fatalf("expected %q, got %q", CodeBadRequest, got)
+	}
+}
+
+func TestNAuthError_Is(t *testing.T) {
+	t.Run("matches same code", func(t *testing.T) {
+		err := fmt.Errorf("wrapped: %w", ErrAccountNotReady())
+
+		if !errors.Is(err, ErrAccountNotReady()) {
+			t.Fatalf("expected errors.Is to match same domain error code")
+		}
+	})
+
+	t.Run("does not match different code", func(t *testing.T) {
+		err := ErrAccountNotReady()
+
+		if errors.Is(err, ErrAccountNotFound()) {
+			t.Fatalf("expected errors.Is not to match a different domain error code")
+		}
+	})
+}

--- a/internal/ports/outbound/k8s.go
+++ b/internal/ports/outbound/k8s.go
@@ -9,6 +9,10 @@ import (
 )
 
 type ConfigMapReader interface {
+	// Get returns the ConfigMap data as a map of key to string value.
+	// Keys from both Data and BinaryData are included.
+	// Returns domain.ErrBadRequest if the configMapRef is invalid.
+	// Returns domain.ErrConfigMapNotFound if the ConfigMap does not exist.
 	Get(ctx context.Context, configMapRef domain.NamespacedName) (map[string]string, error)
 }
 

--- a/internal/ports/outbound/nauth.go
+++ b/internal/ports/outbound/nauth.go
@@ -15,5 +15,13 @@ type ClusterReader interface {
 // AccountReader reads NAuth Account resources
 // TODO: [#228] Remove outbound.AccountReader as an outbound port
 type AccountReader interface {
-	Get(ctx context.Context, accountRef domain.NamespacedName) (account *v1alpha1.Account, err error)
+	Get(ctx context.Context, accountRef domain.NamespacedName) (*v1alpha1.Account, error)
+}
+
+type AccountIDReader interface {
+	// GetAccountID returns the NAuth Account ID for the given account reference.
+	// Returns domain.ErrBadRequest if the accountRef is invalid.
+	// Returns domain.ErrAccountNotFound if the Account does not exist.
+	// Returns domain.ErrAccountNotReady if the Account is not ready or does not have an Account ID label.
+	GetAccountID(ctx context.Context, accountRef domain.NamespacedName) (nauth.AccountID, error)
 }


### PR DESCRIPTION
Replace core Account lookups with AccountIDReader so core code only depends on the Account ID it needs instead of reading `v1alpha1.Account` directly.

Introduce typed domain errors for account/configmap lookup failures and remove the k8s adapter-specific errors. Update the k8s outbound adapter, mocks, and tests to use the new domain errors with errors.Is support.

