### PR TITLE
feat(account-import): watch referenced export accounts and add KUTTL coverage

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -426,7 +426,7 @@ func accountExportWatchPredicateForAccounts() predicate.Funcs {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldExport, oldOK := e.ObjectOld.(*v1alpha1.AccountExport)
 			newExport, newOK := e.ObjectNew.(*v1alpha1.AccountExport)
-			return oldOK && newOK && accountExportUpdateAffectsAccounts(oldExport, newExport)
+			return oldOK && newOK && accountExportUpdateAffectsReferencedResources(oldExport, newExport)
 		},
 		GenericFunc: func(event.GenericEvent) bool {
 			// Ignore all other type of events
@@ -435,7 +435,7 @@ func accountExportWatchPredicateForAccounts() predicate.Funcs {
 	}
 }
 
-func accountExportUpdateAffectsAccounts(oldExport *v1alpha1.AccountExport, newExport *v1alpha1.AccountExport) bool {
+func accountExportUpdateAffectsReferencedResources(oldExport *v1alpha1.AccountExport, newExport *v1alpha1.AccountExport) bool {
 	if oldExport == nil || newExport == nil {
 		return false
 	}

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -426,7 +426,7 @@ func accountExportWatchPredicateForAccounts() predicate.Funcs {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldExport, oldOK := e.ObjectOld.(*v1alpha1.AccountExport)
 			newExport, newOK := e.ObjectNew.(*v1alpha1.AccountExport)
-			return oldOK && newOK && accountExportUpdateAffectsReferencedResources(oldExport, newExport)
+			return oldOK && newOK && accountExportUpdateAffectsAccounts(oldExport, newExport)
 		},
 		GenericFunc: func(event.GenericEvent) bool {
 			// Ignore all other type of events
@@ -435,7 +435,7 @@ func accountExportWatchPredicateForAccounts() predicate.Funcs {
 	}
 }
 
-func accountExportUpdateAffectsReferencedResources(oldExport *v1alpha1.AccountExport, newExport *v1alpha1.AccountExport) bool {
+func accountExportUpdateAffectsAccounts(oldExport *v1alpha1.AccountExport, newExport *v1alpha1.AccountExport) bool {
 	if oldExport == nil || newExport == nil {
 		return false
 	}

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -313,6 +313,7 @@ func (r *AccountImportReconciler) mapExportAccountToAccountImports(ctx context.C
 
 	imports := &v1alpha1.AccountImportList{}
 	if err := r.List(ctx, imports,
+		// TODO: [#11] handle case when Nauth is bound to single namespace
 		// search all namespaces
 		client.MatchingFields{importExportAccountRefIndexKey: accountNsn.String()},
 	); err != nil {

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -43,6 +43,7 @@ import (
 )
 
 const importAccountNameIndexKey string = "import.spec.accountName"
+const importExportAccountRefIndexKey string = "import.spec.exportAccountRef"
 
 // AccountImportReconciler reconciles an AccountImport object.
 type AccountImportReconciler struct {
@@ -197,9 +198,18 @@ func (r *AccountImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		context.Background(),
 		&v1alpha1.AccountImport{},
 		importAccountNameIndexKey,
-		importBySpecAccountNameIndexFunc,
+		byAccountNameIndexFunc,
 	); err != nil {
 		return fmt.Errorf("failed to index AccountImport by account name: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&v1alpha1.AccountImport{},
+		importExportAccountRefIndexKey,
+		byExportAccountRefIndexFunc,
+	); err != nil {
+		return fmt.Errorf("failed to index AccountImport by export account ref: %w", err)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -213,15 +223,53 @@ func (r *AccountImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.mapAccountToAccountImports),
 			builder.WithPredicates(accountImportAccountWatchPredicate()),
 		).
+		Watches(
+			&v1alpha1.Account{},
+			handler.EnqueueRequestsFromMapFunc(r.mapExportAccountToAccountImports),
+			builder.WithPredicates(accountImportExportAccountWatchPredicate()),
+		).
 		Complete(r)
 }
 
-func importBySpecAccountNameIndexFunc(rawObj client.Object) []string {
+func byAccountNameIndexFunc(rawObj client.Object) []string {
 	imp := rawObj.(*v1alpha1.AccountImport)
 	if imp.Spec.AccountName == "" {
 		return nil
 	}
 	return []string{imp.Spec.AccountName}
+}
+
+func byExportAccountRefIndexFunc(rawObj client.Object) []string {
+	imp := rawObj.(*v1alpha1.AccountImport)
+	ref := imp.Spec.ExportAccountRef
+	if ref.Name == "" && ref.Namespace == "" {
+		return nil
+	}
+
+	nsn := types.NamespacedName{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+	if ref.Namespace == "" {
+		// default to import namespace if not set
+		nsn.Namespace = imp.Namespace
+	}
+	return []string{nsn.String()}
+}
+
+func accountImportExportAccountWatchPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool { return true },
+		DeleteFunc: func(event.DeleteEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldAccount, oldOK := e.ObjectOld.(*v1alpha1.Account)
+			newAccount, newOK := e.ObjectNew.(*v1alpha1.Account)
+			return oldOK && newOK && accountUpdateAffectsExportAccountImports(oldAccount, newAccount)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
 }
 
 func (r *AccountImportReconciler) mapAccountToAccountImports(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -240,16 +288,57 @@ func (r *AccountImportReconciler) mapAccountToAccountImports(ctx context.Context
 	}
 
 	requests := make([]reconcile.Request, 0, len(imports.Items))
-	for _, export := range imports.Items {
+	for _, imp := range imports.Items {
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Namespace: export.Namespace,
-				Name:      export.Name,
+				Namespace: imp.Namespace,
+				Name:      imp.Name,
 			},
 		})
 	}
 
 	return requests
+}
+
+func (r *AccountImportReconciler) mapExportAccountToAccountImports(ctx context.Context, obj client.Object) []reconcile.Request {
+	account, ok := obj.(*v1alpha1.Account)
+	if !ok {
+		return nil
+	}
+
+	accountNsn := types.NamespacedName{
+		Namespace: account.Namespace,
+		Name:      account.Name,
+	}
+
+	imports := &v1alpha1.AccountImportList{}
+	if err := r.List(ctx, imports,
+		// search all namespaces
+		client.MatchingFields{importExportAccountRefIndexKey: accountNsn.String()},
+	); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list AccountImports for export Account watch", "account", account.Name, "namespace", account.Namespace)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(imports.Items))
+	for _, imp := range imports.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: imp.Namespace,
+				Name:      imp.Name,
+			},
+		})
+	}
+
+	return requests
+}
+
+func accountUpdateAffectsExportAccountImports(oldAccount *v1alpha1.Account, newAccount *v1alpha1.Account) bool {
+	if oldAccount == nil || newAccount == nil {
+		return false
+	}
+
+	return oldAccount.GetLabel(v1alpha1.AccountLabelAccountID) != newAccount.GetLabel(v1alpha1.AccountLabelAccountID)
 }
 
 func accountImportAccountWatchPredicate() predicate.Funcs {

--- a/internal/adapter/inbound/controller/account_import_watch_test.go
+++ b/internal/adapter/inbound/controller/account_import_watch_test.go
@@ -1,0 +1,184 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/WirelessCar/nauth/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestAccountImportReconciler_ShouldReconcileForExportAccountUpdate(t *testing.T) {
+	createAccount := func() *v1alpha1.Account {
+		return &v1alpha1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "export-account",
+				Namespace: "ns-a",
+				Labels: map[string]string{
+					string(v1alpha1.AccountLabelAccountID): accountIDAccA,
+				},
+			},
+			Status: v1alpha1.AccountStatus{
+				ObservedGeneration: 3,
+				OperatorVersion:    "v1.0.0",
+				ClaimsHash:         "hash-a",
+				ReconcileTimestamp: metav1.Now(),
+				Adoptions: &v1alpha1.AccountAdoptions{
+					Imports: []v1alpha1.AccountAdoption{
+						{
+							Name:               "import-a",
+							UID:                types.UID("import-uid"),
+							ObservedGeneration: 1,
+							Status: v1alpha1.AccountAdoptionStatus{
+								Status: metav1.ConditionFalse,
+								Reason: conditionReasonReconciling,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		mutate        func(account *v1alpha1.Account)
+		expectRequeue bool
+	}{
+		{
+			name: "bound_account_id_label_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Labels[string(v1alpha1.AccountLabelAccountID)] = accountIDAccB
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "bound_account_id_label_removed",
+			mutate: func(account *v1alpha1.Account) {
+				delete(account.Labels, string(v1alpha1.AccountLabelAccountID))
+			},
+			expectRequeue: true,
+		},
+		{
+			name: "adoption_status_only_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.Adoptions.Imports[0].Status.Status = metav1.ConditionTrue
+				account.Status.Adoptions.Imports[0].Status.Reason = conditionReasonOK
+			},
+			expectRequeue: false,
+		},
+		{
+			name: "claims_hash_only_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.ClaimsHash = "hash-b"
+			},
+			expectRequeue: false,
+		},
+		{
+			name: "observed_generation_only_changed",
+			mutate: func(account *v1alpha1.Account) {
+				account.Status.ObservedGeneration = 4
+			},
+			expectRequeue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldAccount := createAccount()
+			newAccount := oldAccount.DeepCopy()
+			tt.mutate(newAccount)
+
+			assert.Equal(t, tt.expectRequeue, accountUpdateAffectsExportAccountImports(oldAccount, newAccount))
+		})
+	}
+}
+
+func TestAccountImportReconciler_MapExportAccountToImports(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(testScheme))
+
+	byExportAccountRefIndexFunc := func(rawObj client.Object) []string {
+		imp := rawObj.(*v1alpha1.AccountImport)
+		ref := imp.Spec.ExportAccountRef
+		if ref.Name == "" && ref.Namespace == "" {
+			return nil
+		}
+
+		nsn := types.NamespacedName{
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+		}
+		if ref.Namespace == "" {
+			nsn.Namespace = imp.Namespace
+		}
+		return []string{nsn.String()}
+	}
+
+	exportAccount := &v1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "export-account",
+			Namespace: "export-ns",
+		},
+	}
+	matchingExplicitNamespace := &v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "import-explicit",
+			Namespace: "import-ns",
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name:      "export-account",
+				Namespace: "export-ns",
+			},
+		},
+	}
+	matchingImplicitNamespace := &v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "import-implicit",
+			Namespace: "export-ns",
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name: "export-account",
+			},
+		},
+	}
+	nonMatchingImport := &v1alpha1.AccountImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "import-other",
+			Namespace: "export-ns",
+		},
+		Spec: v1alpha1.AccountImportSpec{
+			ExportAccountRef: v1alpha1.AccountRef{
+				Name: "other-account",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithIndex(&v1alpha1.AccountImport{}, importExportAccountRefIndexKey, byExportAccountRefIndexFunc).
+		WithObjects(exportAccount, matchingExplicitNamespace, matchingImplicitNamespace, nonMatchingImport).
+		Build()
+
+	reconciler := &AccountImportReconciler{Client: fakeClient}
+
+	requests := reconciler.mapExportAccountToAccountImports(context.Background(), exportAccount)
+	require.Len(t, requests, 2)
+	assert.ElementsMatch(t, []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{Namespace: "import-ns", Name: "import-explicit"},
+		},
+		{
+			NamespacedName: types.NamespacedName{Namespace: "export-ns", Name: "import-implicit"},
+		},
+	}, requests)
+}

