### PR TITLE
feat(account): allow opt-in Account NatsCluster rebinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ NAuth resolves these credentials through a `NatsCluster`. Choose one of these re
 **A.** For single-cluster deployments, set `NATS_CLUSTER_REF` on the NAuth controller (`namespace/name`, for example `nats/my-nats-cluster`) and define the secrets in that referenced `NatsCluster` (`spec.operatorSigningKeySecretRef` and `spec.systemAccountUserCredsSecretRef`).
    - Default behavior (`NATS_CLUSTER_REF_OPTIONAL=false`) is strict mode: account-level `spec.natsClusterRef` must match `NATS_CLUSTER_REF`.
    - `NATS_CLUSTER_REF_OPTIONAL=true` is explicit opt-in default mode: accounts without `spec.natsClusterRef` use `NATS_CLUSTER_REF`, while accounts may override with their own ref.
+   - `ALLOW_ACCOUNT_NATS_CLUSTER_REBIND=true` is an explicit migration mode that allows existing Accounts to be rebound when the resolved `NatsCluster` changes. It defaults to `false`.
    - Recommended migration to per-account explicit refs:
      1) Set `NATS_CLUSTER_REF` with `NATS_CLUSTER_REF_OPTIONAL=false`.
      2) Add the same `spec.natsClusterRef` to all existing `Account` resources.

--- a/charts/nauth/README.md
+++ b/charts/nauth/README.md
@@ -22,6 +22,7 @@
 | nameOverride | string | `""` | Override the chart name used in generated resource names. |
 | namespace.nameOverride | string | `""` | Override the namespace rendered into namespaced resources. Defaults to the Helm release namespace. |
 | namespaced | bool | `false` | Limit the operator to the configured namespace instead of watching all namespaces. |
+| nats.allowAccountNatsClusterRebind | bool | `false` | Allow existing Accounts to change their NatsCluster binding. Disabled by default. |
 | nats.clusterRef | object | `{"name":"","namespace":"","optional":false}` | Operator-level NatsCluster reference. Set `name` to bind the operator to one NATS cluster. |
 | nats.clusterRef.name | string | `""` | NatsCluster resource name. Leave empty to disable operator-level binding. |
 | nats.clusterRef.namespace | string | `""` | NatsCluster resource namespace. When empty and `name` is set, the chart namespace is used. |

--- a/charts/nauth/templates/deployment.yaml
+++ b/charts/nauth/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
             - name: NATS_CLUSTER_REF_OPTIONAL
               value: {{ .Values.nats.clusterRef.optional | quote }}
             {{- end }}
+            - name: ALLOW_ACCOUNT_NATS_CLUSTER_REBIND
+              value: {{ .Values.nats.allowAccountNatsClusterRebind | quote }}
             - name: OPERATOR_VERSION
               value: {{ .Chart.AppVersion | quote }}
           {{- with .Values.securityContext }}

--- a/charts/nauth/tests/deployment_nats_cluster_env_test.yaml
+++ b/charts/nauth/tests/deployment_nats_cluster_env_test.yaml
@@ -12,6 +12,11 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: NATS_CLUSTER_REF_OPTIONAL
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALLOW_ACCOUNT_NATS_CLUSTER_REBIND
+            value: "false"
 
   - it: includes NATS_CLUSTER_REF using nauth.namespaceName when nats.clusterRef.namespace is not set
     release:
@@ -152,3 +157,14 @@ tests:
           content:
             name: NATS_CLUSTER_REF_OPTIONAL
             value: "false"
+
+  - it: includes ALLOW_ACCOUNT_NATS_CLUSTER_REBIND when enabled
+    set:
+      nats:
+        allowAccountNatsClusterRebind: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALLOW_ACCOUNT_NATS_CLUSTER_REBIND
+            value: "true"

