### PR TITLE
build(mise): add CRDs-catalog update workflow

### DIFF
--- a/.mise-tasks/nauth/update-crds-catalog.sh
+++ b/.mise-tasks/nauth/update-crds-catalog.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#MISE description="Update datreeio CRDs-catalog schemas for NAuth"
+#USAGE arg "<catalog_dir>" help="Local datreeio/CRDs-catalog checkout"
+
+set -euo pipefail
+
+: "${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set}"
+
+catalog_dir="${usage_catalog_dir:?catalog_dir is required}"
+crd_dir="$MISE_PROJECT_ROOT/charts/nauth-crds/crds"
+
+if [[ ! -d "$catalog_dir" ]]; then
+    echo "CRDs-catalog checkout does not exist: $catalog_dir" >&2
+    exit 1
+fi
+
+catalog_dir="$(cd "$catalog_dir" && pwd -P)"
+converter="$catalog_dir/Utilities/openapi2jsonschema.py"
+if [[ ! -f "$converter" ]]; then
+    echo "Missing catalog converter: $converter" >&2
+    exit 1
+fi
+
+if [[ ! -d "$crd_dir" ]]; then
+    echo "NAuth CRD directory does not exist: $crd_dir" >&2
+    exit 1
+fi
+
+shopt -s nullglob
+crds=("$crd_dir"/*.yaml)
+shopt -u nullglob
+
+if [[ ${#crds[@]} -eq 0 ]]; then
+    echo "No NAuth CRDs found in $crd_dir" >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+(
+    cd "$tmp_dir"
+    FILENAME_FORMAT="{fullgroup}_{kind}_{version}" \
+        uv run --no-project --with "pyyaml==6.0.2" python "$converter" "${crds[@]}"
+)
+
+shopt -s nullglob
+generated_schemas=("$tmp_dir"/nauth.io_*.json)
+shopt -u nullglob
+
+if [[ ${#generated_schemas[@]} -eq 0 ]]; then
+    echo "No nauth.io schemas were generated" >&2
+    exit 1
+fi
+
+schema_dir="$catalog_dir/nauth.io"
+mkdir -p "$schema_dir"
+find "$schema_dir" -maxdepth 1 -type f -name '*.json' -delete
+
+for schema in "${generated_schemas[@]}"; do
+    schema_name="$(basename "$schema")"
+    cp "$schema" "$schema_dir/${schema_name#nauth.io_}"
+done
+
+echo "Updated $schema_dir"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,12 +114,18 @@ Release tags must use one of these formats:
 
 Do not use `v0.7.0-rc-1`; use `v0.7.0-rc.1`.
 
-1. Create and push a new release tag:
+1. If this release changes NAuth CRDs, regenerate them and update the external CRDs catalog:
+   ```bash
+   make manifests
+   mise nauth:update-crds-catalog ../CRDs-catalog
+   ```
+   See [Updating CRDs-catalog](./docs/crds-catalog.md). Open the catalog PR from that checkout; do not commit generated catalog files to this repository.
+2. Create and push a new release tag:
    ```bash
    git tag v0.7.0-rc.1
    git push origin v0.7.0-rc.1
    ```
-2. Create and publish the GitHub release from the GitHub UI.
+3. Create and publish the GitHub release from the GitHub UI.
 
 The `Operator Release` workflow derives the release version from the tag (without the `v`) and uses it for:
 - operator image tags/labels

--- a/docs/crds-catalog.md
+++ b/docs/crds-catalog.md
@@ -1,0 +1,60 @@
+# Updating CRDs-catalog
+
+NAuth CRDs should be published to the community CRD schema catalog at <https://github.com/datreeio/CRDs-catalog> when a release changes the CRD schema. The catalog is maintained in a separate repository, so generated schema files are committed to a PR there, not to this repository.
+
+## Prerequisites
+
+Fork `datreeio/CRDs-catalog` before editing it. With the GitHub CLI, create the fork and clone your fork outside this repository:
+
+```bash
+gh repo fork datreeio/CRDs-catalog --clone=false
+gh repo clone CRDs-catalog ../CRDs-catalog
+```
+
+If you do not use the GitHub CLI, fork <https://github.com/datreeio/CRDs-catalog> in GitHub and clone your fork into `../CRDs-catalog`.
+
+Install this repository's toolchain with mise:
+
+```bash
+mise install
+```
+
+The catalog update task uses the `python` and `uv` versions from `mise.toml`. Python package requirements are isolated with `uv run --no-project --with pyyaml==6.0.2`, so you do not need to install `pyyaml` globally or create a repository venv.
+
+## Update The Catalog
+
+Regenerate NAuth CRDs before exporting schemas if the release changes API types or controller-gen markers:
+
+```bash
+make manifests
+```
+
+Run the catalog update task with the local catalog checkout path:
+
+```bash
+mise nauth:update-crds-catalog ../CRDs-catalog
+```
+
+The task converts `charts/nauth-crds/crds/*.yaml` with the catalog's `Utilities/openapi2jsonschema.py` and replaces `../CRDs-catalog/nauth.io/*.json`.
+
+Inspect the external catalog diff:
+
+```bash
+git -C ../CRDs-catalog diff -- nauth.io
+```
+
+The expected schema files are:
+
+- `nauth.io/account_v1alpha1.json`
+- `nauth.io/accountexport_v1alpha1.json`
+- `nauth.io/accountimport_v1alpha1.json`
+- `nauth.io/natscluster_v1alpha1.json`
+- `nauth.io/user_v1alpha1.json`
+
+Commit those changes in the CRDs-catalog checkout and open a pull request against `datreeio/CRDs-catalog`.
+
+## Troubleshooting
+
+If the task reports a missing catalog converter, update the local CRDs-catalog checkout from upstream and try again.
+
+If `uv` needs to download `pyyaml` on the first run, allow network access. The package is cached by `uv` and is not installed into global Python site-packages.

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,8 @@ NATS_BOX_VERSION = "0.19.5"
 
 [tools]
 go = "1.26.3"
+python = "3.14.5"
+uv = "0.11.16"
 ginkgo = "2.28.3"
 adr-tools = "3.0.0"
 nsc = "2.12.2"


### PR DESCRIPTION
## Summary
- Add a `mise nauth:update-crds-catalog <catalog_dir>` task for generating NAuth schemas in a forked CRDs-catalog checkout.
- Document the fork-first catalog update workflow.
- Add the CRDs-catalog update to release steps when CRDs change.

## Verification
The workflow has been tested, and a new [PR has been created](https://github.com/datreeio/CRDs-catalog/pull/893) to update the catalog.