--- a/internal/adapter/inbound/controller/account_watch_test.go
+++ b/internal/adapter/inbound/controller/account_watch_test.go
@@ -113,7 +113,7 @@ func TestAccountReconciler_ShouldReconcileForAccountExportUpdate(t *testing.T) {
 			newExport := oldExport.DeepCopy()
 			tt.mutate(newExport)
 
-			assert.Equal(t, tt.expectRequeue, accountExportUpdateAffectsAccounts(oldExport, newExport))
+			assert.Equal(t, tt.expectRequeue, accountExportUpdateAffectsReferencedResources(oldExport, newExport))
 		})
 	}
 }

--- a/internal/adapter/inbound/controller/account_watch_test.go
+++ b/internal/adapter/inbound/controller/account_watch_test.go
@@ -113,7 +113,7 @@ func TestAccountReconciler_ShouldReconcileForAccountExportUpdate(t *testing.T) {
 			newExport := oldExport.DeepCopy()
 			tt.mutate(newExport)
 
-			assert.Equal(t, tt.expectRequeue, accountExportUpdateAffectsReferencedResources(oldExport, newExport))
+			assert.Equal(t, tt.expectRequeue, accountExportUpdateAffectsAccounts(oldExport, newExport))
 		})
 	}
 }

--- a/test/e2e/account-deletion-jetstream/README.md
+++ b/test/e2e/account-deletion-jetstream/README.md
@@ -1,0 +1,21 @@
+# account-deletion-jetstream
+
+This KUTTL suite verifies that deleting `example-account` is blocked while the account still owns a JetStream stream, and then completes after the stream is removed.
+
+It creates:
+
+- `example-account` in the test namespace
+- a JetStream stream named `ORDERS` using temporary credentials for `example-account`
+
+It then:
+
+- requests deletion of `example-account`
+- removes the `ORDERS` stream
+
+The assertions verify that:
+
+- `example-account` reconciles successfully before deletion
+- the delete request puts `example-account` into a terminating state with its finalizer still present
+- `example-account` reports a failed ready condition that mentions the blocking JetStream stream
+- once `ORDERS` is deleted, `example-account` no longer exists
+- the generated account root and signing secrets are cleaned up after deletion completes

