### PR TITLE
feat(account): bootstrap new accounts when request rendering fails

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -190,6 +190,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Manage NATS resources
 	var result *nauth.AccountResult
 	var adoptions *v1alpha1.AccountAdoptions
+	var bootstrapReason error
 	if managementPolicy == v1alpha1.AccountManagementPolicyObserve {
 		var err error
 		result, err = r.manager.Import(ctx, accountRef)
@@ -199,7 +200,11 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	} else {
 		request, adoptionRefs, err := r.toAccountRequest(ctx, natsAccount, accountRef)
 		if err != nil {
-			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to create account request: %w", err))
+			if accountRef.AccountID != "" {
+				return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to create account request: %w", err))
+			}
+			bootstrapReason = fmt.Errorf("failed to create account request: %w", err)
+			request = toBootstrapAccountRequest(natsAccount, accountRef)
 		}
 		result, err = r.manager.CreateOrUpdate(ctx, request)
 		if err != nil {
@@ -224,6 +229,14 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	natsAccount.Status.ClaimsHash = result.ClaimsHash
 	natsAccount.Status.ObservedGeneration = natsAccount.Generation
 	natsAccount.Status.ReconcileTimestamp = metav1.Now()
+	if bootstrapReason != nil {
+		meta.SetStatusCondition(&natsAccount.Status.Conditions, metav1.Condition{
+			Type:    conditionTypeReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  conditionReasonNotReady,
+			Message: fmt.Sprintf("Account bootstrapped with limits only. Full reconciliation is not ready: %s", bootstrapReason),
+		})
+	}
 
 	// Need to copy the status - otherwise overwritten by status from kubernetes api response during spec update
 	status := natsAccount.Status.DeepCopy()
@@ -241,6 +254,10 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	if bootstrapReason != nil {
+		return ctrl.Result{RequeueAfter: requeueImmediately}, nil
+	}
+
 	return r.reporter.status(ctx, natsAccount)
 }
 
@@ -255,32 +272,8 @@ func toAccountReference(state *v1alpha1.Account, clusterTarget nauth.ClusterTarg
 	}
 }
 
