### PR TITLE
feat(chart): add .Values.extraResources

### DIFF
--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -7,6 +7,7 @@
 | affinity | object | `{}` |  |
 | crds.install | bool | `true` | Indicates if Custom Resource Definitions should be installed and upgraded as part of the release. |
 | crds.keep | bool | `true` | Indicates if Custom Resource Definitions should be kept when a release is uninstalled. |
+| extraResources | list | `[]` | Deploy extra resources along the chart. Supports templating |
 | fullnameOverride | string | `""` | Override the chart fullName (Release.name + Chart.name) |
 | global.labels | object | `{}` | Custom labels to apply to all resources. |
 | image.pullPolicy | string | `"IfNotPresent"` | Sets the pull policy for images. |

--- a/charts/nauth/templates/extra_resources.yaml
+++ b/charts/nauth/templates/extra_resources.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraResources }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/nauth/templates/extra_resources.yaml
+++ b/charts/nauth/templates/extra_resources.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraResources }}
 ---
-{{ toYaml . }}
+{{ tpl (toYaml .) $ }}
 {{- end }}

--- a/charts/nauth/tests/extra_resources.yaml
+++ b/charts/nauth/tests/extra_resources.yaml
@@ -1,0 +1,17 @@
+suite: extra resources
+templates:
+  - extra_resources.yaml
+release:
+  name: nauth-test
+tests:
+  - it: renders extra resources
+    set:
+      extraResources:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ .Release.Name }}"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: nauth-test

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -145,3 +145,5 @@ crds:
   install: true
   # -- Indicates if Custom Resource Definitions should be kept when a release is uninstalled.
   keep: true
+
+extraResources: []

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -146,4 +146,5 @@ crds:
   # -- Indicates if Custom Resource Definitions should be kept when a release is uninstalled.
   keep: true
 
+# -- Deploy extra resources along the chart. Supports templating
 extraResources: []


### PR DESCRIPTION
Goal is to allow users of the helm chart to deploy extra resources along nauth. This is useful to pre-configure a NatsCluster or run the operator-bootstrap within a job.