--- a/test/e2e/account-deletion/README.md
+++ b/test/e2e/account-deletion/README.md
@@ -1,0 +1,19 @@
+# account-deletion
+
+This KUTTL suite verifies that deleting `example-account` removes the account and its generated secrets.
+
+It creates:
+
+- `example-account` in the test namespace
+- generated account root and signing secrets for `example-account`
+
+It then deletes:
+
+- `example-account`
+
+The assertions verify that:
+
+- `example-account` reconciles successfully before deletion
+- the generated account root and signing secrets exist before deletion
+- `example-account` no longer exists after deletion
+- the generated account root and signing secrets no longer exist after deletion

--- a/test/e2e/account-export-conflict/README.md
+++ b/test/e2e/account-export-conflict/README.md
@@ -1,0 +1,24 @@
+# account-export-conflict
+
+This KUTTL suite verifies that conflicting exports for `my-account` do not both become active at the same time.
+
+It creates:
+
+- `my-account` in the test namespace
+- `my-account-export-a` for `my-account`
+- `my-account-export-b` for `my-account`
+
+The export rules intentionally overlap:
+
+- `my-account-export-a` exports `conflict.>`
+- `my-account-export-b` exports `conflict.*`
+
+The assertions verify that:
+
+- `my-account` reconciles successfully
+- both exports resolve and store the account ID for `my-account`
+- both exports are bound and valid
+- `my-account` records adoptions for both exports
+- exactly one export is adopted successfully
+- the other export reports a conflict and is not active
+- `my-account` renders only one export claim

--- a/test/e2e/account-export-invalid-update/README.md
+++ b/test/e2e/account-export-invalid-update/README.md
@@ -1,0 +1,20 @@
+# account-export-invalid-update
+
+This KUTTL suite verifies that an invalid update to `my-account-export` does not replace the last valid export claim already adopted by `my-account`.
+
+It creates:
+
+- `my-account` in the test namespace
+- `my-account-export` for `my-account`
+
+It then updates:
+
+- `my-account-export` with an invalid rule
+
+The assertions verify that:
+
+- `my-account` and the initial `my-account-export` reconcile successfully
+- `my-account` adopts the initial export and renders the initial export claim
+- after the invalid update, `my-account-export` no longer has valid rules for the new generation
+- the last valid `desiredClaim` remains present on `my-account-export`
+- `my-account` keeps the previously adopted export claim instead of switching to the invalid update

--- a/test/e2e/account-export-missing-account/README.md
+++ b/test/e2e/account-export-missing-account/README.md
@@ -1,0 +1,16 @@
+# account-export-missing-account
+
+This KUTTL suite verifies that `my-account-export` stays not ready while `my-account` is missing, and then converges after `my-account` is created.
+
+It creates:
+
+- `my-account-export` in the test namespace
+- `my-account` later in the same namespace
+
+The assertions verify that:
+
+- `my-account-export` has valid rules even before `my-account` exists
+- `my-account-export` stays not ready while `my-account` is missing
+- `my-account-export` has no bound account ID while `my-account` is missing
+- once `my-account` is created, `my-account-export` resolves the account ID and reaches `Ready=True`
+- `my-account` adopts the export and renders the expected export claim

--- a/test/e2e/account-export/README.md
+++ b/test/e2e/account-export/README.md
@@ -1,0 +1,21 @@
+# account-export
+
+This KUTTL suite verifies that `my-account-export` is adopted by `my-account` and that updates to `my-account-export` are reflected in `my-account`.
+
+It creates:
+
+- `my-account` in the test namespace
+- `my-account-export` for `my-account`
+
+It then updates:
+
+- `my-account-export`
+
+The assertions verify that:
+
+- `my-account` reconciles successfully
+- `my-account-export` resolves and stores the account ID for `my-account`
+- `my-account-export` reaches `Ready=True`
+- `my-account` adopts `my-account-export`
+- the generated `desiredClaim` for `my-account-export` contains the expected export rule
+- after the update, `my-account` renders the updated export claim

