### PR TITLE
fix(account): allow deleting unbound accounts

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -102,9 +102,6 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	accountID := nauth.AccountID(natsAccount.GetLabel(v1alpha1.AccountLabelAccountID))
-	managementPolicy := natsAccount.GetLabel(v1alpha1.AccountLabelManagementPolicy)
-
 	accountClusterRef, err := toNAuthClusterRef(natsAccount.Spec.NatsClusterRef, natsAccount.Namespace)
 	if err != nil {
 		return r.reporter.error(ctx, natsAccount, err)
@@ -113,6 +110,9 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err != nil {
 		return r.reporter.error(ctx, natsAccount, err)
 	}
+
+	managementPolicy := natsAccount.GetLabel(v1alpha1.AccountLabelManagementPolicy)
+	accountRef := toAccountReference(natsAccount, *clusterTarget)
 
 	// ACCOUNT MARKED FOR DELETION
 	if !natsAccount.DeletionTimestamp.IsZero() {
@@ -129,8 +129,17 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 
-		err := r.validateAccountDeletion(ctx, accountID, domain.Namespace(natsAccount.Namespace))
-		if err != nil {
+		if accountRef.AccountID == "" {
+			foundAccountID, found, err := r.manager.FindAccountID(ctx, accountRef)
+			if err != nil {
+				return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to find account ID for deletion: %w", err))
+			}
+			if found {
+				accountRef.AccountID = foundAccountID
+			}
+		}
+
+		if err = r.validateAccountDeletion(ctx, accountRef.AccountID, domain.Namespace(natsAccount.Namespace)); err != nil {
 			if errors.Is(err, domain.ErrUnknownError) {
 				return ctrl.Result{}, err
 			}
@@ -138,8 +147,8 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		if controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
-			if managementPolicy != v1alpha1.AccountManagementPolicyObserve {
-				if err := r.manager.Delete(ctx, toAccountReference(natsAccount, *clusterTarget)); err != nil {
+			if managementPolicy != v1alpha1.AccountManagementPolicyObserve && accountRef.AccountID != "" {
+				if err := r.manager.Delete(ctx, accountRef); err != nil {
 					return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to delete account: %w", err))
 				}
 			}
@@ -183,12 +192,12 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var adoptions *v1alpha1.AccountAdoptions
 	if managementPolicy == v1alpha1.AccountManagementPolicyObserve {
 		var err error
-		result, err = r.manager.Import(ctx, toAccountReference(natsAccount, *clusterTarget))
+		result, err = r.manager.Import(ctx, accountRef)
 		if err != nil {
 			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to import the observed account: %w", err))
 		}
 	} else {
-		request, adoptionRefs, err := r.toAccountRequest(ctx, natsAccount, accountID, *clusterTarget)
+		request, adoptionRefs, err := r.toAccountRequest(ctx, natsAccount, accountRef)
 		if err != nil {
 			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to create account request: %w", err))
 		}
@@ -246,7 +255,7 @@ func toAccountReference(state *v1alpha1.Account, clusterTarget nauth.ClusterTarg
 	}
 }
 
-func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha1.Account, accountID nauth.AccountID, clusterTarget nauth.ClusterTarget) (nauth.AccountRequest, accountAdoptionRefs, error) {
+func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha1.Account, accountReference nauth.AccountReference) (nauth.AccountRequest, accountAdoptionRefs, error) {
 	var request nauth.AccountRequest
 	adoptionRefs := accountAdoptionRefs{}
 
@@ -273,10 +282,10 @@ func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha
 
 	request = nauth.AccountRequest{
 		AccountRef:       domain.NewNamespacedName(state.Namespace, state.Name),
-		AccountID:        accountID,
+		AccountID:        accountReference.AccountID,
 		ClaimsHash:       state.Status.ClaimsHash,
 		DisplayName:      state.Spec.DisplayName,
-		ClusterTarget:    clusterTarget,
+		ClusterTarget:    accountReference.ClusterTarget,
 		AccountLimits:    toNAuthAccountLimits(state.Spec.AccountLimits),
 		JetStreamEnabled: state.Spec.JetStreamEnabled,
 		JetStreamLimits:  toNAuthJetStreamLimits(state.Spec.JetStreamLimits),
@@ -285,11 +294,11 @@ func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha
 		ImportGroups:     importGroups,
 	}
 
-	if accountID == "" {
+	if accountReference.AccountID == "" {
 		return request, adoptionRefs, nil
 	}
 
-	exports, err := r.findExportsByAccountID(ctx, namespace, accountID)
+	exports, err := r.findExportsByAccountID(ctx, namespace, accountReference.AccountID)
 	if err != nil {
 		return request, adoptionRefs, err
 	}
@@ -300,7 +309,7 @@ func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha
 	request.ExportGroups = append(request.ExportGroups, newExportGroups...)
 	adoptionRefs.exports = append(adoptionRefs.exports, newExportRefs...)
 
-	imports, err := r.findImportsByAccountID(ctx, namespace, accountID)
+	imports, err := r.findImportsByAccountID(ctx, namespace, accountReference.AccountID)
 	if err != nil {
 		return request, adoptionRefs, err
 	}
@@ -499,6 +508,9 @@ func (r *AccountReconciler) mapAccountImportToAccounts(ctx context.Context, obj 
 
 func (r *AccountReconciler) validateAccountDeletion(ctx context.Context, accountID nauth.AccountID, namespace domain.Namespace) error {
 	log := logf.FromContext(ctx)
+	if accountID == "" {
+		return nil
+	}
 
 	// Check for bound users
 	userList := &v1alpha1.UserList{}

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -302,6 +302,63 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldDeleteAccountMarkedFor
 	t.True(k8err.IsNotFound(err))
 }
 
+func (t *AccountControllerTestSuite) Test_Reconcile_ShouldDeleteAccountMarkedForDeletion_WhenAccountIDCanBeFound() {
+	// Given
+	accountID := nauth.AccountID(testutil.AnyNatsTestAccountID())
+	t.setupAccount(
+		t.defaultAccount(func(account *v1alpha1.Account) {
+			account.Finalizers = append(account.Finalizers, finalizerAccount)
+		}),
+	)
+
+	account := &v1alpha1.Account{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.accountNamespacedRef, account))
+	t.Require().NoError(k8sClient.Delete(t.ctx, account))
+
+	t.clusterManagerMock.mockGetClusterTarget(createDummyClusterTarget(), nil)
+	t.accountManagerMock.mockFindAccountID(t.ctx, mock.Anything, accountID, true, nil).Once()
+	t.accountManagerMock.On("Delete", t.ctx, mock.MatchedBy(func(reference nauth.AccountReference) bool {
+		return reference.AccountID == accountID
+	})).Return(nil).Once()
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
+
+	// Then
+	t.Require().NoError(err)
+
+	err = k8sClient.Get(t.ctx, t.accountNamespacedRef, account)
+	t.Require().Error(err)
+	t.True(k8err.IsNotFound(err))
+}
+
+func (t *AccountControllerTestSuite) Test_Reconcile_ShouldRemoveFinalizer_WhenDeletingAccountWithoutManagedState() {
+	// Given
+	t.setupAccount(
+		t.defaultAccount(func(account *v1alpha1.Account) {
+			account.Finalizers = append(account.Finalizers, finalizerAccount)
+		}),
+	)
+
+	account := &v1alpha1.Account{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.accountNamespacedRef, account))
+	t.Require().NoError(k8sClient.Delete(t.ctx, account))
+
+	t.clusterManagerMock.mockGetClusterTarget(createDummyClusterTarget(), nil)
+	t.accountManagerMock.mockFindAccountID(t.ctx, mock.Anything, "", false, nil).Once()
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
+
+	// Then
+	t.Require().NoError(err)
+	t.accountManagerMock.AssertNotCalled(t.T(), "Delete", mock.Anything, mock.Anything)
+
+	err = k8sClient.Get(t.ctx, t.accountNamespacedRef, account)
+	t.Require().Error(err)
+	t.True(k8err.IsNotFound(err))
+}
+
 func createDummyClusterTarget() *nauth.ClusterTarget {
 	sauCreds := domain.NatsUserCreds{
 		Creds:     []byte("FAKE_CREDENTIALS"),
@@ -610,6 +667,17 @@ func (o *accountManagerMock) Import(ctx context.Context, reference nauth.Account
 		return nil, nil
 	}
 	return args.Get(0).(*nauth.AccountResult), nil
+}
+
+func (o *accountManagerMock) FindAccountID(ctx context.Context, reference nauth.AccountReference) (nauth.AccountID, bool, error) {
+	args := o.Called(ctx, reference)
+	return args.Get(0).(nauth.AccountID), args.Bool(1), args.Error(2)
+}
+
+func (o *accountManagerMock) mockFindAccountID(ctx interface{}, state interface{}, result nauth.AccountID, found bool, err error) *mock.Call {
+	call := o.On("FindAccountID", ctx, state)
+	call.Return(result, found, err)
+	return call
 }
 
 func (o *accountManagerMock) Delete(ctx context.Context, reference nauth.AccountReference) error {

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -197,6 +197,27 @@ func (a *AccountManager) CreateOrUpdate(ctx context.Context, request nauth.Accou
 	}, nil
 }
 
+func (a *AccountManager) FindAccountID(ctx context.Context, reference nauth.AccountReference) (nauth.AccountID, bool, error) {
+	if err := reference.AccountRef.Validate(); err != nil {
+		return "", false, fmt.Errorf("invalid account reference: %w", err)
+	}
+
+	// TODO: [#196] Only lookup account root secret.
+	accountSecrets, found, err := a.secretManager.GetSecrets(ctx, reference.AccountRef, string(reference.AccountID))
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get account secrets for account ID lookup: %w", err)
+	}
+	if !found {
+		return "", false, nil
+	}
+
+	accountPublicKey, err := accountSecrets.Root.PublicKey()
+	if err != nil {
+		return "", false, fmt.Errorf("failed to extract account root public key from existing secret: %w", err)
+	}
+	return nauth.AccountID(accountPublicKey), true, nil
+}
+
 func adoptExportGroups(groups nauth.ExportGroups, claimsBuilder *accountClaimsBuilder, adoptions *nauth.AccountAdoptions) error {
 	for _, exp := range groups {
 		adoptionResult := nauth.AdoptionResult{Ref: exp.Ref}

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -533,6 +533,58 @@ func (t *AccountManagerTestSuite) Test_Import_ShouldSucceed() {
 	t.Equal(existingNatsLimitsSubs, *result.Claims.NatsLimits.Subs)
 }
 
+func (t *AccountManagerTestSuite) Test_FindAccountID_ShouldReturnIDFromAccountSecrets() {
+	// Given
+	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
+	account := testutil.CreateNatsTestAccount()
+	t.secretManagerMock.mockGetSecrets(t.ctx, accountRef, "", &Secrets{
+		Root: account.Root.Key,
+		Sign: account.Sign.Key,
+	}).Once()
+
+	// When
+	result, found, err := t.unitUnderTest.FindAccountID(t.ctx, nauth.AccountReference{
+		AccountRef: accountRef,
+	})
+
+	// Then
+	t.NoError(err)
+	t.True(found)
+	t.Equal(nauth.AccountID(account.AccountID()), result)
+}
+
+func (t *AccountManagerTestSuite) Test_FindAccountID_ShouldReturnNotFoundWhenAccountSecretsAreMissing() {
+	// Given
+	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
+	t.secretManagerMock.mockGetSecretsMissing(t.ctx, accountRef, "")
+
+	// When
+	result, found, err := t.unitUnderTest.FindAccountID(t.ctx, nauth.AccountReference{
+		AccountRef: accountRef,
+	})
+
+	// Then
+	t.NoError(err)
+	t.False(found)
+	t.Empty(result)
+}
+
+func (t *AccountManagerTestSuite) Test_FindAccountID_ShouldFailWhenAccountSecretsAreInvalid() {
+	// Given
+	accountRef := domain.NewNamespacedName("account-namespace", "account-name")
+	t.secretManagerMock.mockGetSecretsFoundError(t.ctx, accountRef, "", fmt.Errorf("invalid account secrets"))
+
+	// When
+	result, found, err := t.unitUnderTest.FindAccountID(t.ctx, nauth.AccountReference{
+		AccountRef: accountRef,
+	})
+
+	// Then
+	t.ErrorContains(err, "failed to get account secrets for account ID lookup: invalid account secrets")
+	t.False(found)
+	t.Empty(result)
+}
+
 func (t *AccountManagerTestSuite) Test_Delete_ShouldSucceed() {
 	// Given
 	var (

--- a/internal/ports/inbound/nauth.go
+++ b/internal/ports/inbound/nauth.go
@@ -10,6 +10,7 @@ import (
 type AccountManager interface {
 	CreateOrUpdate(ctx context.Context, request nauth.AccountRequest) (*nauth.AccountResult, error)
 	Import(ctx context.Context, reference nauth.AccountReference) (*nauth.AccountResult, error)
+	FindAccountID(ctx context.Context, reference nauth.AccountReference) (nauth.AccountID, bool, error)
 	Delete(ctx context.Context, reference nauth.AccountReference) error
 }
 


### PR DESCRIPTION
Resolve an Account ID during deletion when the resource is missing the `account.nauth.io/id` label. If an ID can be found from managed account state, use it for validation and NATS cleanup. If no ID can be found, treat the resource as having nothing managed to delete and remove the finalizer.

Keep the lookup on the existing account secret-pair path for now. Narrowing it to only the account root secret is tracked separately in #196.

Fixes: #315
Related: #196
