### PR TITLE
chore: group renovate security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,8 @@
   "vulnerabilityAlerts": {
     "enabled": true,
     "addLabels": ["security"],
+    "groupName": "security vulnerability updates",
+    "groupSlug": "security-vulnerability-updates",
     "vulnerabilityFixStrategy": "lowest"
   },
   "packageRules": [


### PR DESCRIPTION
## Summary

- group Renovate vulnerability alert PRs into one security update PR
- keep the `security` label and lowest fixed version strategy
- leave routine minor/patch/major Renovate behavior unchanged

## Reasoning

NAuth is not auto-deployed from dependency PRs, so batching simultaneous security fixes reduces review noise while keeping vulnerability updates separate from routine dependency maintenance.
