### PR TITLE
ci: tune Renovate dependency PR behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":dependencyDashboard",
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
+    ":gitSignOff",
     "customManagers:biomeVersions"
   ],
   "timezone": "Europe/Stockholm",

--- a/renovate.json
+++ b/renovate.json
@@ -26,12 +26,18 @@
       "addLabels": ["major"]
     },
     {
+      "description": "Group remaining non-major dependency updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["*"],
+      "groupName": "misc dependency updates",
+      "groupSlug": "misc-dependencies"
+    },
+    {
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Go dependencies"
     },
     {
-      "matchManagers": ["bun"],
       "matchFileNames": ["www/**"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "www dependencies"
@@ -42,6 +48,13 @@
       "groupName": "GitHub Actions"
     },
     {
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["/^actions\\//"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "GitHub Actions major updates",
+      "groupSlug": "github-actions-major"
+    },
+    {
       "matchManagers": ["helmv3"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Helm chart dependencies"
@@ -49,12 +62,14 @@
     {
       "matchManagers": ["mise"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "mise tools"
+      "groupName": "local development tools",
+      "groupSlug": "local-development-tools"
     },
     {
       "matchFileNames": [".tool-versions"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "local tool versions"
+      "groupName": "local development tools",
+      "groupSlug": "local-development-tools"
     },
     {
       "matchFileNames": ["mise.toml"],


### PR DESCRIPTION
## Summary

Tune Renovate so generated dependency PRs satisfy repository checks and arrive in more reviewable groups.

## What changed

- Enable Renovate DCO sign-offs so bot commits include the required `Signed-off-by` footer.
- Group remaining non-major dependency updates to reduce one-off PR noise.
- Include `www/**` tooling updates, such as Biome, in the www dependency group.
- Combine `.tool-versions` and mise tool updates as local development tools.
- Batch major GitHub Actions updates while keeping higher-risk Node major, NATS Helm major, and lockfile maintenance separate.

## Validation

- `jq empty renovate.json`
- `npx --yes --package renovate renovate-config-validator renovate.json`

## Commits

- `ci: require Renovate commit sign-offs`
- `ci: reduce Renovate dependency PR noise`