--- a/test/e2e/account-import-cross-namespace/01-create-export-namespace.gotmpl.yaml
+++ b/test/e2e/account-import-cross-namespace/01-create-export-namespace.gotmpl.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}-export

--- a/test/e2e/account-import-cross-namespace/02-assert-accounts.gotmpl.yaml
+++ b/test/e2e/account-import-cross-namespace/02-assert-accounts.gotmpl.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    namespace: {{ .Namespace }}-export
+    name: export-account
+    ref: export_account
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: export_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")

--- a/test/e2e/account-import-cross-namespace/02-create-accounts.gotmpl.yaml
+++ b/test/e2e/account-import-cross-namespace/02-create-accounts.gotmpl.yaml
@@ -1,0 +1,18 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: import-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+---
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: export-account
+  namespace: {{ .Namespace }}-export
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats

--- a/test/e2e/account-import-cross-namespace/03-assert-account.gotmpl.yaml
+++ b/test/e2e/account-import-cross-namespace/03-assert-account.gotmpl.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    namespace: {{ .Namespace }}-export
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(import_account.status.adoptions) && has(import_account.status.adoptions.imports) && import_account.status.adoptions.imports.size() == 1
+  - celExpr: import_account.status.adoptions.imports[0].uid == my_account_import.metadata.uid
+  - celExpr: import_account.status.adoptions.imports[0].status.status == "True"
+  - celExpr: import_account.status.adoptions.imports[0].status.desiredClaimObservedGeneration == my_account_import.status.desiredClaim.observedGeneration
+  - celExpr: has(import_account.status.claims.imports) && import_account.status.claims.imports.size() == 1
+  - celExpr: import_account.status.claims.imports[0].name == "cross-namespace-rule"
+  - celExpr: import_account.status.claims.imports[0].subject == "shared.cross.>"
+  - celExpr: import_account.status.claims.imports[0].type == "stream"
+  - celExpr: import_account.status.claims.imports[0].account == export_account.metadata.labels["account.nauth.io/id"]

--- a/test/e2e/account-import-cross-namespace/03-assert-import.gotmpl.yaml
+++ b/test/e2e/account-import-cross-namespace/03-assert-import.gotmpl.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    namespace: {{ .Namespace }}-export
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Ready")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.desiredClaim.observedGeneration == my_account_import.metadata.generation
+  - celExpr: my_account_import.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_import.status.desiredClaim.rules[0].name == "cross-namespace-rule"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].subject == "shared.cross.>"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].type == "stream"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].account == export_account.metadata.labels["account.nauth.io/id"]

--- a/test/e2e/account-import-cross-namespace/03-create-import.gotmpl.yaml
+++ b/test/e2e/account-import-cross-namespace/03-create-import.gotmpl.yaml
@@ -1,0 +1,13 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountImport
+metadata:
+  name: my-account-import
+spec:
+  accountName: import-account
+  exportAccountRef:
+    name: export-account
+    namespace: {{ .Namespace }}-export
+  rules:
+    - name: cross-namespace-rule
+      subject: shared.cross.>
+      type: stream

--- a/test/e2e/account-import-cross-namespace/99-cleanup-export-namespace.gotmpl.yaml
+++ b/test/e2e/account-import-cross-namespace/99-cleanup-export-namespace.gotmpl.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: Namespace
+    name: {{ .Namespace }}-export

--- a/test/e2e/account-import-cross-namespace/README.md
+++ b/test/e2e/account-import-cross-namespace/README.md
@@ -1,0 +1,20 @@
+# account-import-cross-namespace
+
+This KUTTL suite verifies that an `AccountImport` can bind to an export account in a different Kubernetes namespace.
+
+It creates:
+
+- a dedicated export namespace
+- `import-account` in the test namespace
+- `export-account` in the export namespace
+- `my-account-import` in the test namespace, pointing at the foreign export account
+
+The assertions verify that:
+
+- both accounts reconcile successfully
+- `my-account-import` resolves and stores both account IDs
+- `my-account-import` reaches `Ready=True`
+- the generated `desiredClaim` for `my-account-import` points at the foreign export account ID
+- `import-account` adopts the import and renders the expected import claim
+
+The final step deletes the extra export namespace explicitly, since it is outside the auto-generated test namespace that KUTTL cleans up automatically.

--- a/test/e2e/account-import-invalid-update/01-assert-accounts.yaml
+++ b/test/e2e/account-import-invalid-update/01-assert-accounts.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: export_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+

--- a/test/e2e/account-import-invalid-update/01-create-accounts.yaml
+++ b/test/e2e/account-import-invalid-update/01-create-accounts.yaml
@@ -1,0 +1,18 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: import-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+---
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: export-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+

--- a/test/e2e/account-import-invalid-update/02-assert-account.yaml
+++ b/test/e2e/account-import-invalid-update/02-assert-account.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(import_account.status.adoptions) && has(import_account.status.adoptions.imports) && import_account.status.adoptions.imports.size() == 1
+  - celExpr: import_account.status.adoptions.imports[0].uid == my_account_import.metadata.uid
+  - celExpr: import_account.status.adoptions.imports[0].status.status == "True"
+  - celExpr: import_account.status.adoptions.imports[0].status.desiredClaimObservedGeneration == my_account_import.status.desiredClaim.observedGeneration
+  - celExpr: has(import_account.status.claims.imports) && import_account.status.claims.imports.size() == 1
+  - celExpr: import_account.status.claims.imports[0].name == "initial-rule"
+  - celExpr: import_account.status.claims.imports[0].subject == "shared.>"
+  - celExpr: import_account.status.claims.imports[0].type == "stream"
+  - celExpr: import_account.status.claims.imports[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import-invalid-update/02-assert-import.yaml
+++ b/test/e2e/account-import-invalid-update/02-assert-import.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Ready")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.desiredClaim.observedGeneration == my_account_import.metadata.generation
+  - celExpr: my_account_import.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_import.status.desiredClaim.rules[0].name == "initial-rule"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].subject == "shared.>"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].type == "stream"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import-invalid-update/02-create-import.gotmpl.yaml
+++ b/test/e2e/account-import-invalid-update/02-create-import.gotmpl.yaml
@@ -1,0 +1,13 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountImport
+metadata:
+  name: my-account-import
+spec:
+  accountName: import-account
+  exportAccountRef:
+    name: export-account
+    namespace: {{ .Namespace }}
+  rules:
+    - name: initial-rule
+      subject: shared.>
+      type: stream

