### PR TITLE
test(e2e): add KUTTL coverage for AccountExport workflows

### DIFF
--- a/kuttl-fast.yaml
+++ b/kuttl-fast.yaml
@@ -1,0 +1,15 @@
+# kuttl-fast.yaml does not create (nor delete) the local kind cluster, so you can run kuttl tests faster
+# during their development. To use it you need to have nauth deployed manually in local kind cluster.
+# This is done with `mise nauth:install`
+#
+# After that you can run all kuttl tests with `kuttl test -f kuttl-fast.yaml`
+#
+# OR a specific one with:
+# `kubectl kuttl test --config kuttl-fast.yaml --test account-export`
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+startKIND: false
+artifactsDir: test/logs
+testDirs:
+  - test/e2e
+timeout: 20

--- a/test/e2e/account-export-conflict/01-assert.yaml
+++ b/test/e2e/account-export-conflict/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-account
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+

--- a/test/e2e/account-export-conflict/01-create-account.yaml
+++ b/test/e2e/account-export-conflict/01-create-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+

--- a/test/e2e/account-export-conflict/02-assert-account.yaml
+++ b/test/e2e/account-export-conflict/02-assert-account.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export-a
+    ref: export_a
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export-b
+    ref: export_b
+assertAll:
+  - celExpr: my_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(my_account.status.adoptions) && has(my_account.status.adoptions.exports) && my_account.status.adoptions.exports.size() == 2
+  - celExpr: my_account.status.adoptions.exports.exists(a, a.uid == export_a.metadata.uid)
+  - celExpr: my_account.status.adoptions.exports.exists(a, a.uid == export_b.metadata.uid)
+  - celExpr: my_account.status.adoptions.exports.exists(a, a.uid == export_a.metadata.uid && a.status.desiredClaimObservedGeneration == export_a.status.desiredClaim.observedGeneration)
+  - celExpr: my_account.status.adoptions.exports.exists(a, a.uid == export_b.metadata.uid && a.status.desiredClaimObservedGeneration == export_b.status.desiredClaim.observedGeneration)
+  - celExpr: my_account.status.adoptions.exports.filter(a, a.status.status == "True" && a.status.reason == "OK").size() == 1
+  - celExpr: my_account.status.adoptions.exports.filter(a, a.status.status == "False" && a.status.reason == "Conflict").size() == 1
+  - celExpr: has(my_account.status.claims.exports) && my_account.status.claims.exports.size() == 1
+

--- a/test/e2e/account-export-conflict/02-assert-exports.yaml
+++ b/test/e2e/account-export-conflict/02-assert-exports.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export-a
+    ref: export_a
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export-b
+    ref: export_b
+assertAll:
+  - celExpr: export_a.metadata.labels["accountexport.nauth.io/account-id"] == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: export_b.metadata.labels["accountexport.nauth.io/account-id"] == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: export_a.status.accountID == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: export_b.status.accountID == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: export_a.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: export_b.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: export_a.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: export_b.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: '(export_a.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK") && export_b.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "False" && c.reason == "Failed")) || (export_b.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK") && export_a.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "False" && c.reason == "Failed"))'
+  - celExpr: '(export_a.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "OK") && export_b.status.conditions.exists(c, c.type == "Ready" && c.status == "False" && c.reason == "Reconciling")) || (export_b.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "OK") && export_a.status.conditions.exists(c, c.type == "Ready" && c.status == "False" && c.reason == "Reconciling"))'
+

--- a/test/e2e/account-export-conflict/02-create-export-a.yaml
+++ b/test/e2e/account-export-conflict/02-create-export-a.yaml
@@ -1,0 +1,11 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export-a
+spec:
+  accountName: my-account
+  rules:
+    - name: conflicting-a
+      subject: conflict.>
+      type: stream
+

--- a/test/e2e/account-export-conflict/02-create-export-b.yaml
+++ b/test/e2e/account-export-conflict/02-create-export-b.yaml
@@ -1,0 +1,11 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export-b
+spec:
+  accountName: my-account
+  rules:
+    - name: conflicting-b
+      subject: conflict.*
+      type: stream
+

