### PR TITLE
feat: bootstrap managed Accounts before full reconciliation

### DIFF
--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -49,7 +49,7 @@ import (
 
 // AccountReconciler reconciles an Account object
 type AccountReconciler struct {
-	client.Client
+	kubernetes     *kubernetesClient
 	Scheme         *runtime.Scheme
 	manager        inbound.AccountManager
 	clusterManager inbound.ClusterManager
@@ -66,7 +66,7 @@ func NewAccountReconciler(
 	recorder events.EventRecorder,
 ) *AccountReconciler {
 	return &AccountReconciler{
-		Client:         k8sClient,
+		kubernetes:     newKubernetesClient(k8sClient),
 		Scheme:         scheme,
 		manager:        manager,
 		clusterManager: clusterManager,
@@ -92,7 +92,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	log := logf.FromContext(ctx)
 
 	natsAccount := &v1alpha1.Account{}
-	if err := r.Get(ctx, req.NamespacedName, natsAccount); err != nil {
+	if err := r.kubernetes.Get(ctx, req.NamespacedName, natsAccount); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
@@ -124,7 +124,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			Message: "Deleting account",
 		})
 
-		if err := r.Status().Update(ctx, natsAccount); err != nil {
+		if err := r.kubernetes.Status().Update(ctx, natsAccount); err != nil {
 			log.Info("Failed to update the account status", "name", natsAccount.Name, "error", err)
 			return ctrl.Result{}, err
 		}
@@ -155,7 +155,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// remove our finalizer from the list and update it.
 			controllerutil.RemoveFinalizer(natsAccount, finalizerAccount)
-			if err := r.Update(ctx, natsAccount); err != nil {
+			if err := r.kubernetes.Update(ctx, natsAccount); err != nil {
 				log.Info("failed to remove finalizer", "name", natsAccount.Name, "error", err)
 				return ctrl.Result{}, err
 			}
@@ -168,7 +168,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Add finalizer if not present
 	if added := controllerutil.AddFinalizer(natsAccount, finalizerAccount); added {
-		if err := r.Update(ctx, natsAccount); err != nil {
+		if err := r.kubernetes.Update(ctx, natsAccount); err != nil {
 			log.Info("Failed to add finalizer", "name", natsAccount.Name, "error", err)
 			return ctrl.Result{}, err
 		}
@@ -212,6 +212,11 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	natsAccount.SetLabel(v1alpha1.AccountLabelAccountID, result.AccountID)
 	natsAccount.SetLabel(v1alpha1.AccountLabelSignedBy, result.AccountSignedBy)
 
+	if err := r.kubernetes.PatchLabels(ctx, natsAccount); err != nil {
+		log.Info("Failed to patch account labels", "name", natsAccount.Name, "error", err)
+		return ctrl.Result{}, err
+	}
+
 	// UPDATE ACCOUNT STATUS
 	if result.Claims != nil {
 		claims, err := toAPIAccountClaims(result.Claims)
@@ -224,19 +229,8 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	natsAccount.Status.ClaimsHash = result.ClaimsHash
 	natsAccount.Status.ObservedGeneration = natsAccount.Generation
 	natsAccount.Status.ReconcileTimestamp = metav1.Now()
-
-	// Need to copy the status - otherwise overwritten by status from kubernetes api response during spec update
-	status := natsAccount.Status.DeepCopy()
-	status.OperatorVersion = os.Getenv(envOperatorVersion)
-
-	if err := r.Update(ctx, natsAccount); err != nil {
-		log.Info("Failed to update the account", "name", natsAccount.Name, "error", err)
-		return ctrl.Result{}, err
-	}
-
-	// Get the updated status back before updating the kubernetes api
-	natsAccount.Status = *status
-	if err := r.Status().Update(ctx, natsAccount); err != nil {
+	natsAccount.Status.OperatorVersion = os.Getenv(envOperatorVersion)
+	if err := r.kubernetes.Status().Update(ctx, natsAccount); err != nil {
 		log.Info("Failed to update the account status", "name", natsAccount.Name, "err", err)
 		return ctrl.Result{}, err
 	}
@@ -346,7 +340,7 @@ func (r *AccountReconciler) findExportsByAccountID(ctx context.Context, namespac
 		return nil, fmt.Errorf("account ID required")
 	}
 	exports := &v1alpha1.AccountExportList{}
-	err := r.List(ctx, exports, client.InNamespace(namespace), client.MatchingLabels{
+	err := r.kubernetes.List(ctx, exports, client.InNamespace(namespace), client.MatchingLabels{
 		string(v1alpha1.AccountExportLabelAccountID): string(accountID),
 	})
 	if err != nil {
@@ -360,7 +354,7 @@ func (r *AccountReconciler) findImportsByAccountID(ctx context.Context, namespac
 		return nil, fmt.Errorf("account ID required")
 	}
 	imports := &v1alpha1.AccountImportList{}
-	err := r.List(ctx, imports, client.InNamespace(namespace), client.MatchingLabels{
+	err := r.kubernetes.List(ctx, imports, client.InNamespace(namespace), client.MatchingLabels{
 		string(v1alpha1.AccountImportLabelAccountID): string(accountID),
 	})
 	if err != nil {
@@ -402,7 +396,7 @@ func (r *AccountReconciler) mapAccountExportToAccounts(ctx context.Context, obj 
 	}
 
 	accounts := &v1alpha1.AccountList{}
-	if err := r.List(ctx, accounts,
+	if err := r.kubernetes.List(ctx, accounts,
 		client.InNamespace(export.Namespace),
 		client.MatchingLabels{string(v1alpha1.AccountLabelAccountID): accountID},
 	); err != nil {
@@ -488,7 +482,7 @@ func (r *AccountReconciler) mapAccountImportToAccounts(ctx context.Context, obj 
 	}
 
 	accounts := &v1alpha1.AccountList{}
-	if err := r.List(ctx, accounts,
+	if err := r.kubernetes.List(ctx, accounts,
 		client.InNamespace(imp.Namespace),
 		client.MatchingLabels{string(v1alpha1.AccountLabelAccountID): accountID},
 	); err != nil {
@@ -514,7 +508,7 @@ func (r *AccountReconciler) validateAccountDeletion(ctx context.Context, account
 
 	// Check for bound users
 	userList := &v1alpha1.UserList{}
-	err := r.List(ctx, userList, client.MatchingLabels{string(v1alpha1.UserLabelAccountID): string(accountID)}, client.InNamespace(namespace))
+	err := r.kubernetes.List(ctx, userList, client.MatchingLabels{string(v1alpha1.UserLabelAccountID): string(accountID)}, client.InNamespace(namespace))
 	if err != nil {
 		log.Error(err, "Failed to list users bound to account")
 		return domain.ErrUnknownError.WithCause(err)

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/WirelessCar/nauth/internal/adapter/outbound/k8s"
 	"github.com/WirelessCar/nauth/internal/domain"
@@ -230,12 +232,15 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	natsAccount.Status.ObservedGeneration = natsAccount.Generation
 	natsAccount.Status.ReconcileTimestamp = metav1.Now()
 	natsAccount.Status.OperatorVersion = os.Getenv(envOperatorVersion)
-	if err := r.kubernetes.Status().Update(ctx, natsAccount); err != nil {
+
+	if err := r.kubernetes.UpdateReadyStatusReconciled(ctx, natsAccount); err != nil {
 		log.Info("Failed to update the account status", "name", natsAccount.Name, "err", err)
 		return ctrl.Result{}, err
 	}
 
-	return r.reporter.status(ctx, natsAccount)
+	return ctrl.Result{
+		RequeueAfter: time.Duration(float64(5*time.Minute) * (0.9 + 0.2*rand.Float64())),
+	}, nil
 }
 
 func toAccountReference(state *v1alpha1.Account, clusterTarget nauth.ClusterTarget) nauth.AccountReference {

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -118,52 +118,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// ACCOUNT MARKED FOR DELETION
 	if !natsAccount.DeletionTimestamp.IsZero() {
-		// The account is being deleted
-		meta.SetStatusCondition(&natsAccount.Status.Conditions, metav1.Condition{
-			Type:    conditionTypeReady,
-			Status:  metav1.ConditionFalse,
-			Reason:  conditionReasonReconciling,
-			Message: "Deleting account",
-		})
-
-		if err := r.kubernetes.Status().Update(ctx, natsAccount); err != nil {
-			log.Info("Failed to update the account status", "name", natsAccount.Name, "error", err)
-			return ctrl.Result{}, err
-		}
-
-		if accountRef.AccountID == "" {
-			foundAccountID, found, err := r.manager.FindAccountID(ctx, accountRef)
-			if err != nil {
-				return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to find account ID for deletion: %w", err))
-			}
-			if found {
-				accountRef.AccountID = foundAccountID
-			}
-		}
-
-		if err = r.validateAccountDeletion(ctx, accountRef.AccountID, domain.Namespace(natsAccount.Namespace)); err != nil {
-			if errors.Is(err, domain.ErrUnknownError) {
-				return ctrl.Result{}, err
-			}
-			return r.reporter.error(ctx, natsAccount, err)
-		}
-
-		if controllerutil.ContainsFinalizer(natsAccount, finalizerAccount) {
-			if managementPolicy != v1alpha1.AccountManagementPolicyObserve && accountRef.AccountID != "" {
-				if err := r.manager.Delete(ctx, accountRef); err != nil {
-					return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to delete account: %w", err))
-				}
-			}
-
-			// remove our finalizer from the list and update it.
-			controllerutil.RemoveFinalizer(natsAccount, finalizerAccount)
-			if err := r.kubernetes.Update(ctx, natsAccount); err != nil {
-				log.Info("failed to remove finalizer", "name", natsAccount.Name, "error", err)
-				return ctrl.Result{}, err
-			}
-		}
-		// Stop reconciliation as the item is being deleted
-		return ctrl.Result{}, nil
+		return r.deleteAccount(ctx, natsAccount, accountRef, managementPolicy)
 	}
 
 	// RECONCILE ACCOUNT - Set status & base properties
@@ -241,6 +196,55 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{
 		RequeueAfter: time.Duration(float64(5*time.Minute) * (0.9 + 0.2*rand.Float64())),
 	}, nil
+}
+
+func (r *AccountReconciler) deleteAccount(ctx context.Context, state *v1alpha1.Account, accountRef nauth.AccountReference, managementPolicy string) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	meta.SetStatusCondition(&state.Status.Conditions, metav1.Condition{
+		Type:    conditionTypeReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  conditionReasonReconciling,
+		Message: "Deleting account",
+	})
+
+	if err := r.kubernetes.Status().Update(ctx, state); err != nil {
+		log.Info("Failed to update the account status", "name", state.Name, "error", err)
+		return ctrl.Result{}, err
+	}
+
+	if accountRef.AccountID == "" {
+		foundAccountID, found, err := r.manager.FindAccountID(ctx, accountRef)
+		if err != nil {
+			return r.reporter.error(ctx, state, fmt.Errorf("failed to find account ID for deletion: %w", err))
+		}
+		if found {
+			accountRef.AccountID = foundAccountID
+		}
+	}
+
+	if err := r.validateAccountDeletion(ctx, accountRef.AccountID, domain.Namespace(state.Namespace)); err != nil {
+		if errors.Is(err, domain.ErrUnknownError) {
+			return ctrl.Result{}, err
+		}
+		return r.reporter.error(ctx, state, err)
+	}
+
+	if controllerutil.ContainsFinalizer(state, finalizerAccount) {
+		if managementPolicy != v1alpha1.AccountManagementPolicyObserve && accountRef.AccountID != "" {
+			if err := r.manager.Delete(ctx, accountRef); err != nil {
+				return r.reporter.error(ctx, state, fmt.Errorf("failed to delete account: %w", err))
+			}
+		}
+
+		controllerutil.RemoveFinalizer(state, finalizerAccount)
+		if err := r.kubernetes.Update(ctx, state); err != nil {
+			log.Info("failed to remove finalizer", "name", state.Name, "error", err)
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func toAccountReference(state *v1alpha1.Account, clusterTarget nauth.ClusterTarget) nauth.AccountReference {

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -154,6 +154,22 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to import the observed account: %w", err))
 		}
 	} else {
+		if accountRef.AccountID == "" {
+			// Bootstrap the account
+			result, err = r.manager.CreateOrUpdate(ctx, toBootstrapAccountRequest(natsAccount, accountRef))
+			if err != nil {
+				return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to bootstrap account: %w", err))
+			}
+			natsAccount.SetLabel(v1alpha1.AccountLabelAccountID, result.AccountID)
+			natsAccount.SetLabel(v1alpha1.AccountLabelSignedBy, result.AccountSignedBy)
+			if err := r.kubernetes.PatchLabels(ctx, natsAccount); err != nil {
+				log.Info("Failed to patch account labels", "name", natsAccount.Name, "error", err)
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: requeueImmediately}, nil
+		}
+
+		// Full manage
 		request, adoptionRefs, err := r.toAccountRequest(ctx, natsAccount, accountRef)
 		if err != nil {
 			return r.reporter.error(ctx, natsAccount, fmt.Errorf("failed to create account request: %w", err))
@@ -258,32 +274,8 @@ func toAccountReference(state *v1alpha1.Account, clusterTarget nauth.ClusterTarg
 	}
 }
 
-func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha1.Account, accountReference nauth.AccountReference) (nauth.AccountRequest, accountAdoptionRefs, error) {
-	var request nauth.AccountRequest
-	adoptionRefs := accountAdoptionRefs{}
-
-	namespace := domain.Namespace(state.Namespace)
-	cachedAccountIDReader := newCachedAccountIDReader(ctx, r.accountReader)
-
-	var exportGroups nauth.ExportGroups
-	inlineExportGroup, err := toNAuthExportGroup(GroupNameInline, true, state.Spec.Exports)
-	if err != nil {
-		return request, adoptionRefs, fmt.Errorf("failed to convert inline exports: %w", err)
-	}
-	if inlineExportGroup != nil {
-		exportGroups = nauth.ExportGroups{inlineExportGroup}
-	}
-
-	var importGroups nauth.ImportGroups
-	inlineImportGroup, err := toNAuthImportGroup(GroupNameInline, true, state.Spec.Imports, cachedAccountIDReader)
-	if err != nil {
-		return request, adoptionRefs, fmt.Errorf("failed to convert inline imports: %w", err)
-	}
-	if inlineImportGroup != nil {
-		importGroups = nauth.ImportGroups{inlineImportGroup}
-	}
-
-	request = nauth.AccountRequest{
+func toBootstrapAccountRequest(state *v1alpha1.Account, accountReference nauth.AccountReference) nauth.AccountRequest {
+	return nauth.AccountRequest{
 		AccountRef:       domain.NewNamespacedName(state.Namespace, state.Name),
 		AccountID:        accountReference.AccountID,
 		ClaimsHash:       state.Status.ClaimsHash,
@@ -293,8 +285,30 @@ func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha
 		JetStreamEnabled: state.Spec.JetStreamEnabled,
 		JetStreamLimits:  toNAuthJetStreamLimits(state.Spec.JetStreamLimits),
 		NatsLimits:       toNAuthNatsLimits(state.Spec.NatsLimits),
-		ExportGroups:     exportGroups,
-		ImportGroups:     importGroups,
+	}
+}
+
+func (r *AccountReconciler) toAccountRequest(ctx context.Context, state *v1alpha1.Account, accountReference nauth.AccountReference) (nauth.AccountRequest, accountAdoptionRefs, error) {
+	request := toBootstrapAccountRequest(state, accountReference)
+	adoptionRefs := accountAdoptionRefs{}
+
+	namespace := domain.Namespace(state.Namespace)
+	cachedAccountIDReader := newCachedAccountIDReader(ctx, r.accountReader)
+
+	inlineExportGroup, err := toNAuthExportGroup(GroupNameInline, true, state.Spec.Exports)
+	if err != nil {
+		return request, adoptionRefs, fmt.Errorf("failed to convert inline exports: %w", err)
+	}
+	if inlineExportGroup != nil {
+		request.ExportGroups = nauth.ExportGroups{inlineExportGroup}
+	}
+
+	inlineImportGroup, err := toNAuthImportGroup(GroupNameInline, true, state.Spec.Imports, cachedAccountIDReader)
+	if err != nil {
+		return request, adoptionRefs, fmt.Errorf("failed to convert inline imports: %w", err)
+	}
+	if inlineImportGroup != nil {
+		request.ImportGroups = nauth.ImportGroups{inlineImportGroup}
 	}
 
 	if accountReference.AccountID == "" {

--- a/internal/adapter/inbound/controller/account_export.go
+++ b/internal/adapter/inbound/controller/account_export.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -45,16 +44,16 @@ const exportAccountNameIndexKey string = "export.spec.accountName"
 
 // AccountExportReconciler reconciles an AccountExport object.
 type AccountExportReconciler struct {
-	client.Client
-	Scheme  *runtime.Scheme
-	manager inbound.AccountExportManager
+	kubernetes *kubernetesClient
+	Scheme     *runtime.Scheme
+	manager    inbound.AccountExportManager
 }
 
 func NewAccountExportReconciler(k8sClient client.Client, scheme *runtime.Scheme, manager inbound.AccountExportManager) *AccountExportReconciler {
 	return &AccountExportReconciler{
-		Client:  k8sClient,
-		Scheme:  scheme,
-		manager: manager,
+		kubernetes: newKubernetesClient(k8sClient),
+		Scheme:     scheme,
+		manager:    manager,
 	}
 }
 
@@ -67,7 +66,7 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log := logf.FromContext(ctx)
 
 	state := &v1alpha1.AccountExport{}
-	if err := r.Get(ctx, req.NamespacedName, state); err != nil {
+	if err := r.kubernetes.Get(ctx, req.NamespacedName, state); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
@@ -104,7 +103,7 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	patchLabels := false
 
 	account := &v1alpha1.Account{}
-	accountErr := r.Get(ctx, types.NamespacedName{Namespace: state.Namespace, Name: state.Spec.AccountName}, account)
+	accountErr := r.kubernetes.Get(ctx, types.NamespacedName{Namespace: state.Namespace, Name: state.Spec.AccountName}, account)
 	if accountErr != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Failed to read account", "accountName", state.Spec.AccountName)
@@ -165,9 +164,9 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if patchLabels {
-		err = r.patchLabels(ctx, state)
+		err = r.kubernetes.PatchLabels(ctx, state)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to patch labels: %w", err)
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: requeueImmediately}, nil
 	}
@@ -175,7 +174,7 @@ func (r *AccountExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// sort conditions before save (to keep consistent order)
 	sortConditions(state.Status.Conditions)
 
-	if updateErr := r.Status().Update(ctx, state); updateErr != nil {
+	if updateErr := r.kubernetes.Status().Update(ctx, state); updateErr != nil {
 		log.Error(updateErr, "Failed to update status: %w", updateErr)
 		return ctrl.Result{}, updateErr
 	}
@@ -263,7 +262,7 @@ func (r *AccountExportReconciler) mapAccountToAccountExports(ctx context.Context
 	}
 
 	exports := &v1alpha1.AccountExportList{}
-	if err := r.List(ctx, exports,
+	if err := r.kubernetes.List(ctx, exports,
 		client.InNamespace(account.Namespace),
 		client.MatchingFields{exportAccountNameIndexKey: account.Name},
 	); err != nil {
@@ -328,21 +327,6 @@ func accountExportAdoptionSnapshot(account *v1alpha1.Account) map[string]adoptio
 		}
 	}
 	return adoptions
-}
-
-func (r *AccountExportReconciler) patchLabels(ctx context.Context, resource *v1alpha1.AccountExport) error {
-	patchData, err := json.Marshal(map[string]map[string]map[string]string{
-		"metadata": {
-			"labels": resource.GetLabels(),
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to generate patch for label: %w", err)
-	}
-	if err = r.Patch(ctx, resource, client.RawPatch(types.MergePatchType, patchData)); err != nil {
-		return fmt.Errorf("failed to patch label: %w", err)
-	}
-	return nil
 }
 
 func isAccountExportReady(state *v1alpha1.AccountExport) bool {

--- a/internal/adapter/inbound/controller/account_export_watch_test.go
+++ b/internal/adapter/inbound/controller/account_export_watch_test.go
@@ -165,7 +165,7 @@ func TestAccountExportReconciler_MapAccountToExports(t *testing.T) {
 		WithObjects(account, exportA, exportB, exportOtherNamespace).
 		Build()
 
-	reconciler := &AccountExportReconciler{Client: fakeClient}
+	reconciler := &AccountExportReconciler{kubernetes: newKubernetesClient(fakeClient)}
 
 	requests := reconciler.mapAccountToAccountExports(context.Background(), account)
 	require.Len(t, requests, 1)

--- a/internal/adapter/inbound/controller/account_import.go
+++ b/internal/adapter/inbound/controller/account_import.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,16 +46,16 @@ const importExportAccountRefIndexKey string = "import.spec.exportAccountRef"
 
 // AccountImportReconciler reconciles an AccountImport object.
 type AccountImportReconciler struct {
-	client.Client
-	Scheme  *runtime.Scheme
-	manager inbound.AccountImportManager
+	kubernetes *kubernetesClient
+	Scheme     *runtime.Scheme
+	manager    inbound.AccountImportManager
 }
 
 func NewAccountImportReconciler(k8sClient client.Client, scheme *runtime.Scheme, manager inbound.AccountImportManager) *AccountImportReconciler {
 	return &AccountImportReconciler{
-		Client:  k8sClient,
-		Scheme:  scheme,
-		manager: manager,
+		kubernetes: newKubernetesClient(k8sClient),
+		Scheme:     scheme,
+		manager:    manager,
 	}
 }
 
@@ -67,7 +66,7 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log := logf.FromContext(ctx)
 
 	state := &v1alpha1.AccountImport{}
-	if err := r.Get(ctx, req.NamespacedName, state); err != nil {
+	if err := r.kubernetes.Get(ctx, req.NamespacedName, state); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
@@ -162,7 +161,7 @@ func (r *AccountImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// sort conditions before save (to keep consistent order)
 	sortConditions(state.Status.Conditions)
 
-	if err := r.Status().Update(ctx, state); err != nil {
+	if err := r.kubernetes.Status().Update(ctx, state); err != nil {
 		log.Error(err, "Failed to update status", "namespace", state.Namespace, "name", state.GetName())
 		return ctrl.Result{}, err
 	}
@@ -282,7 +281,7 @@ func (r *AccountImportReconciler) mapAccountToAccountImports(ctx context.Context
 	}
 
 	imports := &v1alpha1.AccountImportList{}
-	if err := r.List(ctx, imports,
+	if err := r.kubernetes.List(ctx, imports,
 		client.InNamespace(account.Namespace),
 		client.MatchingFields{importAccountNameIndexKey: account.Name},
 	); err != nil {
@@ -315,7 +314,7 @@ func (r *AccountImportReconciler) mapExportAccountToAccountImports(ctx context.C
 	}
 
 	imports := &v1alpha1.AccountImportList{}
-	if err := r.List(ctx, imports,
+	if err := r.kubernetes.List(ctx, imports,
 		client.MatchingFields{importExportAccountRefIndexKey: accountNsn.String()},
 	); err != nil {
 		logf.FromContext(ctx).Error(err, "Failed to list AccountImports for export Account watch", "account", account.Name, "namespace", account.Namespace)
@@ -399,7 +398,7 @@ func (r *AccountImportReconciler) getConditionedAccount(ctx context.Context, acc
 	}
 
 	result := &v1alpha1.Account{}
-	if err := r.Get(ctx, client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}, result); err != nil {
+	if err := r.kubernetes.Get(ctx, client.ObjectKey{Namespace: accountRef.Namespace, Name: accountRef.Name}, result); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, metav1.Condition{
 				Status:  metav1.ConditionFalse,
@@ -450,16 +449,8 @@ func (r *AccountImportReconciler) upsertLabels(ctx context.Context, resource *v1
 	}
 
 	if patch {
-		patchData, err := json.Marshal(map[string]map[string]map[string]string{
-			"metadata": {
-				"labels": resource.GetLabels(),
-			},
-		})
-		if err != nil {
-			return false, fmt.Errorf("failed to generate patch for labels: %w", err)
-		}
-		if err = r.Patch(ctx, resource, client.RawPatch(types.MergePatchType, patchData)); err != nil {
-			return false, fmt.Errorf("failed to patch labels: %w", err)
+		if err := r.kubernetes.PatchLabels(ctx, resource); err != nil {
+			return false, err
 		}
 		return true, nil
 	}

--- a/internal/adapter/inbound/controller/account_import_watch_test.go
+++ b/internal/adapter/inbound/controller/account_import_watch_test.go
@@ -169,7 +169,7 @@ func TestAccountImportReconciler_MapExportAccountToImports(t *testing.T) {
 		WithObjects(exportAccount, matchingExplicitNamespace, matchingImplicitNamespace, nonMatchingImport).
 		Build()
 
-	reconciler := &AccountImportReconciler{Client: fakeClient}
+	reconciler := &AccountImportReconciler{kubernetes: newKubernetesClient(fakeClient)}
 
 	requests := reconciler.mapExportAccountToAccountImports(context.Background(), exportAccount)
 	require.Len(t, requests, 2)

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -152,38 +152,105 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSetFinalizer() {
 	t.Contains(account.Finalizers, finalizerAccount)
 }
 
-func (t *AccountControllerTestSuite) Test_Reconcile_ShouldSucceed_WhenCreatingAccount() {
+func (t *AccountControllerTestSuite) Test_Reconcile_ShouldBootstrap_WhenCreatingAccount() {
 	// Given
+	importLimit := int64(3)
+	streamLimit := int64(5)
+	subLimit := int64(7)
+	unlimited := int64(-1)
+	wildcardExports := true
+	maxBytesRequired := false
+	accountID := testutil.AnyNatsTestAccountID()
+
 	t.setupAccount(
 		t.defaultAccount(func(account *v1alpha1.Account) {
 			account.Finalizers = append(account.Finalizers, finalizerAccount)
+			account.Spec.AccountLimits = &v1alpha1.AccountLimits{
+				Imports:         &importLimit,
+				Exports:         &unlimited,
+				WildcardExports: &wildcardExports,
+				Conn:            &unlimited,
+				LeafNodeConn:    &unlimited,
+			}
+			account.Spec.JetStreamLimits = &v1alpha1.JetStreamLimits{
+				MemoryStorage:        &unlimited,
+				DiskStorage:          &unlimited,
+				Streams:              &streamLimit,
+				Consumer:             &unlimited,
+				MaxAckPending:        &unlimited,
+				MemoryMaxStreamBytes: &unlimited,
+				DiskMaxStreamBytes:   &unlimited,
+				MaxBytesRequired:     &maxBytesRequired,
+			}
+			account.Spec.NatsLimits = &v1alpha1.NatsLimits{
+				Subs:    &subLimit,
+				Data:    &unlimited,
+				Payload: &unlimited,
+			}
+			account.Spec.Imports = v1alpha1.Imports{
+				{
+					AccountRef: v1alpha1.AccountRef{
+						Name:      "export-account",
+						Namespace: t.accountNamespace,
+					},
+					Name:    "stream-import",
+					Subject: "foo.>",
+					Type:    v1alpha1.Stream,
+				},
+			}
 		}),
 	)
 
-	mockResult := &nauth.AccountResult{
-		AccountID:       testutil.AnyNatsTestAccountID(),
-		AccountSignedBy: "OPERATOR_SIGNING_KEY",
-		Claims:          &nauth.AccountClaims{},
-		ClaimsHash:      "CLAIMS_HASH",
-	}
-	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, mockResult).Once()
 	t.clusterManagerMock.mockGetClusterTarget(createDummyClusterTarget(), nil)
+	t.accountManagerMock.mockCreateOrUpdateFn(t.ctx, mock.Anything, func(request nauth.AccountRequest) (*nauth.AccountResult, error) {
+		t.Empty(request.ExportGroups)
+		t.Empty(request.ImportGroups)
+		t.Equal(&nauth.AccountLimits{
+			Imports:         &importLimit,
+			Exports:         &unlimited,
+			WildcardExports: &wildcardExports,
+			Conn:            &unlimited,
+			LeafNodeConn:    &unlimited,
+		}, request.AccountLimits)
+		t.Equal(&nauth.JetStreamLimits{
+			MemoryStorage:        &unlimited,
+			DiskStorage:          &unlimited,
+			Streams:              &streamLimit,
+			Consumer:             &unlimited,
+			MaxAckPending:        &unlimited,
+			MemoryMaxStreamBytes: &unlimited,
+			DiskMaxStreamBytes:   &unlimited,
+			MaxBytesRequired:     &maxBytesRequired,
+		}, request.JetStreamLimits)
+		t.Equal(&nauth.NatsLimits{
+			Subs:    &subLimit,
+			Data:    &unlimited,
+			Payload: &unlimited,
+		}, request.NatsLimits)
 
-	// When (expect manager.CreateOrUpdate)
-	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
+		return &nauth.AccountResult{
+			AccountID:       accountID,
+			AccountSignedBy: "OPERATOR_SIGNING_KEY",
+		}, nil
+	}).Once()
+
+	// When
+	result, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
 
 	// Then
 	t.Require().NoError(err)
+	t.Equal(requeueImmediately, result.RequeueAfter)
+
 	account := &v1alpha1.Account{}
 	err = k8sClient.Get(t.ctx, t.accountNamespacedRef, account)
 	t.Require().NoError(err)
 
-	for _, c := range account.Status.Conditions {
-		t.Equal(metav1.ConditionTrue, c.Status)
-		t.Equal(conditionReasonReconciled, c.Reason)
-	}
-	t.Equal("CLAIMS_HASH", account.Status.ClaimsHash)
-	t.Equal(t.operatorVersion, account.Status.OperatorVersion)
+	t.Equal(accountID, account.GetLabel(v1alpha1.AccountLabelAccountID))
+	t.Equal("OPERATOR_SIGNING_KEY", account.GetLabel(v1alpha1.AccountLabelSignedBy))
+	t.Equal(createDummyClusterTarget().UID, account.GetLabel(v1alpha1.AccountLabelNatsClusterID))
+	t.Empty(account.Status.ClaimsHash)
+	t.Empty(account.Status.OperatorVersion)
+	t.Nil(meta.FindStatusCondition(account.Status.Conditions, conditionTypeReady))
 	t.Empty(t.fakeRecorder.Events)
 }
 
@@ -214,7 +281,7 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenCreateOrUpdat
 		t.Equal(conditionReasonErrored, c.Reason)
 	}
 	t.Len(t.fakeRecorder.Events, 1)
-	t.Contains(<-t.fakeRecorder.Events, "failed to apply account: a test error")
+	t.Contains(<-t.fakeRecorder.Events, "failed to bootstrap account: a test error")
 }
 
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenChangingNatsCluster() {

--- a/internal/adapter/inbound/controller/account_watch_test.go
+++ b/internal/adapter/inbound/controller/account_watch_test.go
@@ -164,7 +164,7 @@ func TestAccountReconciler_MapAccountExportToAccounts(t *testing.T) {
 		WithObjects(accountA, accountB, accountOtherNamespace, export).
 		Build()
 
-	reconciler := &AccountReconciler{Client: fakeClient}
+	reconciler := &AccountReconciler{kubernetes: newKubernetesClient(fakeClient)}
 
 	requests := reconciler.mapAccountExportToAccounts(context.Background(), export)
 	require.Len(t, requests, 1)

--- a/internal/adapter/inbound/controller/kubernetes.go
+++ b/internal/adapter/inbound/controller/kubernetes.go
@@ -1,0 +1,43 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type kubernetesClient struct {
+	client.Client
+}
+
+func newKubernetesClient(k8sClient client.Client) *kubernetesClient {
+	return &kubernetesClient{
+		Client: k8sClient,
+	}
+}
+
+type metadataPatch struct {
+	Metadata labelsPatch `json:"metadata"`
+}
+
+type labelsPatch struct {
+	Labels map[string]string `json:"labels"`
+}
+
+func (c *kubernetesClient) PatchLabels(ctx context.Context, resource client.Object) error {
+	patchData, err := json.Marshal(metadataPatch{
+		Metadata: labelsPatch{
+			Labels: resource.GetLabels(),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to generate label patch: %w", err)
+	}
+	if err = c.Patch(ctx, resource, client.RawPatch(types.MergePatchType, patchData)); err != nil {
+		return fmt.Errorf("failed to patch labels: %w", err)
+	}
+	return nil
+}

--- a/internal/adapter/inbound/controller/kubernetes.go
+++ b/internal/adapter/inbound/controller/kubernetes.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,4 +42,21 @@ func (c *kubernetesClient) PatchLabels(ctx context.Context, resource client.Obje
 		return fmt.Errorf("failed to patch labels: %w", err)
 	}
 	return nil
+}
+
+func (c *kubernetesClient) UpdateReadyStatus(ctx context.Context, resource Object, status metav1.ConditionStatus, reason string, message string) error {
+	meta.SetStatusCondition(resource.GetConditions(), metav1.Condition{
+		Type:    conditionTypeReady,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+	if err := c.Status().Update(ctx, resource); err != nil {
+		return fmt.Errorf("failed to update ready status: %w", err)
+	}
+	return nil
+}
+
+func (c *kubernetesClient) UpdateReadyStatusReconciled(ctx context.Context, resource Object) error {
+	return c.UpdateReadyStatus(ctx, resource, metav1.ConditionTrue, conditionReasonReconciled, "Successfully reconciled")
 }

--- a/mise.toml
+++ b/mise.toml
@@ -37,7 +37,7 @@ alias = "nld"
 run = "vale README.md www/src/content/docs/index.mdx www/src/content/docs/guides"
 
 [tasks."nauth:e2e-test"]
-silent = true
+silent = false
 description = "Run end-to-end tests"
 run = """
 make build-e2e-ctl


### PR DESCRIPTION
This adds an initial bootstrap step for managed Accounts that do not yet have an Account ID. The controller now creates a limits-only Account JWT, patches the Account ID and signer labels, and immediately requeues so the next reconcile can perform the full Account reconciliation with imports, exports, adoptions, and status updates.

Also included:
- patch Account labels instead of full resource updates
- update Account Ready status through the Kubernetes helper
- extract Account deletion handling for readability
- keep observed Accounts on the import-only path

Closes: #313