--- a/test/e2e/account-import-invalid-update/03-account-import-invalid-update.gotmpl.yaml
+++ b/test/e2e/account-import-invalid-update/03-account-import-invalid-update.gotmpl.yaml
@@ -1,0 +1,16 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountImport
+metadata:
+  name: my-account-import
+spec:
+  accountName: import-account
+  exportAccountRef:
+    name: export-account
+    namespace: {{ .Namespace }}
+  rules:
+    - name: invalid-rule-a
+      subject: duplicate-service.*
+      type: service
+    - name: invalid-rule-b
+      subject: duplicate-service.*
+      type: service

--- a/test/e2e/account-import-invalid-update/03-assert-account.yaml
+++ b/test/e2e/account-import-invalid-update/03-assert-account.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(import_account.status.adoptions) && has(import_account.status.adoptions.imports) && import_account.status.adoptions.imports.size() == 1
+  - celExpr: import_account.status.adoptions.imports[0].uid == my_account_import.metadata.uid
+  - celExpr: import_account.status.adoptions.imports[0].status.status == "True"
+  - celExpr: import_account.status.adoptions.imports[0].status.desiredClaimObservedGeneration == my_account_import.status.desiredClaim.observedGeneration
+  - celExpr: has(import_account.status.claims.imports) && import_account.status.claims.imports.size() == 1
+  - celExpr: import_account.status.claims.imports[0].name == "initial-rule"
+  - celExpr: import_account.status.claims.imports[0].subject == "shared.>"
+  - celExpr: import_account.status.claims.imports[0].type == "stream"
+  - celExpr: import_account.status.claims.imports[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import-invalid-update/03-assert-import.yaml
+++ b/test/e2e/account-import-invalid-update/03-assert-import.yaml
@@ -1,0 +1,33 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.generation == 2
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "False" && c.reason == "NOK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "False" && c.reason == "Adopting")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "False" && c.reason == "NotReady")
+  - celExpr: has(my_account_import.status.desiredClaim) && my_account_import.status.desiredClaim.observedGeneration == 1
+  - celExpr: my_account_import.status.desiredClaim.observedGeneration < my_account_import.metadata.generation
+  - celExpr: my_account_import.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_import.status.desiredClaim.rules[0].name == "initial-rule"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].subject == "shared.>"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].type == "stream"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import-invalid-update/README.md
+++ b/test/e2e/account-import-invalid-update/README.md
@@ -1,0 +1,21 @@
+# account-import-invalid-update
+
+This KUTTL suite verifies that an invalid update to `my-account-import` does not replace the last valid import claim already adopted by `import-account`.
+
+It creates:
+
+- `import-account` in the test namespace
+- `export-account` in the test namespace
+- `my-account-import` in the test namespace, pointing at `export-account`
+
+It then updates:
+
+- `my-account-import` with invalid import rules
+
+The assertions verify that:
+
+- the initial `my-account-import` reconciles successfully
+- `import-account` adopts the initial import and renders the initial import claim
+- after the invalid update, the new generation does not become valid or ready
+- the last valid `desiredClaim` remains present on `my-account-import`
+- `import-account` keeps the previously adopted import claim instead of switching to the invalid update

--- a/test/e2e/account-import-missing-account/01-assert-export-account.yaml
+++ b/test/e2e/account-import-missing-account/01-assert-export-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+assertAll:
+  - celExpr: export_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+
+

--- a/test/e2e/account-import-missing-account/01-create-export-account.yaml
+++ b/test/e2e/account-import-missing-account/01-create-export-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: export-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+

--- a/test/e2e/account-import-missing-account/02-assert-import.yaml
+++ b/test/e2e/account-import-missing-account/02-assert-import.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "False" && c.reason == "NotFound")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "False" && c.reason == "NOK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "False" && c.reason == "Adopting")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "False" && c.reason == "NotReady")
+  - celExpr: '!has(my_account_import.status.desiredClaim)'
+
+

--- a/test/e2e/account-import-missing-account/02-create-import.gotmpl.yaml
+++ b/test/e2e/account-import-missing-account/02-create-import.gotmpl.yaml
@@ -1,0 +1,13 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountImport
+metadata:
+  name: my-account-import
+spec:
+  accountName: import-account
+  exportAccountRef:
+    name: export-account
+    namespace: {{ .Namespace }}
+  rules:
+    - name: recovery-rule
+      subject: delayed-account.>
+      type: stream

