### PR TITLE
feat: add configurable structured operator logging

### DIFF
--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -15,6 +15,8 @@
 | image.repository | string | `"nauth-operator"` | Sets the operator repository |
 | image.tag | string | appVersion | Overrides the image tag |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
+| logging.format | string | `""` | Operator log output format. Leave empty to keep the operator default text output. Set to `json` for structured log ingestion. |
+| logging.level | string | `""` | Operator log level. Supported values: `debug`, `info`, `warn`, `error`. |
 | monitoring.enabled | bool | `false` | Exposes controller-runtime Prometheus metrics on `/metrics`. Use this endpoint directly from Prometheus or scrape it with the OpenTelemetry Collector Prometheus receiver. |
 | monitoring.serviceMonitor | object | `{"enabled":false}` | Enables serviceMonitor feature. Requires CRD to be installed beforehand. |
 | nameOverride | string | `""` | Override the chart name |

--- a/charts/nauth/templates/deployment.yaml
+++ b/charts/nauth/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080
             - --metrics-secure=false
+            {{- if .Values.logging.format }}
+            - --log-format={{ .Values.logging.format }}
+            {{- end }}
+            {{- if .Values.logging.level }}
+            - --log-level={{ .Values.logging.level }}
+            {{- end }}
             {{- if .Values.namespaced }}
             - --namespace={{ include "nauth.namespaceName" . }}
             {{- end }}

--- a/charts/nauth/templates/verify.yaml
+++ b/charts/nauth/templates/verify.yaml
@@ -1,0 +1,6 @@
+{{- if and .Values.logging.format (not (mustHas .Values.logging.format (list "text" "json"))) }}
+{{- fail "logging.format must be empty, text, or json" }}
+{{- end }}
+{{- if and .Values.logging.level (not (mustHas .Values.logging.level (list "debug" "info" "warn" "error"))) }}
+{{- fail "logging.level must be empty, debug, info, warn, or error" }}
+{{- end }}

--- a/charts/nauth/tests/deployment_logging_test.yaml
+++ b/charts/nauth/tests/deployment_logging_test.yaml
@@ -1,0 +1,38 @@
+suite: deployment logging args
+templates:
+  - deployment.yaml
+tests:
+  - it: keeps existing operator logging defaults by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --log-format=json
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --log-level=info
+
+  - it: configures structured logging when requested
+    set:
+      logging:
+        format: json
+        level: info
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-format=json
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-level=info
+
+  - it: allows readable debug logging for local chart installs
+    set:
+      logging:
+        format: text
+        level: debug
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-format=text
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --log-level=debug

--- a/charts/nauth/tests/verify_test.yaml
+++ b/charts/nauth/tests/verify_test.yaml
@@ -1,0 +1,19 @@
+suite: values validation
+templates:
+  - verify.yaml
+tests:
+  - it: rejects invalid logging format
+    set:
+      logging:
+        format: console
+    asserts:
+      - failedTemplate:
+          errorMessage: logging.format must be empty, text, or json
+
+  - it: rejects invalid logging level
+    set:
+      logging:
+        level: trace
+    asserts:
+      - failedTemplate:
+          errorMessage: logging.level must be empty, debug, info, warn, or error

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -61,6 +61,12 @@ namespace:
 # -- If true, limits the scope of nauth to a single namespace. Otherwise, all namespaces will be watched.
 namespaced: false
 