--- a/test/e2e/account-export-invalid-update/01-assert.yaml
+++ b/test/e2e/account-export-invalid-update/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-account
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+

--- a/test/e2e/account-export-invalid-update/01-create-account.yaml
+++ b/test/e2e/account-export-invalid-update/01-create-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+

--- a/test/e2e/account-export-invalid-update/02-assert-account.yaml
+++ b/test/e2e/account-export-invalid-update/02-assert-account.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(my_account.status.adoptions) && has(my_account.status.adoptions.exports) && my_account.status.adoptions.exports.size() == 1
+  - celExpr: my_account.status.adoptions.exports[0].uid == my_account_export.metadata.uid
+  - celExpr: my_account.status.adoptions.exports[0].status.desiredClaimObservedGeneration == my_account_export.status.desiredClaim.observedGeneration
+  - celExpr: my_account.status.adoptions.exports[0].status.reason == "OK" && my_account.status.adoptions.exports[0].status.status == "True"
+  - celExpr: has(my_account.status.claims.exports) && my_account.status.claims.exports.size() == 1
+  - celExpr: my_account.status.claims.exports[0].name == "initial-rule"
+  - celExpr: my_account.status.claims.exports[0].subject == "export-invalid-update.>"
+  - celExpr: my_account.status.claims.exports[0].type == "stream"
+

--- a/test/e2e/account-export-invalid-update/02-assert-export.yaml
+++ b/test/e2e/account-export-invalid-update/02-assert-export.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account_export.metadata.labels["accountexport.nauth.io/account-id"] == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.accountID == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.desiredClaim.observedGeneration == my_account_export.metadata.generation
+  - celExpr: my_account_export.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_export.status.desiredClaim.rules[0].name == "initial-rule"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].subject == "export-invalid-update.>"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].type == "stream"
+

--- a/test/e2e/account-export-invalid-update/02-create-export.yaml
+++ b/test/e2e/account-export-invalid-update/02-create-export.yaml
@@ -1,0 +1,11 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export
+spec:
+  accountName: my-account
+  rules:
+    - name: initial-rule
+      subject: export-invalid-update.>
+      type: stream
+

--- a/test/e2e/account-export-invalid-update/03-account-export-invalid-update.yaml
+++ b/test/e2e/account-export-invalid-update/03-account-export-invalid-update.yaml
@@ -1,0 +1,11 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export
+spec:
+  accountName: my-account
+  rules:
+    - name: invalid-rule
+      subject: .
+      type: stream
+

--- a/test/e2e/account-export-invalid-update/03-assert-account.yaml
+++ b/test/e2e/account-export-invalid-update/03-assert-account.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(my_account.status.adoptions) && has(my_account.status.adoptions.exports) && my_account.status.adoptions.exports.size() == 1
+  - celExpr: my_account.status.adoptions.exports[0].uid == my_account_export.metadata.uid
+  - celExpr: my_account.status.adoptions.exports[0].status.desiredClaimObservedGeneration == my_account_export.status.desiredClaim.observedGeneration
+  - celExpr: my_account.status.adoptions.exports[0].status.reason == "OK" && my_account.status.adoptions.exports[0].status.status == "True"
+  - celExpr: has(my_account.status.claims.exports) && my_account.status.claims.exports.size() == 1
+  - celExpr: my_account.status.claims.exports[0].name == "initial-rule"
+  - celExpr: my_account.status.claims.exports[0].subject == "export-invalid-update.>"
+  - celExpr: my_account.status.claims.exports[0].type == "stream"
+

