### PR TITLE
docs: align public NAuth documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,29 +57,10 @@ it's important to have an understanding of how the basics work.
 
 [![NATS decentralized JWT Auth](https://i3.ytimg.com/vi/5pQVjN0ym5w/hqdefault.jpg)](https://youtu.be/5pQVjN0ym5w)
 
-## Import an existing NATS Account
-Use this to "observe" an account that already exists in the NATS cluster. NAuth will fetch the JWT from NATS and update 
-the account status, but it will never push a new JWT.
+## Observe existing NATS accounts
+NAuth can observe an existing NATS account without taking ownership of its JWT. Use this when migrating accounts into NAuth or recovering desired state from an existing cluster.
 
-#### Required Secrets
- - Account root seed secret labeled: `account.nauth.io/id=$ACCOUNT_PUBKEY`, `nauth.io/secret-type=account-root` and 
-`nauth.io/managed=true`. 
- - Account signing seed secret labeled: `account.nauth.io/id=$ACCOUNT_PUBKEY`, `nauth.io/secret-type=account-sign` 
-and `nauth.io/managed=true`. 
-
-#### Account CR example
-```yaml
-apiVersion: nauth.io/v1alpha1
-kind: Account
-metadata:
-  name: my-acc
-  labels:
-    account.nauth.io/id: $ACCOUNT_PUBKEY
-    nauth.io/management-policy: observe        # observe-only
-```
-
-Note: the System Account required by NAuth itself can only be observed and reconciliation of such an Account CRD without
-`nauth.io/management-policy: observe` label will fail.
+See the [observe existing accounts guide](https://nauth.io/guides/observe-existing-accounts/) for the required Secret labels and `Account` resource example.
 
 ## Nauth Development
 Check out the [CONTRIBUTING](./CONTRIBUTING.md) guide.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ NAuth can observe an existing NATS account without taking ownership of its JWT. 
 
 See the [observe existing accounts guide](https://nauth.io/guides/observe-existing-accounts/) for the required Secret labels and `Account` resource example.
 
-## Nauth Development
-Check out the [CONTRIBUTING](./CONTRIBUTING.md) guide.
+## Contributing
+Contributions are welcome. Open an issue for bugs, ideas, or larger changes, and read the [CONTRIBUTING](./CONTRIBUTING.md) guide for local setup and PR guidance.
 
 ### Join our Slack
 We co-locate with the NATS Slack in our [own channel](https://natsio.slack.com/archives/C0AFYH76KPD)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ NAuth resolves these credentials through a `NatsCluster`. Choose one of these re
 
 **B.** Define an explicit `spec.natsClusterRef` reference in each `Account` CR to a specific `NatsCluster`.
 
-You can see a full [operator example setup here](./examples/nauth/manifests/operator.yaml.md). 
-For a more secrets related example on how to set up NAuth using explicit secrets lookup based on `NatsClusterRef` and `NatsCluster` resources, see the [cluster reference scenario](./examples/nauth/manifests/scenarios/cluster-ref/README.md).
+For an example that defines a `NatsCluster`, explicit `spec.natsClusterRef`, and the required credential Secret references, see the [cluster reference scenario](./examples/nauth/manifests/scenarios/cluster-ref/README.md).
 
 ## Getting Started
 Running a large NATS cluster requires that the operator is secured properly. If you do not already have an operator, try

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ alongside the main chart with `crds.install=false`.
 NAuth requires [NATS](https://nats.io) to be installed in the cluster, since NAuth integrates with NATS (over NATS) to provide the account JWT:s.
 See examples of how to setup NATS with JWT auth together with NAuth in the [examples](./examples) directory.
 
-Nauth requires the **system account user credentials** and the [**operator signing key nkey seed**](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth) to be provided as k8s secrets.
+NAuth requires the **system account user credentials** and the [**operator signing key nkey seed**](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth) to be provided as Kubernetes Secrets.
 
-You can provide and resolve these secrets in three ways:
+NAuth resolves these credentials through a `NatsCluster`. Choose one of these reference patterns:
 
-**A.** For single-cluster deployments, set `NATS_CLUSTER_REF` on the nauth controller (`namespace/name`, for example `nats/my-nats-cluster`) and define the secrets in that referenced `NatsCluster` (`spec.operatorSigningKeySecretRef` and `spec.systemAccountUserCredsSecretRef`).
+**A.** For single-cluster deployments, set `NATS_CLUSTER_REF` on the NAuth controller (`namespace/name`, for example `nats/my-nats-cluster`) and define the secrets in that referenced `NatsCluster` (`spec.operatorSigningKeySecretRef` and `spec.systemAccountUserCredsSecretRef`).
    - Default behavior (`NATS_CLUSTER_REF_OPTIONAL=false`) is strict mode: account-level `spec.natsClusterRef` must match `NATS_CLUSTER_REF`.
    - `NATS_CLUSTER_REF_OPTIONAL=true` is explicit opt-in default mode: accounts without `spec.natsClusterRef` use `NATS_CLUSTER_REF`, while accounts may override with their own ref.
    - Recommended migration to per-account explicit refs:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,30 +1,9 @@
 # Reporting Security Issues
 
-If you discover a security issue, please report it by sending an email to security@wirelesscar.com
+If you discover a security issue, please report it by sending an email to security@wirelesscar.com.
 
-For critical issues, please encrypt message.
+Do not open a public GitHub issue for suspected vulnerabilities.
 
-This will allow us to assess the risk, and make a fix available before we add a bug report to the GitHub repository.
+This lets us assess the risk and make a fix available before public disclosure.
 
-Thanks for helping make this project safe for everyone.
-
-## Mail signature
-```
------BEGIN PGP SIGNED MESSAGE-----
-Hash: SHA256
-
-Contact: mailto:security@wirelesscar.com
-Expires: 2026-03-03T23:59:59.000Z
-Encryption: https://www.wirelesscar.com/.security/public.pgp
-Encryption: https://www.wirelesscar.com/.security/public.smime.crt
-Preferred-Languages: en
-Canonical: https://www.wirelesscar.com/.well-known/security.txt
------BEGIN PGP SIGNATURE-----
-
-iI8EARYIADcWIQQwReSYICxoGt6PTz9qqGsTcpy8twUCZAHowxkcc2VjdXJpdHlA
-d2lyZWxlc3NjYXIuY29tAAoJEGqoaxNynLy3iq4A/jCoHKp2LDVHM6UuvEckPt50
-eohKmtHZag9EucCT+H5EAP0dA6QSi893Lea4OewkPzmYUeU7nIQrFXRgQ11c84jd
-Ag==
-=IEd2
------END PGP SIGNATURE-----
-```
+If encrypted disclosure is required, send a minimal initial report and request current encryption details.

--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -43,6 +43,7 @@ export default defineConfig({
 					label: "Guides",
 					items: [
 						{ label: "Getting Started", slug: "guides/getting-started" },
+						{ label: "Observe Existing Accounts", slug: "guides/observe-existing-accounts" },
 						{ label: "Observability", slug: "guides/observability" },
 					],
 				},

--- a/www/src/content/docs/guides/getting-started.mdx
+++ b/www/src/content/docs/guides/getting-started.mdx
@@ -50,6 +50,8 @@ out:
 
 You can also use [`nsc`](https://github.com/nats-io/nsc) directly to create a throw-away operator & system account.
 
+Already have NATS accounts you do not want NAuth to manage yet? Use [observe mode](/guides/observe-existing-accounts/) to read existing account claims into status before migrating them into `spec`.
+
 ## More on decentralized JWT Auth
 It is recommended to have an understanding of how [decentralized authentication & authorization for
 NATS](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) works before using NAuth.

--- a/www/src/content/docs/guides/getting-started.mdx
+++ b/www/src/content/docs/guides/getting-started.mdx
@@ -17,16 +17,31 @@ NAuth supports installation through packaged [Helm](https://helm.sh) charts.
 
 ```bash
 helm install nauth oci://ghcr.io/wirelesscar/nauth \
---create-namespace \
---namespace nauth
+  --create-namespace \
+  --namespace nauth
 ```
+
+A [`nauth-crds`](https://github.com/WirelessCar/nauth/tree/main/charts/nauth-crds) chart is also available for installing CRDs separately. Use it alongside the main chart with `crds.install=false`.
 
 ### Pre-requisites
 NAuth requires [NATS](https://nats.io) to be installed in the cluster, since NAuth integrates with NATS (over NATS) to provide the account JWT:s.
 See examples of how to setup NATS with JWT auth together with NAuth in the [examples](https://github.com/WirelessCar/nauth/tree/main/examples) directory.
 
+NAuth requires these credentials as Kubernetes Secrets:
 
-## Getting Started
+- system account user credentials
+- [operator signing key nkey seed](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth)
+
+Define a `NatsCluster` resource with either `spec.url` or `spec.urlFrom`, plus `spec.operatorSigningKeySecretRef` and `spec.systemAccountUserCredsSecretRef`.
+
+Then choose how accounts target that cluster:
+
+- For single-cluster deployments, configure the controller with `NATS_CLUSTER_REF` (`namespace/name`). With the Helm chart, set `nats.clusterRef.name` and optionally `nats.clusterRef.namespace`.
+- For multi-cluster deployments, set `spec.natsClusterRef` on each `Account`.
+
+By default, an operator-level `NATS_CLUSTER_REF` is strict: account-level refs must match it. Set `NATS_CLUSTER_REF_OPTIONAL=true` when accounts without `spec.natsClusterRef` should use the operator cluster by default while still allowing explicit overrides.
+
+## Operator Setup
 Running a large NATS cluster requires that the operator is secured properly. If you do not already have an operator, try
 out:
 - the [operator-bootstrap](https://github.com/WirelessCar/nauth/tree/main/operator-bootstrap) utility which comes with NAuth to create your own operator

--- a/www/src/content/docs/guides/getting-started.mdx
+++ b/www/src/content/docs/guides/getting-started.mdx
@@ -50,6 +50,50 @@ out:
 
 You can also use [`nsc`](https://github.com/nats-io/nsc) directly to create a throw-away operator & system account.
 
+## Manage Accounts and Users
+NAuth's main workflow is to declare NATS accounts and users as Kubernetes resources. The controller creates the NATS account JWT, keeps it updated from `Account.spec`, and creates user credentials for each `User`.
+
+Create an account:
+
+```yaml
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: example-account
+  namespace: my-team
+spec:
+  natsClusterRef:
+    namespace: nats
+    name: my-nats-cluster
+  accountLimits:
+    conn: 100
+    imports: 10
+    exports: 10
+  natsLimits:
+    subs: 100
+```
+
+Create a user for that account:
+
+```yaml
+apiVersion: nauth.io/v1alpha1
+kind: User
+metadata:
+  name: example-user
+  namespace: my-team
+spec:
+  accountName: example-account
+  permissions:
+    pub:
+      allow:
+        - foo.>
+    sub:
+      allow:
+        - foo.>
+```
+
+NAuth writes the resulting user credentials to a Kubernetes Secret named `<user>-nats-user-creds` in the same namespace. For the full API surface, see the [API reference](/crds/).
+
 Already have NATS accounts you do not want NAuth to manage yet? Use [observe mode](/guides/observe-existing-accounts/) to read existing account claims into status before migrating them into `spec`.
 
 ## More on decentralized JWT Auth

--- a/www/src/content/docs/guides/getting-started.mdx
+++ b/www/src/content/docs/guides/getting-started.mdx
@@ -99,9 +99,7 @@ Already have NATS accounts you do not want NAuth to manage yet? Use [observe mod
 ## More on decentralized JWT Auth
 It is recommended to have an understanding of how [decentralized authentication & authorization for
 NATS](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) works before using NAuth.
-However, setting up your local NAuth & NATS bundle to experiment is also a good way to learn! Check out our
-[CONTRIBUTING guide](https://github.com/WirelessCar/nauth/blob/main/CONTRIBUTING.md), which describes how to setup a
-local testing environment with a bundled NATS cluster & configuration.
+Hands-on manifests are available in the [examples directory](https://github.com/WirelessCar/nauth/tree/main/examples), including account, user, import/export, and cluster reference scenarios.
 
 Check out this video for a comprehensive description on how decentralized JWT Auth works. In order to work with NAuth,
 it's important to have an understanding of how the basics work.

--- a/www/src/content/docs/guides/observe-existing-accounts.mdx
+++ b/www/src/content/docs/guides/observe-existing-accounts.mdx
@@ -1,0 +1,49 @@
+---
+title: Observe Existing Accounts
+description: Observe existing NATS accounts without letting NAuth manage them
+---
+
+NAuth's main workflow is to manage NATS `Account` and `User` resources from Kubernetes desired state. Observe mode is the exception: use it when an account already exists in NATS and you want NAuth to read it without taking ownership.
+
+In observe mode, NAuth reads the existing account JWT from NATS and populates `status.claims`. It does not manage or push a new JWT. The observed claims can be used as a starting point when migrating the account into `spec` or recovering desired state.
+
+The account root seed and account signing seed must exist as Kubernetes Secrets. NAuth discovers them by labels and reads each seed from the `default` data key.
+
+- account root seed labels: `account.nauth.io/id=$ACCOUNT_PUBKEY`, `nauth.io/secret-type=account-root`
+- account signing seed labels: `account.nauth.io/id=$ACCOUNT_PUBKEY`, `nauth.io/secret-type=account-sign`
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-acc-root
+  labels:
+    account.nauth.io/id: $ACCOUNT_PUBKEY
+    nauth.io/secret-type: account-root
+stringData:
+  default: $ACCOUNT_ROOT_SEED
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-acc-sign
+  labels:
+    account.nauth.io/id: $ACCOUNT_PUBKEY
+    nauth.io/secret-type: account-sign
+stringData:
+  default: $ACCOUNT_SIGNING_SEED
+```
+
+Create the `Account` resource with `nauth.io/management-policy: observe`:
+
+```yaml
+apiVersion: nauth.io/v1alpha1
+kind: Account
+metadata:
+  name: my-acc
+  labels:
+    account.nauth.io/id: $ACCOUNT_PUBKEY
+    nauth.io/management-policy: observe
+```
+
+If you represent the NATS system account in NAuth, use observe mode. NAuth prevents management of the system account JWT.

--- a/www/src/content/docs/index.mdx
+++ b/www/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Nauth
+title: NAuth
 description: Simplify NATS Operator & Account management for Kubernetes
 template: splash
 editUrl: false
@@ -22,39 +22,7 @@ import IconKubernetes from "~icons/devicon/kubernetes";
 import FluentColorShieldCheckmark48 from '~icons/fluent-color/shield-checkmark-48';
 import Card from "../../components/Card.astro";
 
-{/* ## Quick Start
-
-<CardGrid stagger>
-  <LinkCard 
-    title="Quick Start" 
-    icon="rocket"
-    href="./guides/quick-start/"
-    description="Get up and running with Nauth in minutes. Perfect for testing and development environments."
-  />
-  
-  <LinkCard 
-    title="Complete Setup" 
-    icon="open-book"
-    href="./guides/installation/"
-    description="Full installation guide with production-ready configurations and security best practices."
-  />
-  
-  <LinkCard 
-    title="User Management" 
-    icon="users"
-    href="./guides/user-management/"
-    description="Create and manage NATS users with fine-grained permissions and access controls."
-  />
-  
-  <LinkCard 
-    title="Account Management" 
-    icon="setting"
-    href="./guides/account-management/"
-    description="Configure NATS accounts, set limits, and organize your messaging infrastructure."
-  />
-</CardGrid> */}
-
-## Why Nauth?
+## Why NAuth?
 
 <CardGrid stagger>
   <Card title="Kubernetes Native">
@@ -75,10 +43,28 @@ import Card from "../../components/Card.astro";
 ## Documentation
 
 <CardGrid>
+  <LinkCard
+    title="Getting Started"
+    icon="rocket"
+    href="./guides/getting-started/"
+    description="Install NAuth, configure NATS credentials, and manage Accounts and Users."
+  />
+  <LinkCard
+    title="Observability"
+    icon="chart"
+    href="./guides/observability/"
+    description="Scrape controller-runtime metrics and monitor reconciliation behavior."
+  />
   <LinkCard 
     title="API Reference" 
     icon="document"
     href="./crds/"
     description="Complete API documentation for all Custom Resource Definitions."
+  />
+  <LinkCard
+    title="Examples"
+    icon="open-book"
+    href="https://github.com/WirelessCar/nauth/tree/main/examples"
+    description="Runnable Account, User, import/export, and cluster reference scenarios."
   />
 </CardGrid>

--- a/www/src/content/docs/index.mdx
+++ b/www/src/content/docs/index.mdx
@@ -64,7 +64,7 @@ import Card from "../../components/Card.astro";
   
   <Card title="Secure by Default">
     <FluentColorShieldCheckmark48 slot="icon" class="icon" size="1.333em" />
-    Automated key rotation, secure credential management, and isolation between accounts.
+    Keeps the operator root seed out of the controller and uses Kubernetes-native Secret management for credentials.
   </Card>
   
   <Card title="Easy to Use" icon="approve-check">


### PR DESCRIPTION
## Summary

Align the public NAuth documentation with current behavior and clean up stale or misplaced guidance.

## Changes

- Remove expired security metadata from `SECURITY.md`.
- Replace the homepage key-rotation overclaim with implemented credential-management behavior.
- Update Getting Started with current install, `NatsCluster`, Account, and User guidance.
- Move observe/import details into a dedicated guide and keep it secondary in main onboarding.
- Fix README credential-resolution wording and replace a stub operator example link.
- Keep contributor setup out of public Getting Started while making contribution guidance explicit in README.
- Expose current docs entry points from the homepage.

## Verification

- `bun run check`
- `bun run build`
- `git diff --check`

## Notes

`nauth.io` versioning/release-alignment is intentionally left for a follow-up PR.