--- a/charts/nauth/values.schema.json
+++ b/charts/nauth/values.schema.json
@@ -156,6 +156,10 @@
     "nats": {
       "type": "object",
       "properties": {
+        "allowAccountNatsClusterRebind": {
+          "description": "Allow existing Accounts to change their NatsCluster binding. Disabled by default.",
+          "type": "boolean"
+        },
         "clusterRef": {
           "description": "Operator-level NatsCluster reference. Set `name` to bind the operator to one NATS cluster.",
           "type": "object",

--- a/charts/nauth/values.yaml
+++ b/charts/nauth/values.yaml
@@ -12,6 +12,9 @@ global:
 
 # @schema additionalProperties: false
 nats:
+  # -- Allow existing Accounts to change their NatsCluster binding. Disabled by default.
+  allowAccountNatsClusterRebind: false
+
   # To move from one operator-level NatsCluster binding to explicit per-Account
   # bindings, first set this reference in strict mode, then add matching
   # `spec.natsClusterRef` values to existing Accounts, and finally remove the

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -213,6 +213,7 @@ func main() {
 	var operatorNatsCluster *core.OperatorNatsCluster
 	natsClusterRef := strings.TrimSpace(os.Getenv("NATS_CLUSTER_REF"))
 	natsClusterRefOptional := false
+	allowAccountNatsClusterRebind := false
 	if rawOptional, ok := os.LookupEnv("NATS_CLUSTER_REF_OPTIONAL"); ok {
 		natsClusterRefOptional, err = strconv.ParseBool(strings.TrimSpace(rawOptional))
 		if err != nil {
@@ -220,9 +221,23 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	if rawAllowRebind, ok := os.LookupEnv("ALLOW_ACCOUNT_NATS_CLUSTER_REBIND"); ok {
+		allowAccountNatsClusterRebind, err = strconv.ParseBool(strings.TrimSpace(rawAllowRebind))
+		if err != nil {
+			setupLog.Error(
+				err,
+				"invalid ALLOW_ACCOUNT_NATS_CLUSTER_REBIND value",
+				"ALLOW_ACCOUNT_NATS_CLUSTER_REBIND",
+				rawAllowRebind,
+			)
+			os.Exit(1)
+		}
+	}
 	if natsClusterRef != "" {
 		setupLog.Info("manager configured with operator NATS cluster",
-			"natsClusterRef", natsClusterRef, "natsClusterRefOptional", natsClusterRefOptional)
+			"natsClusterRef", natsClusterRef,
+			"natsClusterRefOptional", natsClusterRefOptional,
+			"allowAccountNatsClusterRebind", allowAccountNatsClusterRebind)
 		operatorClusterRef, err := parseNatsClusterRef(natsClusterRef)
 		if err != nil {
 			setupLog.Error(err, "invalid NATS_CLUSTER_REF value", "NATS_CLUSTER_REF", natsClusterRef)
@@ -287,6 +302,7 @@ func main() {
 		clusterManager,
 		accountClient,
 		mgr.GetEventRecorder("account-controller"),
+		allowAccountNatsClusterRebind,
 	)
 	if err = accountReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Account")

--- a/internal/adapter/inbound/controller/account.go
+++ b/internal/adapter/inbound/controller/account.go
@@ -57,12 +57,13 @@ var (
 
 // AccountReconciler reconciles an Account object
 type AccountReconciler struct {
-	kubernetes     *kubernetesClient
-	Scheme         *runtime.Scheme
-	manager        inbound.AccountManager
-	clusterManager inbound.ClusterManager
-	accountReader  k8s.AccountReader
-	reporter       *statusReporter
+	kubernetes                    *kubernetesClient
+	Scheme                        *runtime.Scheme
+	manager                       inbound.AccountManager
+	clusterManager                inbound.ClusterManager
+	accountReader                 k8s.AccountReader
+	reporter                      *statusReporter
+	allowAccountNatsClusterRebind bool
 }
 
 func NewAccountReconciler(
@@ -72,14 +73,16 @@ func NewAccountReconciler(
 	clusterManager inbound.ClusterManager,
 	accountReader k8s.AccountReader,
 	recorder events.EventRecorder,
+	allowAccountNatsClusterRebind bool,
 ) *AccountReconciler {
 	return &AccountReconciler{
-		kubernetes:     newKubernetesClient(k8sClient),
-		Scheme:         scheme,
-		manager:        manager,
-		clusterManager: clusterManager,
-		accountReader:  accountReader,
-		reporter:       newStatusReporter(k8sClient, recorder),
+		kubernetes:                    newKubernetesClient(k8sClient),
+		Scheme:                        scheme,
+		manager:                       manager,
+		clusterManager:                clusterManager,
+		accountReader:                 accountReader,
+		reporter:                      newStatusReporter(k8sClient, recorder),
+		allowAccountNatsClusterRebind: allowAccountNatsClusterRebind,
 	}
 }
 
@@ -142,7 +145,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// RECONCILE ACCOUNT
 
 	// Bind to NatsCluster
-	if err := bindAccountToCluster(natsAccount, clusterTarget.UID); err != nil {
+	if err := bindAccountToCluster(natsAccount, clusterTarget.UID, r.allowAccountNatsClusterRebind); err != nil {
 		return r.reporter.error(ctx, natsAccount, err)
 	}
 
@@ -265,15 +268,12 @@ func (r *AccountReconciler) deleteAccount(ctx context.Context, state *v1alpha1.A
 	return ctrl.Result{}, nil
 }
 
-func bindAccountToCluster(account *v1alpha1.Account, clusterID string) error {
+func bindAccountToCluster(account *v1alpha1.Account, clusterID string, allowRebind bool) error {
 	boundToClusterID := account.GetLabel(v1alpha1.AccountLabelNatsClusterID)
-	if boundToClusterID == "" {
-		account.SetLabel(v1alpha1.AccountLabelNatsClusterID, clusterID)
-		return nil
-	}
-	if boundToClusterID != clusterID {
+	if boundToClusterID != "" && boundToClusterID != clusterID && !allowRebind {
 		return fmt.Errorf("account already bound to cluster with uid: %s", boundToClusterID)
 	}
+	account.SetLabel(v1alpha1.AccountLabelNatsClusterID, clusterID)
 	return nil
 }
 

--- a/internal/adapter/inbound/controller/account_test.go
+++ b/internal/adapter/inbound/controller/account_test.go
@@ -77,19 +77,24 @@ func (t *AccountControllerTestSuite) SetupTest() {
 
 	t.accountManagerMock = &accountManagerMock{}
 	t.clusterManagerMock = &clusterManagerMock{}
-	accountClient := k8s.NewAccountClient(k8sClient)
 	t.fakeRecorder = events.NewFakeRecorder(5)
-	t.unitUnderTest = NewAccountReconciler(
+	t.unitUnderTest = t.newAccountReconciler(false)
+
+	t.Require().NoError(ensureNamespace(t.ctx, t.operatorNamespace))
+	t.Require().NoError(ensureNamespace(t.ctx, t.accountNamespace))
+}
+
+func (t *AccountControllerTestSuite) newAccountReconciler(allowAccountNatsClusterRebind bool) *AccountReconciler {
+	accountClient := k8s.NewAccountClient(k8sClient)
+	return NewAccountReconciler(
 		k8sClient,
 		k8sClient.Scheme(),
 		t.accountManagerMock,
 		t.clusterManagerMock,
 		accountClient,
 		t.fakeRecorder,
+		allowAccountNatsClusterRebind,
 	)
-
-	t.Require().NoError(ensureNamespace(t.ctx, t.operatorNamespace))
-	t.Require().NoError(ensureNamespace(t.ctx, t.accountNamespace))
 }
 
 func (t *AccountControllerTestSuite) TearDownTest() {
@@ -310,6 +315,35 @@ func (t *AccountControllerTestSuite) Test_Reconcile_ShouldFail_WhenChangingNatsC
 	c := meta.FindStatusCondition(account.Status.Conditions, conditionTypeReady)
 	t.Equal(metav1.ConditionFalse, c.Status)
 	t.Equal(conditionReasonErrored, c.Reason)
+}
+
+func (t *AccountControllerTestSuite) Test_Reconcile_ShouldAllowChangingNatsCluster_WhenConfigured() {
+	// Given
+	t.setupAccount(
+		t.defaultAccount(func(account *v1alpha1.Account) {
+			account.Finalizers = append(account.Finalizers, finalizerAccount)
+			account.SetLabel(v1alpha1.AccountLabelNatsClusterID, "natscluster1")
+		}),
+	)
+	t.unitUnderTest = t.newAccountReconciler(true)
+
+	target := createDummyClusterTarget()
+	target.UID = "natscluster2"
+	t.clusterManagerMock.mockGetClusterTarget(target, nil)
+	t.accountManagerMock.mockCreateOrUpdate(t.ctx, mock.Anything, &nauth.AccountResult{
+		AccountID:       "account-id",
+		AccountSignedBy: "operator-signing-key",
+	}).Once()
+
+	// When
+	_, err := t.unitUnderTest.Reconcile(t.ctx, reconcile.Request{NamespacedName: t.accountNamespacedRef})
+
+	// Then
+	t.Require().NoError(err)
+
+	account := &v1alpha1.Account{}
+	t.Require().NoError(k8sClient.Get(t.ctx, t.accountNamespacedRef, account))
+	t.Equal("natscluster2", account.GetLabel(v1alpha1.AccountLabelNatsClusterID))
 }
 
 func (t *AccountControllerTestSuite) Test_Reconcile_ShouldNotDeleteObservedAccount() {


### PR DESCRIPTION
Allow existing Accounts to follow replacement NatsCluster resources during migration while keeping rebinding disabled by default.

Refs: #355