-func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha1.Account, accountReference nauth.AccountReference) (nauth.AccountRequest, accountAdoptionRefs, error) {
-	var request nauth.AccountRequest
-	adoptionRefs := accountAdoptionRefs{}
-
-	namespace := domain.Namespace(state.Namespace)
-	cachedAccountIDReader := newCachedAccountIDReader(ctx, r.accountReader)
-
-	var exportGroups nauth.ExportGroups
-	inlineExportGroup, err := toNAuthExportGroup(GroupNameInline, true, state.Spec.Exports)
-	if err != nil {
-		return request, adoptionRefs, fmt.Errorf("failed to convert inline exports: %w", err)
-	}
-	if inlineExportGroup != nil {
-		exportGroups = nauth.ExportGroups{inlineExportGroup}
-	}
-
-	var importGroups nauth.ImportGroups
-	inlineImportGroup, err := toNAuthImportGroup(GroupNameInline, true, state.Spec.Imports, cachedAccountIDReader)
-	if err != nil {
-		return request, adoptionRefs, fmt.Errorf("failed to convert inline imports: %w", err)
-	}
-	if inlineImportGroup != nil {
-		importGroups = nauth.ImportGroups{inlineImportGroup}
-	}
-
-	request = nauth.AccountRequest{
+func toBootstrapAccountRequest(state *v1alpha1.Account, accountReference nauth.AccountReference) nauth.AccountRequest {
+	return nauth.AccountRequest{
 		AccountRef:       domain.NewNamespacedName(state.Namespace, state.Name),
 		AccountID:        accountReference.AccountID,
 		ClaimsHash:       state.Status.ClaimsHash,
@@ -290,8 +283,30 @@ func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha
 		JetStreamEnabled: state.Spec.JetStreamEnabled,
 		JetStreamLimits:  toNAuthJetStreamLimits(state.Spec.JetStreamLimits),
 		NatsLimits:       toNAuthNatsLimits(state.Spec.NatsLimits),
-		ExportGroups:     exportGroups,
-		ImportGroups:     importGroups,
+	}
+}
+
+func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha1.Account, accountReference nauth.AccountReference) (nauth.AccountRequest, accountAdoptionRefs, error) {
+	request := toBootstrapAccountRequest(state, accountReference)
+	adoptionRefs := accountAdoptionRefs{}
+
+	namespace := domain.Namespace(state.Namespace)
+	cachedAccountIDReader := newCachedAccountIDReader(ctx, r.accountReader)
+
+	inlineExportGroup, err := toNAuthExportGroup(GroupNameInline, true, state.Spec.Exports)
+	if err != nil {
+		return request, adoptionRefs, fmt.Errorf("failed to convert inline exports: %w", err)
+	}
+	if inlineExportGroup != nil {
+		request.ExportGroups = nauth.ExportGroups{inlineExportGroup}
+	}
+
+	inlineImportGroup, err := toNAuthImportGroup(GroupNameInline, true, state.Spec.Imports, cachedAccountIDReader)
+	if err != nil {
+		return request, adoptionRefs, fmt.Errorf("failed to convert inline imports: %w", err)
+	}
+	if inlineImportGroup != nil {
+		request.ImportGroups = nauth.ImportGroups{inlineImportGroup}
 	}
 
 	if accountReference.AccountID == "" {

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -217,6 +217,175 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdat
 	t.Contains(<-t.fakeRecorder.Events, "failed to apply account: a test error")
 }
 
+func (t *AccountControllerTestSuite) Test_Reconcile_ShouldBootstrap_WhenNewAccountRequestFails() {
+	// Given
+	importLimit := int64(3)
+	streamLimit := int64(5)
+	subLimit := int64(7)
+	unlimited := int64(-1)
+	wildcardExports := true
+	maxBytesRequired := false
+	exportAccountName := "export-account"
+	accountID := testutil.AnyNatsTestAccountID()
+
+	t.setupAccount(
+		t.defaultAccount(func(account *v1alpha1.Account) {
+			account.Name = exportAccountName
+			account.Finalizers = append(account.Finalizers, finalizerAccount)
+		}),
+	)
+	t.setupAccount(
+		t.defaultAccount(func(account *v1alpha1.Account) {
+			account.Finalizers = append(account.Finalizers, finalizerAccount)
+			account.Spec.AccountLimits = &v1alpha1.AccountLimits{
+				Imports:         &importLimit,
+				Exports:         &unlimited,
+				WildcardExports: &wildcardExports,
+				Conn:            &unlimited,
+				LeafNodeConn:    &unlimited,
+			}
+			account.Spec.JetStreamLimits = &v1alpha1.JetStreamLimits{
+				MemoryStorage:        &unlimited,
+				DiskStorage:          &unlimited,
+				Streams:              &streamLimit,
+				Consumer:             &unlimited,
+				MaxAckPending:        &unlimited,
+				MemoryMaxStreamBytes: &unlimited,
+				DiskMaxStreamBytes:   &unlimited,
+				MaxBytesRequired:     &maxBytesRequired,
+			}
+			account.Spec.NatsLimits = &v1alpha1.NatsLimits{
+				Subs:    &subLimit,
+				Data:    &unlimited,
+				Payload: &unlimited,
+			}
+			account.Spec.Imports = v1alpha1.Imports{
+				{
+					AccountRef: v1alpha1.AccountRef{
+						Name:      exportAccountName,
+						Namespace: t.accountNamespace,
+					},
+					Name:    "stream-import",
+					Subject: "foo.>",
+					Type:    v1alpha1.Stream,
+				},
+			}
+		}),
+	)
+
+	t.clusterManagerMock.mockGetClusterTarget(createDummyClusterTarget(), nil)
+	t.accountManagerMock.mockCreateOrUpdateFn(t.ctx, mock.Anything, func(request nauth.AccountRequest) (*nauth.AccountResult, error) {
+		t.Empty(request.ExportGroups)
+		t.Empty(request.ImportGroups)
+		t.Equal(&nauth.AccountLimits{
+			Imports:         &importLimit,
+			Exports:         &unlimited,
+			WildcardExports: &wildcardExports,
+			Conn:            &unlimited,
+			LeafNodeConn:    &unlimited,
+		}, request.AccountLimits)
+		t.Equal(&nauth.JetStreamLimits{
+			MemoryStorage:        &unlimited,
+			DiskStorage:          &unlimited,
+			Streams:              &streamLimit,
+			Consumer:             &unlimited,
+			MaxAckPending:        &unlimited,
+			MemoryMaxStreamBytes: &unlimited,
+			DiskMaxStreamBytes:   &unlimited,
+			MaxBytesRequired:     &maxBytesRequired,
+		}, request.JetStreamLimits)
+		t.Equal(&nauth.NatsLimits{
+			Subs:    &subLimit,
+			Data:    &unlimited,
+			Payload: &unlimited,
+		}, request.NatsLimits)
+
+		return &nauth.AccountResult{
+			AccountID:       accountID,
+			AccountSignedBy: "OPERATOR_SIGNING_KEY",
+			Claims: &nauth.AccountClaims{
+				AccountLimits:   request.AccountLimits,
+				JetStreamLimits: request.JetStreamLimits,
+				NatsLimits:      request.NatsLimits,
+			},
+			ClaimsHash: "BOOTSTRAP_CLAIMS_HASH",
+			Adoptions:  nauth.NewAccountAdoptions(),
+		}, nil
+	}).Once()
+
+	// When
+	result, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
+
+	// Then
+	t.Require().NoError(err)
+	t.Equal(requeueImmediately, result.RequeueAfter)
+
+	account := &v1alpha1.Account{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.accountNamespacedRef, account))
+	t.Equal(accountID, account.GetLabel(v1alpha1.AccountLabelAccountID))
+	t.Equal("OPERATOR_SIGNING_KEY", account.GetLabel(v1alpha1.AccountLabelSignedBy))
+	t.Equal("BOOTSTRAP_CLAIMS_HASH", account.Status.ClaimsHash)
+	t.Equal(t.operatorVersion, account.Status.OperatorVersion)
+
+	c := meta.FindStatusCondition(account.Status.Conditions, conditionTypeReady)
+	t.Require().NotNil(c)
+	t.Equal(metav1.ConditionFalse, c.Status)
+	t.Equal(conditionReasonNotReady, c.Reason)
+	t.Contains(c.Message, "Account bootstrapped with limits only")
+	t.Contains(c.Message, "failed to create account request")
+	t.Empty(t.fakeRecorder.Events)
+}
+
+func (t *AccountControllerTestSuite) Test_Reconcile_ShouldNotBootstrap_WhenExistingAccountRequestFails() {
+	// Given
+	exportAccountName := "export-account"
+	accountID := testutil.AnyNatsTestAccountID()
+
+	t.setupAccount(
+		t.defaultAccount(func(account *v1alpha1.Account) {
+			account.Name = exportAccountName
+			account.Finalizers = append(account.Finalizers, finalizerAccount)
+		}),
+	)
+	t.setupAccount(
+		t.defaultAccount(func(account *v1alpha1.Account) {
+			account.Finalizers = append(account.Finalizers, finalizerAccount)
+			account.SetLabel(v1alpha1.AccountLabelAccountID, accountID)
+			account.Spec.Imports = v1alpha1.Imports{
+				{
+					AccountRef: v1alpha1.AccountRef{
+						Name:      exportAccountName,
+						Namespace: t.accountNamespace,
+					},
+					Name:    "stream-import",
+					Subject: "foo.>",
+					Type:    v1alpha1.Stream,
+				},
+			}
+		}),
+	)
+
+	t.clusterManagerMock.mockGetClusterTarget(createDummyClusterTarget(), nil)
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
+
+	// Then
+	t.Require().Error(err)
+	t.ErrorIs(err, domain.ErrAccountNotReady)
+	t.accountManagerMock.AssertNotCalled(t.T(), "CreateOrUpdate", mock.Anything, mock.Anything)
+
+	account := &v1alpha1.Account{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.accountNamespacedRef, account))
+
+	c := meta.FindStatusCondition(account.Status.Conditions, conditionTypeReady)
+	t.Require().NotNil(c)
+	t.Equal(metav1.ConditionFalse, c.Status)
+	t.Equal(conditionReasonErrored, c.Reason)
+	t.Require().Len(t.fakeRecorder.Events, 1)
+	t.Contains(<-t.fakeRecorder.Events, "failed to create account request")
+}
+
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenChangingNatsCluster() {
 	// Given
 	t.setupAccount(


### PR DESCRIPTION
When a new Account cannot render its full AccountRequest, for example because inline imports reference Accounts that are not ready yet, bootstrap the Account with limits only. The bootstrap reconcile creates the Account JWT, writes the Account ID labels/status, marks the Account NotReady, and requeues immediately.

The next reconcile loop can then use the Account ID even if full request rendering still fails. This also lets related Account resources progress further in their own reconciliation and report clearer readiness errors instead of being blocked by a missing Account ID.

Issue: #313
