### PR TITLE
fix: update status on input validation failure

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -189,7 +189,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	} else {
 		request, adoptionRefs, err := r.toAccountRequest(ctx, natsAccount, accountID, *clusterTarget)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to create account request: %w", err)
+			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to create account request: %w", err))
 		}
 		result, err = r.manager.CreateOrUpdate(ctx, request)
 		if err != nil {


### PR DESCRIPTION
Today when NAuth fails to create the AccountRequest during Account reconcile process, it silently errors out without updating the resource status, hence the user is blind. This happens when e.g. looking up an Account by reference to validate an inline import. When this fails, the operator should update status to visualize the issue to the user.