--- a/test/e2e/account-export-invalid-update/03-assert-export.yaml
+++ b/test/e2e/account-export-invalid-update/03-assert-export.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account_export.metadata.labels["accountexport.nauth.io/account-id"] == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.accountID == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.metadata.generation == 2
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "ValidRules" && c.status == "False" && c.reason == "Invalid")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "False" && c.reason == "Adopting")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "Ready" && c.status == "False" && c.reason == "Reconciling")
+  - celExpr: has(my_account_export.status.desiredClaim) && my_account_export.status.desiredClaim.observedGeneration == 1
+  - celExpr: my_account_export.status.desiredClaim.observedGeneration < my_account_export.metadata.generation
+  - celExpr: my_account_export.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_export.status.desiredClaim.rules[0].name == "initial-rule"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].subject == "export-invalid-update.>"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].type == "stream"
+

--- a/test/e2e/account-export-missing-account/01-assert-export.yaml
+++ b/test/e2e/account-export-missing-account/01-assert-export.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "False")
+  - celExpr: '!my_account_export.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True")'
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "Ready" && c.status == "False" && c.reason == "Reconciling")
+  - celExpr: has(my_account_export.status.desiredClaim) && my_account_export.status.desiredClaim.observedGeneration == my_account_export.metadata.generation
+  - celExpr: my_account_export.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_export.status.desiredClaim.rules[0].name == "recovery-rule"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].subject == "export-missing-account.>"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].type == "stream"
+

--- a/test/e2e/account-export-missing-account/01-create-export.yaml
+++ b/test/e2e/account-export-missing-account/01-create-export.yaml
@@ -1,0 +1,11 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export
+spec:
+  accountName: my-account
+  rules:
+    - name: recovery-rule
+      subject: export-missing-account.>
+      type: stream
+

--- a/test/e2e/account-export-missing-account/02-assert-account.yaml
+++ b/test/e2e/account-export-missing-account/02-assert-account.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(my_account.status.adoptions) && has(my_account.status.adoptions.exports) && my_account.status.adoptions.exports.size() == 1
+  - celExpr: my_account.status.adoptions.exports[0].uid == my_account_export.metadata.uid
+  - celExpr: my_account.status.adoptions.exports[0].status.desiredClaimObservedGeneration == my_account_export.status.desiredClaim.observedGeneration
+  - celExpr: my_account.status.adoptions.exports[0].status.reason == "OK" && my_account.status.adoptions.exports[0].status.status == "True"
+  - celExpr: has(my_account.status.claims.exports) && my_account.status.claims.exports.size() == 1
+  - celExpr: my_account.status.claims.exports[0].name == "recovery-rule"
+  - celExpr: my_account.status.claims.exports[0].subject == "export-missing-account.>"
+  - celExpr: my_account.status.claims.exports[0].type == "stream"
+

--- a/test/e2e/account-export-missing-account/02-assert-export.yaml
+++ b/test/e2e/account-export-missing-account/02-assert-export.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account_export.metadata.labels["accountexport.nauth.io/account-id"] == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.accountID == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.desiredClaim.observedGeneration == my_account_export.metadata.generation
+  - celExpr: my_account_export.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_export.status.desiredClaim.rules[0].name == "recovery-rule"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].subject == "export-missing-account.>"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].type == "stream"
+

--- a/test/e2e/account-export-missing-account/02-create-account.yaml
+++ b/test/e2e/account-export-missing-account/02-create-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+

--- a/test/e2e/account-export/01-assert.yaml
+++ b/test/e2e/account-export/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-account
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled

--- a/test/e2e/account-export/01-create-account.yaml
+++ b/test/e2e/account-export/01-create-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats

--- a/test/e2e/account-export/02-assert-account.yaml
+++ b/test/e2e/account-export/02-assert-account.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(my_account.status.adoptions) && has(my_account.status.adoptions.exports) && my_account.status.adoptions.exports.size() == 1
+  - celExpr: my_account.status.adoptions.exports[0].uid == my_account_export.metadata.uid
+  - celExpr: my_account.status.adoptions.exports[0].status.desiredClaimObservedGeneration == my_account_export.status.desiredClaim.observedGeneration
+  - celExpr: my_account.status.adoptions.exports[0].status.reason == "Adopted" && my_account.status.adoptions.exports[0].status.status == "True"