--- a/test/e2e/account-import-missing-account/03-assert-account.yaml
+++ b/test/e2e/account-import-missing-account/03-assert-account.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(import_account.status.adoptions) && has(import_account.status.adoptions.imports) && import_account.status.adoptions.imports.size() == 1
+  - celExpr: import_account.status.adoptions.imports[0].uid == my_account_import.metadata.uid
+  - celExpr: import_account.status.adoptions.imports[0].status.status == "True"
+  - celExpr: import_account.status.adoptions.imports[0].status.desiredClaimObservedGeneration == my_account_import.status.desiredClaim.observedGeneration
+  - celExpr: has(import_account.status.claims.imports) && import_account.status.claims.imports.size() == 1
+  - celExpr: import_account.status.claims.imports[0].name == "recovery-rule"
+  - celExpr: import_account.status.claims.imports[0].subject == "delayed-account.>"
+  - celExpr: import_account.status.claims.imports[0].type == "stream"
+  - celExpr: import_account.status.claims.imports[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import-missing-account/03-assert-import.yaml
+++ b/test/e2e/account-import-missing-account/03-assert-import.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Ready")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.desiredClaim.observedGeneration == my_account_import.metadata.generation
+  - celExpr: my_account_import.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_import.status.desiredClaim.rules[0].name == "recovery-rule"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].subject == "delayed-account.>"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].type == "stream"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import-missing-account/03-create-import-account.yaml
+++ b/test/e2e/account-import-missing-account/03-create-import-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: import-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+

--- a/test/e2e/account-import-missing-account/README.md
+++ b/test/e2e/account-import-missing-account/README.md
@@ -1,0 +1,17 @@
+# account-import-missing-account
+
+This KUTTL suite verifies that `my-account-import` stays not ready while `import-account` is missing, and then converges after `import-account` is created.
+
+It creates:
+
+- `export-account` in the test namespace
+- `my-account-import` in the test namespace, pointing at `export-account`
+- `import-account` later in the same namespace
+
+The assertions verify that:
+
+- `my-account-import` resolves `export-account` immediately
+- `my-account-import` stays not ready while `import-account` is missing
+- `my-account-import` has no `desiredClaim` while `import-account` is missing
+- once `import-account` is created, `my-account-import` resolves the import account ID and reaches `Ready=True`
+- `import-account` adopts the import and renders the expected import claim

--- a/test/e2e/account-import-missing-export-account/01-assert-import-account.yaml
+++ b/test/e2e/account-import-missing-export-account/01-assert-import-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")

--- a/test/e2e/account-import-missing-export-account/01-create-import-account.yaml
+++ b/test/e2e/account-import-missing-export-account/01-create-import-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: import-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats

--- a/test/e2e/account-import-missing-export-account/02-assert-import.yaml
+++ b/test/e2e/account-import-missing-export-account/02-assert-import.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: '!has(my_account_import.status.exportAccountID)'
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "False" && c.reason == "NotFound")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "False" && c.reason == "NOK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "False" && c.reason == "Adopting")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "False" && c.reason == "NotReady")
+  - celExpr: '!has(my_account_import.status.desiredClaim)'

--- a/test/e2e/account-import-missing-export-account/02-create-import.gotmpl.yaml
+++ b/test/e2e/account-import-missing-export-account/02-create-import.gotmpl.yaml
@@ -1,0 +1,13 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountImport
+metadata:
+  name: my-account-import
+spec:
+  accountName: import-account
+  exportAccountRef:
+    name: export-account
+    namespace: {{ .Namespace }}
+  rules:
+    - name: delayed-export-rule
+      subject: export-delayed.>
+      type: stream

--- a/test/e2e/account-import-missing-export-account/03-assert-account.yaml
+++ b/test/e2e/account-import-missing-export-account/03-assert-account.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(import_account.status.adoptions) && has(import_account.status.adoptions.imports) && import_account.status.adoptions.imports.size() == 1
+  - celExpr: import_account.status.adoptions.imports[0].uid == my_account_import.metadata.uid
+  - celExpr: import_account.status.adoptions.imports[0].status.status == "True"
+  - celExpr: import_account.status.adoptions.imports[0].status.desiredClaimObservedGeneration == my_account_import.status.desiredClaim.observedGeneration
+  - celExpr: has(import_account.status.claims.imports) && import_account.status.claims.imports.size() == 1
+  - celExpr: import_account.status.claims.imports[0].name == "delayed-export-rule"
+  - celExpr: import_account.status.claims.imports[0].subject == "export-delayed.>"
+  - celExpr: import_account.status.claims.imports[0].type == "stream"
+  - celExpr: import_account.status.claims.imports[0].account == export_account.metadata.labels["account.nauth.io/id"]

--- a/test/e2e/account-import-missing-export-account/03-assert-export-account.yaml
+++ b/test/e2e/account-import-missing-export-account/03-assert-export-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+assertAll:
+  - celExpr: export_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")

--- a/test/e2e/account-import-missing-export-account/03-assert-import.yaml
+++ b/test/e2e/account-import-missing-export-account/03-assert-import.yaml
@@ -1,0 +1,30 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Ready")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.desiredClaim.observedGeneration == my_account_import.metadata.generation
+  - celExpr: my_account_import.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_import.status.desiredClaim.rules[0].name == "delayed-export-rule"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].subject == "export-delayed.>"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].type == "stream"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].account == export_account.metadata.labels["account.nauth.io/id"]

--- a/test/e2e/account-import-missing-export-account/03-create-export-account.yaml
+++ b/test/e2e/account-import-missing-export-account/03-create-export-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: export-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats

--- a/test/e2e/account-import-missing-export-account/README.md
+++ b/test/e2e/account-import-missing-export-account/README.md
@@ -1,0 +1,19 @@
+# account-import-missing-export-account
+
+This KUTTL suite verifies that `my-account-import` does not become ready while `export-account` is missing, and then converges automatically after `export-account` exists.
+
+It creates:
+
+- `import-account` in the test namespace
+- `my-account-import` in the test namespace, pointing at `export-account`
+- `export-account` later in the same namespace
+
+The assertions verify that:
+
+- `import-account` reconciles successfully
+- `my-account-import` binds to `import-account` immediately
+- `my-account-import` stays not ready while `export-account` is missing
+- `my-account-import` has no resolved export account ID or `desiredClaim` while `export-account` is missing
+- `export-account` reconciles successfully once created
+- `my-account-import` resolves `export-account`, reaches `Ready=True`, and renders the expected `desiredClaim`
+- `import-account` adopts the import and renders the expected import claim

