### PR TITLE
docs: label release availability in guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,14 @@ mise run nauth:generate-docs
 ```
 (this runs `helm-docs` together with CRD reference generation)
 
+### Version labels
+The documentation website follows the current `main` branch. Mark release-sensitive features with:
+
+- `Since vX.Y.Z` when the feature is available from a published release.
+- `Unreleased` when the feature is documented on `main` before the next NAuth release.
+
+Before tagging a release, replace relevant `Unreleased` labels with `Since vX.Y.Z`.
+
 ## Releasing
 Releases are tag-driven and use [SemVer](https://semver.org/). Release candidate tags use SemVer
 pre-release identifiers; the leading `v` is only the Git tag prefix and is stripped before publishing artifacts.

--- a/www/src/content/docs/guides/getting-started.mdx
+++ b/www/src/content/docs/guides/getting-started.mdx
@@ -32,6 +32,8 @@ NAuth requires these credentials as Kubernetes Secrets:
 - system account user credentials
 - [operator signing key nkey seed](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth)
 
+> **Since v0.6.0:** NAuth resolves NATS connection and credential references through the `NatsCluster` resource.
+
 Define a `NatsCluster` resource with either `spec.url` or `spec.urlFrom`, plus `spec.operatorSigningKeySecretRef` and `spec.systemAccountUserCredsSecretRef`.
 
 Then choose how accounts target that cluster:
@@ -51,6 +53,8 @@ out:
 You can also use [`nsc`](https://github.com/nats-io/nsc) directly to create a throw-away operator & system account.
 
 ## Manage Accounts and Users
+> **Since v0.1.0:** `Account` and `User` resources are the core NAuth workflow.
+
 NAuth's main workflow is to declare NATS accounts and users as Kubernetes resources. The controller creates the NATS account JWT, keeps it updated from `Account.spec`, and creates user credentials for each `User`.
 
 Create an account:

--- a/www/src/content/docs/guides/observability.mdx
+++ b/www/src/content/docs/guides/observability.mdx
@@ -22,13 +22,13 @@ controller_runtime_reconcile_total{controller="<controller>",result="<result>"}
 
 Current controller labels:
 
-| Resource | Controller label |
-| --- | --- |
-| `Account` | `account` |
-| `AccountExport` | `accountexport` |
-| `AccountImport` | `accountimport` |
-| `User` | `user` |
-| `NatsCluster` | `natscluster` |
+| Resource | Controller label | Availability |
+| --- | --- | --- |
+| `Account` | `account` | Since v0.1.0 |
+| `AccountExport` | `accountexport` | Unreleased |
+| `AccountImport` | `accountimport` | Unreleased |
+| `User` | `user` | Since v0.1.0 |
+| `NatsCluster` | `natscluster` | Since v0.6.1 |
 
 Useful Grafana queries:
 

--- a/www/src/content/docs/guides/observe-existing-accounts.mdx
+++ b/www/src/content/docs/guides/observe-existing-accounts.mdx
@@ -3,6 +3,8 @@ title: Observe Existing Accounts
 description: Observe existing NATS accounts without letting NAuth manage them
 ---
 
+> **Since v0.6.1:** Observe mode is available through the `nauth.io/management-policy: observe` label.
+
 NAuth's main workflow is to manage NATS `Account` and `User` resources from Kubernetes desired state. Observe mode is the exception: use it when an account already exists in NATS and you want NAuth to read it without taking ownership.
 
 In observe mode, NAuth reads the existing account JWT from NATS and populates `status.claims`. It does not manage or push a new JWT. The observed claims can be used as a starting point when migrating the account into `spec` or recovering desired state.


### PR DESCRIPTION
nauth.io follows main, so some documented behavior can exist before the next released chart. Add targeted Since/Unreleased labels where version context matters, and document the maintainer convention for updating those labels during release prep.