--- a/test/e2e/account-export/02-assert-export.yaml
+++ b/test/e2e/account-export/02-assert-export.yaml
@@ -1,0 +1,35 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account_export.metadata.labels["accountexport.nauth.io/account-id"] == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.accountID == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+
+---
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export
+#  labels:
+#    accountexport.nauth.io/account-id: ACCOUNTID   # Verified above
+status:
+  #  accountId: ACCOUNTID    # verified above
+  desiredClaim:
+    observedGeneration: 1
+    rules:
+      - name: test-rule
+        subject: export-account.>
+        type: stream

--- a/test/e2e/account-export/02-create-export.yaml
+++ b/test/e2e/account-export/02-create-export.yaml
@@ -1,0 +1,10 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export
+spec:
+  accountName: my-account
+  rules:
+    - name: test-rule
+      subject: export-account.>
+      type: stream

--- a/test/e2e/account-export/03-account-export-update.yaml
+++ b/test/e2e/account-export/03-account-export-update.yaml
@@ -1,0 +1,11 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountExport
+metadata:
+  name: my-account-export
+spec:
+  accountName: my-account
+  rules:
+    - name: updated-rule
+      subject: export-account-updated.>
+      type: stream
+

--- a/test/e2e/account-export/03-assert-account.yaml
+++ b/test/e2e/account-export/03-assert-account.yaml
@@ -1,0 +1,23 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(my_account.status.adoptions) && has(my_account.status.adoptions.exports) && my_account.status.adoptions.exports.size() == 1
+  - celExpr: my_account.status.adoptions.exports[0].uid == my_account_export.metadata.uid
+  - celExpr: my_account.status.adoptions.exports[0].status.desiredClaimObservedGeneration == my_account_export.status.desiredClaim.observedGeneration
+  - celExpr: my_account.status.adoptions.exports[0].status.status == "True"
+  - celExpr: has(my_account.status.claims.exports) && my_account.status.claims.exports.size() == 1
+  - celExpr: my_account.status.claims.exports[0].name == "updated-rule"
+  - celExpr: my_account.status.claims.exports[0].subject == "export-account-updated.>"
+  - celExpr: my_account.status.claims.exports[0].type == "stream"
+

--- a/test/e2e/account-export/03-assert-export.yaml
+++ b/test/e2e/account-export/03-assert-export.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: my-account
+    ref: my_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountExport
+    name: my-account-export
+    ref: my_account_export
+assertAll:
+  - celExpr: my_account_export.metadata.labels["accountexport.nauth.io/account-id"] == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.accountID == my_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_export.status.desiredClaim.observedGeneration == my_account_export.metadata.generation
+  - celExpr: my_account_export.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_export.status.desiredClaim.rules[0].name == "updated-rule"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].subject == "export-account-updated.>"
+  - celExpr: my_account_export.status.desiredClaim.rules[0].type == "stream"
+


### PR DESCRIPTION
## Summary

Add end-to-end KUTTL coverage for `AccountExport` behavior so export reconciliation is exercised across the main happy path and key failure/recovery scenarios.

## What changed

- add a new `account-export` KUTTL scenario covering:
  - account creation
  - export creation
  - export adoption by the account
  - export updates propagating into the desired claim
- add an `account-export-conflict` scenario covering competing exports for the same account and asserting conflict handling/adoption state
- add an `account-export-invalid-update` scenario covering invalid rule updates and asserting that the previously observed desired claim is preserved while reconciliation remains non-ready
- add an `account-export-missing-account` scenario covering export creation before the target account exists, then verifying recovery once the account is created
- add `kuttl-fast.yaml` to make it easier to iterate on KUTTL suites against an already-running local Kind cluster

## Why

`AccountExport` flows had limited e2e coverage. These tests lock in expected behavior for reconciliation, adoption, conflict handling, recovery, and teardown, reducing the risk of regressions in controller behavior.

## How to validate

```bash
make test-e2e