--- a/test/e2e/account-import-observe/README.md
+++ b/test/e2e/account-import-observe/README.md
@@ -1,0 +1,16 @@
+# account-import-observe
+
+This KUTTL suite verifies that an observed account can be imported from an externally provided account JWT and reconciled through `nauth.io/management-policy: observe`.
+
+It creates:
+
+- account root and signing secrets for the fixed account ID `ADDS6I3G7LBIBNDMZ5Q32VUJN2XNSW2QK4HY2SY5ZA7I2JLBFYF4KJDO`
+- an uploaded account JWT for the same account ID
+- `example-account` in observe mode, bound to that account ID
+
+The assertions verify that:
+
+- `example-account` reconciles successfully in observe mode
+- `example-account` keeps the expected account ID and signed-by labels
+- `example-account` imports the claims from the uploaded JWT
+- the observed claims include the expected limits and export rule from the external account definition

--- a/test/e2e/account-import-service-local-subject/01-assert-accounts.yaml
+++ b/test/e2e/account-import-service-local-subject/01-assert-accounts.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: export_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")

--- a/test/e2e/account-import-service-local-subject/01-create-accounts.yaml
+++ b/test/e2e/account-import-service-local-subject/01-create-accounts.yaml
@@ -1,0 +1,17 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: import-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+---
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: export-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats

--- a/test/e2e/account-import-service-local-subject/02-assert-account.yaml
+++ b/test/e2e/account-import-service-local-subject/02-assert-account.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(import_account.status.adoptions) && has(import_account.status.adoptions.imports) && import_account.status.adoptions.imports.size() == 1
+  - celExpr: import_account.status.adoptions.imports[0].uid == my_account_import.metadata.uid
+  - celExpr: import_account.status.adoptions.imports[0].status.status == "True"
+  - celExpr: import_account.status.adoptions.imports[0].status.desiredClaimObservedGeneration == my_account_import.status.desiredClaim.observedGeneration
+  - celExpr: has(import_account.status.claims.imports) && import_account.status.claims.imports.size() == 1
+  - celExpr: import_account.status.claims.imports[0].name == "service-rule"
+  - celExpr: import_account.status.claims.imports[0].subject == "svc.request"
+  - celExpr: import_account.status.claims.imports[0].localSubject == "local.svc.request"
+  - celExpr: import_account.status.claims.imports[0].type == "service"
+  - celExpr: import_account.status.claims.imports[0].account == export_account.metadata.labels["account.nauth.io/id"]

--- a/test/e2e/account-import-service-local-subject/02-assert-import.yaml
+++ b/test/e2e/account-import-service-local-subject/02-assert-import.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Ready")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.desiredClaim.observedGeneration == my_account_import.metadata.generation
+  - celExpr: my_account_import.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_import.status.desiredClaim.rules[0].name == "service-rule"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].subject == "svc.request"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].localSubject == "local.svc.request"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].type == "service"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].account == export_account.metadata.labels["account.nauth.io/id"]

--- a/test/e2e/account-import-service-local-subject/02-create-import.gotmpl.yaml
+++ b/test/e2e/account-import-service-local-subject/02-create-import.gotmpl.yaml
@@ -1,0 +1,14 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountImport
+metadata:
+  name: my-account-import
+spec:
+  accountName: import-account
+  exportAccountRef:
+    name: export-account
+    namespace: {{ .Namespace }}
+  rules:
+    - name: service-rule
+      subject: svc.request
+      localSubject: local.svc.request
+      type: service

--- a/test/e2e/account-import-service-local-subject/README.md
+++ b/test/e2e/account-import-service-local-subject/README.md
@@ -1,0 +1,23 @@
+# account-import-service-local-subject
+
+This KUTTL suite verifies that `my-account-import` supports a service import rule with `localSubject`.
+
+It creates:
+
+- `import-account` in the test namespace
+- `export-account` in the test namespace
+- `my-account-import` in the test namespace, pointing at `export-account`
+
+The import rule uses:
+
+- `subject: svc.request`
+- `localSubject: local.svc.request`
+- `type: service`
+
+The assertions verify that:
+
+- `import-account` and `export-account` reconcile successfully
+- `my-account-import` resolves and stores both account IDs
+- `my-account-import` reaches `Ready=True`
+- the generated `desiredClaim` for `my-account-import` preserves `subject`, `localSubject`, `type`, and the resolved export account ID
+- `import-account` adopts the import and renders the expected service import claim

--- a/test/e2e/account-import/01-assert-accounts.yaml
+++ b/test/e2e/account-import/01-assert-accounts.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: export_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+

--- a/test/e2e/account-import/01-create-accounts.yaml
+++ b/test/e2e/account-import/01-create-accounts.yaml
@@ -1,0 +1,18 @@
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: import-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+---
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: export-account
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: local-nats
+

--- a/test/e2e/account-import/02-assert-account.yaml
+++ b/test/e2e/account-import/02-assert-account.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: import_account.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Reconciled")
+  - celExpr: has(import_account.status.adoptions) && has(import_account.status.adoptions.imports) && import_account.status.adoptions.imports.size() == 1
+  - celExpr: import_account.status.adoptions.imports[0].uid == my_account_import.metadata.uid
+  - celExpr: import_account.status.adoptions.imports[0].status.status == "True"
+  - celExpr: import_account.status.adoptions.imports[0].status.desiredClaimObservedGeneration == my_account_import.status.desiredClaim.observedGeneration
+  - celExpr: has(import_account.status.claims.imports) && import_account.status.claims.imports.size() == 1
+  - celExpr: import_account.status.claims.imports[0].name == "initial-rule"
+  - celExpr: import_account.status.claims.imports[0].subject == "shared.>"
+  - celExpr: import_account.status.claims.imports[0].type == "stream"
+  - celExpr: import_account.status.claims.imports[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import/02-assert-import.yaml
+++ b/test/e2e/account-import/02-assert-import.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20
+resourceRefs:
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: import-account
+    ref: import_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: Account
+    name: export-account
+    ref: export_account
+  - apiVersion: nauth.io/v1alpha1
+    kind: AccountImport
+    name: my-account-import
+    ref: my_account_import
+assertAll:
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/account-id"] == import_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.metadata.labels["accountimport.nauth.io/export-account-id"] == export_account.metadata.labels["account.nauth.io/id"]
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "Ready" && c.status == "True" && c.reason == "Ready")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "ValidRules" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "BoundToExportAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.conditions.exists(c, c.type == "AdoptedByAccount" && c.status == "True" && c.reason == "OK")
+  - celExpr: my_account_import.status.desiredClaim.observedGeneration == my_account_import.metadata.generation
+  - celExpr: my_account_import.status.desiredClaim.rules.size() == 1
+  - celExpr: my_account_import.status.desiredClaim.rules[0].name == "initial-rule"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].subject == "shared.>"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].type == "stream"
+  - celExpr: my_account_import.status.desiredClaim.rules[0].account == export_account.metadata.labels["account.nauth.io/id"]
+

