### PR TITLE
fix(account): block account deletion while imports or exports are still bound

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -123,7 +123,6 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			log.Info("Failed to list users", "name", natsAccount.Name, "error", err)
 			return ctrl.Result{}, err
 		}
-
 		if len(userList.Items) > 0 {
 			return r.reporter.error(
 				ctx,
@@ -132,14 +131,29 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			)
 		}
 
-		// TODO: [#11] This will block the deletion and requires manual intervention to continue (removing finalizer)
-		// TODO: [#11] Investigate and understand if blocking preemptively with webhooks is a better option (not allowing change)?
-		adoptions := natsAccount.Status.Adoptions
-		if adoptions != nil && len(adoptions.Exports) > 0 {
+		exports, err := r.findExportsByAccountID(ctx, domain.Namespace(natsAccount.Namespace), accountID)
+		if err != nil {
+			log.Error(err, "Failed to list exports for account during deletion", "name", natsAccount.Name)
+			return ctrl.Result{}, err
+		}
+		if len(exports.Items) > 0 {
 			return r.reporter.error(
 				ctx,
 				natsAccount,
-				fmt.Errorf("cannot delete an account with adopted exports, found %d adoptions", len(adoptions.Exports)),
+				fmt.Errorf("cannot delete an account with bound exports, found %d bindings", len(exports.Items)),
+			)
+		}
+
+		imports, err := r.findImportsByAccountID(ctx, domain.Namespace(natsAccount.Namespace), accountID)
+		if err != nil {
+			log.Error(err, "Failed to list imports for account during deletion", "name", natsAccount.Name)
+			return ctrl.Result{}, err
+		}
+		if len(imports.Items) > 0 {
+			return r.reporter.error(
+				ctx,
+				natsAccount,
+				fmt.Errorf("cannot delete an account with bound imports, found %d bindings", len(imports.Items)),
 			)
 		}
 

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -116,45 +117,12 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 
-		// Check for connected users
-		userList := &v1alpha1.UserList{}
-		err := r.List(ctx, userList, client.MatchingLabels{string(v1alpha1.UserLabelAccountID): string(accountID)}, client.InNamespace(req.Namespace))
+		err := r.validateAccountDeletion(ctx, accountID, domain.Namespace(natsAccount.Namespace))
 		if err != nil {
-			log.Info("Failed to list users", "name", natsAccount.Name, "error", err)
-			return ctrl.Result{}, err
-		}
-		if len(userList.Items) > 0 {
-			return r.reporter.error(
-				ctx,
-				natsAccount,
-				fmt.Errorf("cannot delete an account with associated users, found %d users", len(userList.Items)),
-			)
-		}
-
-		exports, err := r.findExportsByAccountID(ctx, domain.Namespace(natsAccount.Namespace), accountID)
-		if err != nil {
-			log.Error(err, "Failed to list exports for account during deletion", "name", natsAccount.Name)
-			return ctrl.Result{}, err
-		}
-		if len(exports.Items) > 0 {
-			return r.reporter.error(
-				ctx,
-				natsAccount,
-				fmt.Errorf("cannot delete an account with bound exports, found %d bindings", len(exports.Items)),
-			)
-		}
-
-		imports, err := r.findImportsByAccountID(ctx, domain.Namespace(natsAccount.Namespace), accountID)
-		if err != nil {
-			log.Error(err, "Failed to list imports for account during deletion", "name", natsAccount.Name)
-			return ctrl.Result{}, err
-		}
-		if len(imports.Items) > 0 {
-			return r.reporter.error(
-				ctx,
-				natsAccount,
-				fmt.Errorf("cannot delete an account with bound imports, found %d bindings", len(imports.Items)),
-			)
+			if errors.Is(err, domain.ErrUnknownError) {
+				return ctrl.Result{}, err
+			}
+			return r.reporter.error(ctx, natsAccount, err)
 		}
 
 		if controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
@@ -529,6 +497,43 @@ func (r *AccountReconciler) mapAccountImportToAccounts(ctx context.Context, obj 
 	}
 
 	return requests
+}
+
+func (r *AccountReconciler) validateAccountDeletion(ctx context.Context, accountID nauth.AccountID, namespace domain.Namespace) error {
+	log := logf.FromContext(ctx)
+
+	// Check for bound users
+	userList := &v1alpha1.UserList{}
+	err := r.List(ctx, userList, client.MatchingLabels{string(v1alpha1.UserLabelAccountID): string(accountID)}, client.InNamespace(namespace))
+	if err != nil {
+		log.Error(err, "Failed to list users bound to account")
+		return domain.ErrUnknownError.WithCause(err)
+	}
+	if len(userList.Items) > 0 {
+		return fmt.Errorf("cannot delete an account with associated users, found %d users", len(userList.Items))
+	}
+
+	// check for bound exports
+	exports, err := r.findExportsByAccountID(ctx, namespace, accountID)
+	if err != nil {
+		log.Error(err, "Failed to list exports bound to account")
+		return domain.ErrUnknownError.WithCause(err)
+	}
+	if len(exports.Items) > 0 {
+		return fmt.Errorf("found %d export bindings", len(exports.Items))
+	}
+
+	// check for bound imports
+	imports, err := r.findImportsByAccountID(ctx, namespace, accountID)
+	if err != nil {
+		log.Error(err, "Failed to list imports bound to account")
+		return domain.ErrUnknownError.WithCause(err)
+	}
+	if len(imports.Items) > 0 {
+		return fmt.Errorf("found %d import bindings", len(imports.Items))
+	}
+
+	return nil
 }
 
 func accountImportWatchPredicateForAccounts() predicate.Funcs {

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -59,7 +59,8 @@ func NewAccountImportReconciler(k8sClient client.Client, scheme *runtime.Scheme,
 	}
 }
 
-// +kubebuilder:rbac:groups=nauth.io,resources=accountimports,verbs=get;list;watch
+// +kubebuilder:rbac:groups=nauth.io,resources=accountimports,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=nauth.io,resources=accountimports/status,verbs=get;update;patch
 
 func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)


### PR DESCRIPTION
# Summary

This PR fixes account deletion handling so an `Account` cannot be removed while dependent `AccountImport` or AccountExport` bindings still exist. Previously the delete flow only relied on adoption status, which did not update once in the deletion logic flow.

* The reconciliation logic now lists bound imports and exports directly during account deletion and returns a clear error when bindings are still present. 

* It also updates AccountImport RBAC to allow the controller to patch status and labels as part of reconciliation.