+logging:
+  # -- Operator log output format. Leave empty to keep the operator default text output. Set to `json` for structured log ingestion.
+  format: ""
+  # -- Operator log level. Supported values: `debug`, `info`, `warn`, `error`.
+  level: ""
+
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 
 	"github.com/WirelessCar/nauth/internal/domain/nauth"
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -35,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -55,6 +58,16 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const (
+	logFormatText = "text"
+	logFormatJSON = "json"
+
+	logLevelDebug = "debug"
+	logLevelInfo  = "info"
+	logLevelWarn  = "warn"
+	logLevelError = "error"
+)
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -66,6 +79,8 @@ func main() {
 	var namespace string
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
+	var logFormat string
+	var logLevel string
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -87,13 +102,20 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")
+	flag.StringVar(&logFormat, "log-format", "",
+		"Log output format. Supported values: text, json. Defaults to existing text output.")
+	flag.StringVar(&logLevel, "log-level", "",
+		"Log level. Supported values: debug, info, warn, error. Defaults to existing controller-runtime verbosity.")
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	if _, err := initLogger(&opts, logFormat, logLevel); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid logging configuration: %s\n", err.Error())
+		os.Exit(1)
+	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -349,6 +371,41 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func initLogger(opts *zap.Options, format string, level string) (logr.Logger, error) {
+	switch strings.ToLower(format) {
+	case "":
+	case logFormatText:
+		zap.ConsoleEncoder()(opts)
+	case logFormatJSON:
+		zap.JSONEncoder()(opts)
+	default:
+		return logr.Logger{}, fmt.Errorf("unsupported log format %q", format)
+	}
+
+	switch strings.ToLower(level) {
+	case "":
+	case logLevelDebug:
+		opts.Level = zapcore.DebugLevel
+	case logLevelInfo:
+		opts.Level = zapcore.InfoLevel
+	case logLevelWarn:
+		opts.Level = zapcore.WarnLevel
+	case logLevelError:
+		opts.Level = zapcore.ErrorLevel
+	default:
+		return logr.Logger{}, fmt.Errorf("unsupported log level %q", level)
+	}
+
+	logger := zap.New(zap.UseFlagOptions(opts))
+	ctrl.SetLogger(logger)
+	if strings.EqualFold(format, logFormatJSON) {
+		// Route Kubernetes/client-go klog entries through the configured structured logger.
+		klog.SetLogger(logger.WithName("klog"))
+	}
+
+	return logger, nil
 }
 
 func parseNatsClusterRef(refStr string) (*nauth.ClusterRef, error) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func Test_initLogger_ShouldKeepDevelopmentDefaults_WhenNoNAuthLoggingFlagsAreSet(t *testing.T) {
+	opts := zap.Options{
+		Development: true,
+	}
+
+	if _, err := initLogger(&opts, "", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if !opts.Development {
+		t.Fatal("expected local defaults to keep zap development mode")
+	}
+	if opts.Level != nil {
+		t.Fatal("expected local defaults to use controller-runtime development log level")
+	}
+}
+
+func Test_initLogger_ShouldConfigureJSONInfoLogging(t *testing.T) {
+	var log bytes.Buffer
+	opts := zap.Options{
+		Development: true,
+		DestWriter:  &log,
+	}
+
+	logger, err := initLogger(&opts, "json", "info")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger.Info("structured message", "field", "value")
+
+	var entry map[string]any
+	if err := json.Unmarshal(log.Bytes(), &entry); err != nil {
+		t.Fatalf("expected JSON log entry, got %q: %s", log.String(), err.Error())
+	}
+
+	if entry["level"] != "info" {
+		t.Fatalf("expected info level, got %q", entry["level"])
+	}
+	if entry["msg"] != "structured message" {
+		t.Fatalf("expected structured message, got %q", entry["msg"])
+	}
+	if entry["field"] != "value" {
+		t.Fatalf("expected structured field, got %q", entry["field"])
+	}
+	if _, ok := entry["ts"]; !ok {
+		t.Fatal("expected timestamp field")
+	}
+}
+
+func Test_initLogger_ShouldKeepDevelopmentDefaults_WhenOnlyJSONFormatIsSet(t *testing.T) {
+	opts := zap.Options{
+		Development: true,
+	}
+
+	if _, err := initLogger(&opts, "json", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if !opts.Development {
+		t.Fatal("expected JSON format to preserve existing zap development mode")
+	}
+	if opts.Level != nil {
+		t.Fatal("expected JSON format to preserve existing controller-runtime log level")
+	}
+}
+
+func Test_initLogger_ShouldAcceptTextFormat(t *testing.T) {
+	opts := zap.Options{
+		Development: true,
+	}
+
+	if _, err := initLogger(&opts, "text", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if !opts.Development {
+		t.Fatal("expected text format to keep zap development mode")
+	}
+}
+
+func Test_initLogger_ShouldSupportWarnLevel(t *testing.T) {
+	opts := zap.Options{
+		Development: true,
+	}
+
+	if _, err := initLogger(&opts, "json", "warn"); err != nil {
+		t.Fatal(err)
+	}
+
+	if opts.Level.Enabled(zapcore.InfoLevel) {
+		t.Fatal("expected warn level to suppress info logs")
+	}
+	if !opts.Level.Enabled(zapcore.WarnLevel) {
+		t.Fatal("expected warn level to emit warn logs")
+	}
+}
+
+func Test_initLogger_ShouldRejectInvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		level  string
+	}{
+		{name: "format", format: "logfmt", level: "info"},
+		{name: "console_alias", format: "console", level: "info"},
+		{name: "level", format: "json", level: "trace"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := zap.Options{
+				Development: true,
+			}
+
+			if _, err := initLogger(&opts, tt.format, tt.level); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,18 @@ godebug default=go1.25
 
 require (
 	github.com/approvals/go-approval-tests v1.10.0 // tests only
+	github.com/go-logr/logr v1.4.3
 	github.com/nats-io/jwt/v2 v2.8.1
 	github.com/nats-io/nats-server/v2 v2.14.0 // tests only
 	github.com/nats-io/nats.go v1.52.0
 	github.com/nats-io/nkeys v0.4.15
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1 // tests only
+	go.uber.org/zap v1.27.1
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
+	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -33,7 +36,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
@@ -83,7 +85,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
@@ -106,7 +107,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/apiserver v0.36.0 // indirect
 	k8s.io/component-base v0.36.0 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
 	k8s.io/streaming v0.36.0 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect

--- a/www/src/content/docs/guides/observability.mdx
+++ b/www/src/content/docs/guides/observability.mdx
@@ -1,11 +1,33 @@
 ---
 title: Observability
-description: Observe NAuth reconciliation metrics
+description: Configure NAuth logs and reconciliation metrics
 ---
 
-NAuth exposes controller-runtime metrics on `/metrics` when chart monitoring is enabled. These are Prometheus metrics and can be scraped by Prometheus directly or by the OpenTelemetry Collector Prometheus receiver.
+## Logs
 
-Enable the metrics endpoint:
+NAuth uses readable text logs by default. Enable JSON when your log pipeline expects structured records.
+
+Helm:
+
+```bash
+helm upgrade --install nauth oci://ghcr.io/wirelesscar/nauth \
+  --namespace nauth \
+  --create-namespace \
+  --set logging.format=json \
+  --set logging.level=info
+```
+
+Binary:
+
+```bash
+manager --log-format=json --log-level=info
+```
+
+Formats: `text`, `json`. Levels: `debug`, `info`, `warn`, `error`.
+
+## Metrics
+
+Enable the controller-runtime `/metrics` endpoint:
 
 ```bash
 helm upgrade --install nauth oci://ghcr.io/wirelesscar/nauth \
@@ -14,13 +36,13 @@ helm upgrade --install nauth oci://ghcr.io/wirelesscar/nauth \
   --set monitoring.enabled=true
 ```
 
-The reconciliation count metric is:
+Core reconcile metric:
 
 ```text
 controller_runtime_reconcile_total{controller="<controller>",result="<result>"}
 ```
 
-Current controller labels:
+Controller labels:
 
 | Resource | Controller label | Availability |
 | --- | --- | --- |
@@ -30,7 +52,7 @@ Current controller labels:
 | `User` | `user` | Since v0.1.0 |
 | `NatsCluster` | `natscluster` | Since v0.6.1 |
 
-Useful Grafana queries:
+Grafana queries:
 
 ```text
 sum by (controller, result) (rate(controller_runtime_reconcile_total{service="nauth-metrics-service"}[5m]))


### PR DESCRIPTION
Add opt-in JSON logging for NAuth while preserving the existing human-readable text output by default. Expose log format and level configuration through both the operator flags and Helm values, with validation to catch invalid chart settings before deployment.

When JSON logging is enabled, route Kubernetes/client-go klog output through the same logger so leader-election and library messages are emitted consistently. Update the observability guide with concise logging and metrics usage examples.

Refs: #340
Signed-off-by: Thobias Karlsson <thobias.karlsson@gmail.com>