--- a/test/e2e/account-import/02-create-import.gotmpl.yaml
+++ b/test/e2e/account-import/02-create-import.gotmpl.yaml
@@ -1,0 +1,13 @@
+apiVersion: nauth.io/v1alpha1
+kind: AccountImport
+metadata:
+  name: my-account-import
+spec:
+  accountName: import-account
+  exportAccountRef:
+    name: export-account
+    namespace: {{ .Namespace }}
+  rules:
+    - name: initial-rule
+      subject: shared.>
+      type: stream

--- a/test/e2e/account-import/README.md
+++ b/test/e2e/account-import/README.md
@@ -1,0 +1,17 @@
+# account-import
+
+This KUTTL suite verifies that `my-account-import` is adopted by `import-account` and renders a valid stream import from `export-account`.
+
+It creates:
+
+- `import-account` in the test namespace
+- `export-account` in the test namespace
+- `my-account-import` in the test namespace, pointing at `export-account`
+
+The assertions verify that:
+
+- `import-account` and `export-account` reconcile successfully
+- `my-account-import` resolves and stores both account IDs
+- `my-account-import` reaches `Ready=True`
+- the generated `desiredClaim` for `my-account-import` contains the expected stream import rule
+- `import-account` adopts the import and renders the expected import claim

--- a/test/e2e/account-update/README.md
+++ b/test/e2e/account-update/README.md
@@ -1,0 +1,18 @@
+# account-update
+
+This KUTTL suite verifies that updating `example-account` changes its claims without changing its account ID.
+
+It creates:
+
+- `example-account` in the test namespace
+
+It then updates:
+
+- the display name and NATS limits on `example-account`
+
+The assertions verify that:
+
+- `example-account` reconciles successfully before and after the update
+- the original account ID is recorded before the update
+- the updated claims are applied after the update
+- the account ID on `example-account` stays the same across the update

--- a/test/e2e/basic-test/README.md
+++ b/test/e2e/basic-test/README.md
@@ -1,0 +1,22 @@
+# basic-test
+
+This KUTTL suite verifies the basic happy path for operator bootstrap resources, `example-account`, and `example-user`.
+
+It verifies existing bootstrap resources:
+
+- `operator-op-sign` in the `nats` namespace
+- `operator-sau-creds` in the `nats` namespace
+- `local-nats` as the default `NatsCluster`
+
+It creates:
+
+- `example-account` in the test namespace
+- `example-user` in the test namespace, pointing at `example-account`
+
+The assertions verify that:
+
+- the operator bootstrap secrets and `local-nats` exist and reference each other correctly
+- `example-account` reconciles successfully and receives an account ID and signing key
+- the generated account root and signing secrets exist for `example-account`
+- `example-user` reconciles successfully and is linked to `example-account`
+- the generated user credentials secret exists and is owned by `example-user`

--- a/test/e2e/cluster-ref-test/README.md
+++ b/test/e2e/cluster-ref-test/README.md
@@ -1,0 +1,22 @@
+# cluster-ref-test
+
+This KUTTL suite verifies the `natsClusterRef` flow using a dedicated namespace and secrets that do not use legacy `nauth.io/secret-type` labels.
+
+It creates:
+
+- the namespace `cluster-ref-test`
+- `nats-url-config` in `cluster-ref-test`
+- `my-operator-signing-key` in `cluster-ref-test`
+- `my-system-account-creds` in `cluster-ref-test`
+- `test-cluster` as a `NatsCluster` in `cluster-ref-test`
+- `cluster-ref-account` in `cluster-ref-test`
+- `cluster-ref-user` in `cluster-ref-test`
+
+The assertions verify that:
+
+- the setup secrets and ConfigMap exist without relying on legacy secret labels
+- `test-cluster` reconciles successfully and loads its URL and secret references from the dedicated namespace
+- `cluster-ref-account` reconciles successfully through `test-cluster`
+- `cluster-ref-account` gets generated account root and signing secrets in `cluster-ref-test`
+- no legacy operator bootstrap secret copies are created in `cluster-ref-test`
+- `cluster-ref-user` reconciles successfully and receives a generated user credentials secret


### PR DESCRIPTION
## Summary

Add end-to-end coverage for `AccountImport` scenarios and update the controller to reconcile imports when the referenced export account changes.

## What changed

- add an `AccountImport` field index for `spec.exportAccountRef`
- watch referenced `Account` resources from the `AccountImport` controller so imports are requeued when the export account binding changes
- add unit tests for the new export-account watch and request mapping behavior
- add KUTTL suites covering:
  - basic account import flow
  - cross-namespace export account references
  - missing import account recovery
  - missing export account recovery
  - invalid import updates preserving the last valid adopted claim
  - service imports with `localSubject`
- add brief (AI generated) README documentation for all KUTTL suites

## How to validate

```bash
make test
make test-e2e