### PR TITLE
fix(chart): allow recording events.k8s.io warnings

### DIFF
--- a/charts/nauth/templates/rbac_manager_role.yaml
+++ b/charts/nauth/templates/rbac_manager_role.yaml
@@ -84,3 +84,10 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/nauth/tests/rbac_manager_role_natscluster_permissions_test.yaml
+++ b/charts/nauth/tests/rbac_manager_role_natscluster_permissions_test.yaml
@@ -1,4 +1,4 @@
-suite: manager role NatsCluster permissions
+suite: manager role permissions
 templates:
   - templates/rbac_manager_role.yaml
 tests:
@@ -31,3 +31,15 @@ tests:
             verbs:
               - update
 
+  - it: grants write access to events.k8s.io events
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - events.k8s.io
+            resources:
+              - events
+            verbs:
+              - create
+              - patch

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -81,6 +81,7 @@ func NewAccountReconciler(
 // +kubebuilder:rbac:groups=nauth.io,resources=natsclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -61,6 +61,7 @@ func NewAccountExportReconciler(k8sClient client.Client, scheme *runtime.Scheme,
 // +kubebuilder:rbac:groups=nauth.io,resources=accountexports,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=nauth.io,resources=accountexports/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)

--- a/internal/adapter/inbound/controller/natscluster.go
+++ b/internal/adapter/inbound/controller/natscluster.go
@@ -75,6 +75,7 @@ func NewNatsClusterReconciler(
 // +kubebuilder:rbac:groups=nauth.io,resources=natsclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=nauth.io,resources=natsclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 func (r *NatsClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)

--- a/internal/adapter/inbound/controller/user.go
+++ b/internal/adapter/inbound/controller/user.go
@@ -59,6 +59,7 @@ func NewUserReconciler(k8sClient client.Client, scheme *runtime.Scheme, manager 
 // +kubebuilder:rbac:groups=nauth.io,resources=users/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=nauth.io,resources=users/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Grant the manager Role/ClusterRole permission to create and patch events.k8s.io Events. The controllers use events.EventRecorder, so warning events are rejected without this API group permission.

Keep the existing core events permission for now until the broader RBAC review removes stale permissions deliberately.

Fixes: #316
