### PR TITLE
fix: align Helm values with rendered chart behavior

### DIFF
--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -35,7 +35,6 @@
 | resources | object | `{}` | Resource requests and limits for the NAuth operator container. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context for the NAuth operator container. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount. |
-| serviceAccount.automount | bool | `true` | Reserved value for ServiceAccount token automounting. This value is not currently rendered by the chart. |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount for the NAuth operator. |
 | serviceAccount.nameOverride | string | `""` | Override the ServiceAccount name. Defaults to the generated full name when empty. |
 | terminationGracePeriodSeconds | int | `10` | Termination grace period for the NAuth operator Pod, in seconds. |

--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -28,7 +28,7 @@
 | nats.clusterRef.optional | bool | `false` | Whether account-level `spec.natsClusterRef` values may override this operator-level cluster. |
 | nodeSelector | object | `{}` | Node selector for scheduling the NAuth operator Pod. |
 | podAnnotations | object | `{}` | Annotations to add to the NAuth operator Pod. |
-| podLabels | object | `{}` | Reserved value for labels on the NAuth operator Pod. This value is not currently rendered by the chart. |
+| podLabels | object | `{}` | Additional labels to add to the NAuth operator Pod. |
 | podSecurityContext | object | `{"runAsNonRoot":true}` | Pod security context for the NAuth operator Pod. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe for the NAuth operator container. |
 | replicaCount | int | `1` | Number of NAuth operator replicas. |

--- a/charts/nauth/templates/_helpers.tpl
+++ b/charts/nauth/templates/_helpers.tpl
@@ -66,3 +66,13 @@ Selector labels
 app.kubernetes.io/name: {{ include "nauth.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create labels for the NAuth operator Pod.
+*/}}
+{{- define "nauth.podLabels" -}}
+{{- $labels := dict "control-plane" "controller-manager" -}}
+{{- $_ := merge $labels (include "nauth.labels" . | fromYaml) -}}
+{{- $_ := merge $labels (.Values.podLabels | default dict) -}}
+{{- toYaml $labels -}}
+{{- end }}

--- a/charts/nauth/templates/deployment.yaml
+++ b/charts/nauth/templates/deployment.yaml
@@ -21,8 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        control-plane: controller-manager
-        {{- include "nauth.labels" . | nindent 8 }}
+        {{- include "nauth.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "nauth.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}

--- a/charts/nauth/tests/deployment_pod_labels_test.yaml
+++ b/charts/nauth/tests/deployment_pod_labels_test.yaml
@@ -1,0 +1,39 @@
+suite: .Values.podLabels on deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: propagates podLabels to the operator Pod
+    set:
+      podLabels:
+        custom.label/team: platform
+        custom.label/tier: control-plane
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["custom.label/team"]
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels["custom.label/tier"]
+          value: control-plane
+      - notExists:
+          path: metadata.labels["custom.label/team"]
+
+  - it: preserves labels used by the Deployment selector
+    set:
+      podLabels:
+        control-plane: overridden
+        app.kubernetes.io/name: overridden
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["control-plane"]
+          value: controller-manager
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: nauth
+
+  - it: handles nil podLabels
+    set:
+      podLabels: ~
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["control-plane"]
+          value: controller-manager

--- a/charts/nauth/values.schema.json
+++ b/charts/nauth/values.schema.json
@@ -199,7 +199,7 @@
       }
     },
     "podLabels": {
-      "description": "Reserved value for labels on the NAuth operator Pod. This value is not currently rendered by the chart.",
+      "description": "Additional labels to add to the NAuth operator Pod.",
       "type": [
         "object",
         "null"

--- a/charts/nauth/values.schema.json
+++ b/charts/nauth/values.schema.json
@@ -254,10 +254,6 @@
             "type": "string"
           }
         },
-        "automount": {
-          "description": "Reserved value for ServiceAccount token automounting. This value is not currently rendered by the chart.",
-          "type": "boolean"
-        },
         "create": {
           "description": "Create a ServiceAccount for the NAuth operator.",
           "type": "boolean"

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -85,9 +85,8 @@ serviceAccount:
 # -- Annotations to add to the NAuth operator Pod.
 podAnnotations: {}
 
-# TODO(#345): Decide whether to render this value or remove it from the public values API.
 # @schema type: [object, null]; additionalProperties: {type: string}
-# -- Reserved value for labels on the NAuth operator Pod. This value is not currently rendered by the chart.
+# -- Additional labels to add to the NAuth operator Pod.
 podLabels: {}
 
 # @schema type: [object, null]; skipProperties: true

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -75,9 +75,6 @@ logging:
 serviceAccount:
   # -- Create a ServiceAccount for the NAuth operator.
   create: true
-  # TODO(#345): Decide whether to render this value or remove it from the public values API.
-  # -- Reserved value for ServiceAccount token automounting. This value is not currently rendered by the chart.
-  automount: true
   # @schema type: [object, null]; additionalProperties: {type: string}
   # -- Annotations to add to the ServiceAccount.
   annotations: {}


### PR DESCRIPTION
## Summary

- Render `podLabels` on the operator Pod to support pod-specific monitoring, policy, and operational labels while preserving Deployment selector labels.
- Remove `serviceAccount.automount` because it was never rendered, and disabling token mounting would prevent NAuth from authenticating to the Kubernetes API.
- Update generated chart documentation and schema, with Helm unit test coverage for pod labels.

Closes: #345

## Commits

- **fix(chart): remove unused serviceAccount automount value**
- **fix(chart): render podLabels on operator pod**

